### PR TITLE
Prevent error when invalid variable name set 

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -24,7 +24,7 @@
           :class="elementCssClass(element)"
           ref="elements"
           :validationData="transientData"
-          v-model="model[element.config.name]"
+          v-model="model[getValidPath(element.config.name)]"
           @submit="submit"
           @pageNavigate="pageNavigate"
           :name="element.config.name !== undefined ? element.config.name : null"
@@ -163,6 +163,19 @@ export default {
     this.parseCss();
   },
   methods: {
+    getValidPath(objectPath) {
+      return this.objectPathHasError(objectPath)
+        ? `["${objectPath}"]`
+        : objectPath;
+    },
+    objectPathHasError(objectPath) {
+      try {
+        this.$vueSet({}, objectPath);
+        return false;
+      } catch (error) {
+        return true;
+      }
+    },
     submit() {
       if (this.isValid()) {
         this.setDefaultValues();
@@ -223,7 +236,7 @@ export default {
 
       if (
         !item.config.name ||
-        this.model[item.config.name] !== undefined ||
+        this.model[this.getValidPath(item.config.name)] !== undefined ||
         item.component === 'FormButton'
       ) {
         return;
@@ -251,7 +264,7 @@ export default {
         defaultValue = [];
       }
 
-      this.model[item.config.name] = defaultValue;
+      this.model[this.getValidPath(item.config.name)] = defaultValue;
     },
     parseCss() {
       const containerSelector = "#screen-builder-container";

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -251,9 +251,7 @@ export default {
         defaultValue = [];
       }
 
-      this.$vueSet(this.transientData, item.config.name, defaultValue);
-      this.$set(this.data, item.config.name, defaultValue);
-
+      this.model[item.config.name] = defaultValue;
     },
     parseCss() {
       const containerSelector = "#screen-builder-container";


### PR DESCRIPTION
Fixes #252.

This PR ensures that when a variable name contains a value that would be an invalid path name for [vue-deepset](https://github.com/bhoriuchi/vue-deepset), that it's set as a string name / object property, e.g.:
```
foo.bar => { "foo": { "bar": "some value" } }
foo.000.bar => { "foo.000.bar": "some value" }
```

Video of fix: https://www.dropbox.com/s/kbtmtnvqjc1x7qr/var_name_working.mov?dl=0.