### PR TITLE
Adjust mask to cover 100% of element

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -124,15 +124,14 @@
               </button>
             </div>
 
-            <div class="card-body m-0 pb-4 pt-4 position-relative">
-              <component
-                :class="elementCssClass(element)"
-                v-bind="element.config"
-                :is="element['editor-component']"
-                @input="element.config.interactive ? element.config.content = $event : null"
-              />
-              <div v-if="!element.config.interactive" class="mask"></div>
-            </div>
+            <component
+              tabindex="-1"
+              class="prevent-interaction card-body m-0 pb-4 pt-4"
+              :class="elementCssClass(element)"
+              v-bind="element.config"
+              :is="element['editor-component']"
+              @input="element.config.interactive ? element.config.content = $event : null"
+            />
           </div>
         </div>
       </draggable>
@@ -466,13 +465,8 @@ $header-bg: #f7f7f7;
     border: none;
   }
 
-  .mask {
-    position: absolute;
-    left: 0;
-    top: 0;
-    opacity: 0;
-    width: 100%;
-    height: 100%;
+  .prevent-interaction {
+    pointer-events: none;
   }
 }
 

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -123,14 +123,16 @@
                 <i class="far fa-trash-alt text-light"/>
               </button>
             </div>
-            <component
-              class="card-body m-0 pb-4 pt-4"
-              :class="elementCssClass(element)"
-              v-bind="element.config"
-              :is="element['editor-component']"
-              @input="element.config.interactive ? element.config.content = $event : null"
-            />
-            <div v-if="!element.config.interactive" class="mask" :class="{ selected: selected === element }"></div>
+
+            <div class="card-body m-0 pb-4 pt-4 position-relative">
+              <component
+                :class="elementCssClass(element)"
+                v-bind="element.config"
+                :is="element['editor-component']"
+                @input="element.config.interactive ? element.config.content = $event : null"
+              />
+              <div v-if="!element.config.interactive" class="mask"></div>
+            </div>
           </div>
         </div>
       </draggable>
@@ -444,8 +446,6 @@ $header-bg: #f7f7f7;
 }
 
 .control-item {
-  position: relative;
-
   .delete {
     position: absolute;
     top: 0px;
@@ -469,15 +469,10 @@ $header-bg: #f7f7f7;
   .mask {
     position: absolute;
     left: 0;
-    background-color: rgba(0, 0, 0, 0);
-    width: 100%;
     top: 0;
+    opacity: 0;
+    width: 100%;
     height: 100%;
-
-    &.selected {
-      top: 4rem;
-      height: 50%;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #254.

Gif of fix (with file-upload component):
![working_mask](https://user-images.githubusercontent.com/7561061/60027603-c73f6b00-966b-11e9-8779-e0192f79fdf6.gif)

Screenshots of fix:
<img width="462" alt="Screen Shot 2019-06-24 at 10 30 15 AM" src="https://user-images.githubusercontent.com/7561061/60027399-657f0100-966b-11e9-979b-74c50cf2730d.png">

<img width="595" alt="Screen Shot 2019-06-24 at 10 29 36 AM" src="https://user-images.githubusercontent.com/7561061/60027406-6879f180-966b-11e9-9c3d-25a6b9eb9d37.png">

<img width="591" alt="Screen Shot 2019-06-24 at 10 29 18 AM" src="https://user-images.githubusercontent.com/7561061/60027417-6c0d7880-966b-11e9-85ba-cbb443e5af17.png">
