### PR TITLE
Fix externals

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -16,13 +16,12 @@ module.exports = {
       ],
       symlinks: false,
     },
-    externals: {
-      subtract: [
-        'bootstrap',
-        '@processmaker/vue-form-elements',
-        'i18next',
-        '@panter/vue-i18next'
-      ]
-    }
+    externals: process.env.NODE_ENV === 'production' ? [
+      'vue',
+      /^bootstrap\/.+$/,
+      /^@processmaker\/.+$/,
+      'i18next',
+      '@panter/vue-i18next',
+    ] : [],
   },
 }


### PR DESCRIPTION
Externals was not correctly set up for peer dependencies. This PR fixes that; it is now set up in the same was as in https://github.com/ProcessMaker/spark-modeler/pull/433.