### PR TITLE
Prevent clickaway on modal

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -7,6 +7,7 @@
     hide-footer
     :title="$t('Computed Properties')"
     @hidden="displayTableList"
+    no-close-on-backdrop
   >
     <b-alert
       :variant="alertVariant"

--- a/src/components/custom-css.vue
+++ b/src/components/custom-css.vue
@@ -10,6 +10,7 @@
     @hide="hide"
     cancel-variant="btn btn-outline-secondary"
     ok-variant="btn btn-secondary ml-2"
+    no-close-on-backdrop
   >
     <p>{{ $t("You can set CSS Selector names in the inspector. Use them here with [selector='my-selector']") }}</p>
     <div class="editor">


### PR DESCRIPTION
Prevents click-away on Calcs and CSS modals

**Spark Video Demo**
https://drive.google.com/open?id=1p81FAr67IEkMnb_J2I0LT3zDTHyTGEHt

Fixes #248 