### PR TITLE
Replace config accordion with variable and design

### DIFF
--- a/src/components/inspector/page-select.vue
+++ b/src/components/inspector/page-select.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mb-2">
+  <div>
     <label class="typo__label">{{ label }}</label>
     <multiselect v-model="target" label="content" :options="options" :helper="helper"/>
     <small v-if="helper" class="form-text text-muted">{{ helper }}</small>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -312,6 +312,7 @@ const variableFields = [
   'id',
   'image',
   'fieldValue',
+  'readonly',
 ];
 
 export default {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -123,7 +123,7 @@
             >
               <i class="fas fa-arrows-alt-v mr-1 text-muted"/>
               <i v-if="element.config.icon" :class="element.config.icon" class="mr-2 ml-1"/>
-              {{ element.config.name || $t('Variable Name') }}
+              {{ element.config.name || $t('Key Name') }}
               <button
                 class="btn btn-sm btn-danger ml-auto"
                 @click="deleteItem(index)"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -152,26 +152,52 @@
 
         <b-card-body class="p-0 h-100 overflow-auto">
           <b-button
-            v-b-toggle.configuration
+            v-if="variableFields.length > 0"
+            v-b-toggle.variable
             variant="outline"
             class="text-left card-header d-flex align-items-center w-100 outline-0 text-capitalize shadow-none"
-            @click="showConfiguration = !showConfiguration"
+            @click="showVariable = !showVariable"
           >
             <i class="fas fa-cog mr-2"/>
-            {{ $t('Configuration') }}
+            {{ $t('Variable') }}
             <i
               class="fas fa-angle-down ml-auto"
-              :class="{ 'fas fa-angle-right' : showConfiguration }"
+              :class="{ 'fas fa-angle-right' : showVariable }"
             />
           </b-button>
-
-          <b-collapse id="configuration" visible class="mt-2">
+          <b-collapse id="variable" visible>
             <component
-              v-for="(item, index) in inspection.inspector"
+              v-for="(item, index) in variableFields"
               :formConfig="config"
               :key="index"
               :is="item.type"
-              class="border-bottom pt-1 pb-3 pr-4 pl-4"
+              class="border-bottom m-0 p-4"
+              v-bind="item.config"
+              v-model="inspection.config[item.field]"
+            />
+          </b-collapse>
+
+          <b-button
+            v-if="designFields.length > 0"
+            v-b-toggle.design
+            variant="outline"
+            class="text-left card-header d-flex align-items-center w-100 outline-0 text-capitalize shadow-none"
+            @click="showDesign = !showDesign"
+          >
+            <i class="fas fa-cog mr-2"/>
+            {{ $t('Design') }}
+            <i
+              class="fas fa-angle-down ml-auto"
+              :class="{ 'fas fa-angle-right' : showDesign }"
+            />
+          </b-button>
+          <b-collapse id="design" visible>
+            <component
+              v-for="(item, index) in designFields"
+              :formConfig="config"
+              :key="index"
+              :is="item.type"
+              class="border-bottom m-0 p-4"
               v-bind="item.config"
               v-model="inspection.config[item.field]"
             />
@@ -269,6 +295,20 @@ const defaultConfig = [{
   items: [],
 }];
 
+const variableFields = [
+  'name',
+  'type',
+  'validation',
+  'options',
+  'eventData',
+  'editable',
+  'fields',
+  'form',
+  'id',
+  'image',
+  'fieldValue',
+];
+
 export default {
   props: ['validationErrors', 'initialConfig', 'title'],
   mixins: [HasColorProperty],
@@ -309,11 +349,22 @@ export default {
       pageDelete: 0,
       translated: [],
       showAssignment: false,
-      showConfiguration: false,
+      showVariable: false,
+      showDesign: false,
       filterQuery: '',
     };
   },
   computed: {
+    variableFields() {
+      return this.inspection.inspector
+        ? this.inspection.inspector.filter(input => variableFields.includes(input.field))
+        : [];
+    },
+    designFields() {
+      return this.inspection.inspector
+        ? this.inspection.inspector.filter(input => !variableFields.includes(input.field))
+        : [];
+    },
     displayDelete() {
       return this.config.length > 1;
     },

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -55,6 +55,7 @@ const bgcolorProperty = {
     ],
   },
 };
+
 const colorProperty = {
   type: 'ColorSelect',
   field: 'color',
@@ -94,6 +95,17 @@ const colorProperty = {
       content: 'dark',
     },
     ],
+  },
+};
+
+const variableKeyProperty = {
+  type: 'FormInput',
+  field: 'name',
+  config: {
+    label: 'Key Name',
+    name: 'Key Name',
+    validation: 'required',
+    helper: 'A variable key name is a symbolic name to reference information.',
   },
 };
 
@@ -266,68 +278,60 @@ export default [
         helper: null,
         type: 'text',
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          name: 'Variable Name',
-          validation: 'required',
-          helper: 'The variable name for this field',
-        },
-      },
-      {
-        type: 'FormMultiselect',
-        field: 'type',
-        config: {
-          label: 'Field Type',
-          name: 'Field Type',
-          helper: 'The type for this field',
-          options: [{
-            value: 'text',
-            content: 'Text',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormMultiselect',
+          field: 'type',
+          config: {
+            label: 'Field Type',
+            name: 'Field Type',
+            helper: 'The type for this field',
+            options: [{
+              value: 'text',
+              content: 'Text',
+            },
+            {
+              value: 'password',
+              content: 'Password',
+            },
+            ],
           },
-          {
-            value: 'password',
-            content: 'Password',
+        },
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
           },
-          ],
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'validation',
+          config: {
+            label: 'Validation',
+            helper: 'The validation rules needed for this field',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'validation',
-        config: {
-          label: 'Validation',
-          helper: 'The validation rules needed for this field',
+        {
+          type: 'FormInput',
+          field: 'placeholder',
+          config: {
+            label: 'Placeholder',
+            helper: 'The placeholder is what is shown in the field when no value is provided yet',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'placeholder',
-        config: {
-          label: 'Placeholder',
-          helper: 'The placeholder is what is shown in the field when no value is provided yet',
+        {
+          type: 'FormInput',
+          field: 'helper',
+          config: {
+            label: 'Help Text',
+            helper: 'Help text is meant to provide additional guidance on the field\'s value',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'helper',
-        config: {
-          label: 'Help Text',
-          helper: 'Help text is meant to provide additional guidance on the field\'s value',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -347,58 +351,50 @@ export default [
         helper: null,
         rows: 2,
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          name: 'Variable Name',
-          validation: 'required',
-          helper: 'The variable name for this field',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'validation',
+          config: {
+            label: 'Validation',
+            helper: 'The validation rules needed for this field',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'validation',
-        config: {
-          label: 'Validation',
-          helper: 'The validation rules needed for this field',
+        {
+          type: 'FormInput',
+          field: 'rows',
+          config: {
+            label: 'Rows',
+            helper: 'The number of rows to provide for input',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'rows',
-        config: {
-          label: 'Rows',
-          helper: 'The number of rows to provide for input',
+        {
+          type: 'FormInput',
+          field: 'placeholder',
+          config: {
+            label: 'Placeholder',
+            helper: 'The placeholder is what is shown in the field when no value is provided yet',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'placeholder',
-        config: {
-          label: 'Placeholder',
-          helper: 'The placeholder is what is shown in the field when no value is provided yet',
+        {
+          type: 'FormInput',
+          field: 'helper',
+          config: {
+            label: 'Help Text',
+            helper: 'Help text is meant to provide additional guidance on the field\'s value',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'helper',
-        config: {
-          label: 'Help Text',
-          helper: 'Help text is meant to provide additional guidance on the field\'s value',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -424,50 +420,42 @@ export default [
         ],
         helper: null,
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          helper: 'The variable name for this field',
-          validation: 'required',
-          name: 'Variable Name',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'validation',
+          config: {
+            label: 'Validation',
+            helper: 'The validation rules needed for this field',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'validation',
-        config: {
-          label: 'Validation',
-          helper: 'The validation rules needed for this field',
+        {
+          type: 'FormInput',
+          field: 'helper',
+          config: {
+            label: 'Help Text',
+            helper: 'Help text is meant to provide additional guidance on the field\'s value',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'helper',
-        config: {
-          label: 'Help Text',
-          helper: 'Help text is meant to provide additional guidance on the field\'s value',
+        {
+          type: 'OptionsList',
+          field: 'options',
+          config: {
+            label: 'Options List',
+            helper: 'List of options available in the select drop down',
+          },
         },
-      },
-      {
-        type: 'OptionsList',
-        field: 'options',
-        config: {
-          label: 'Options List',
-          helper: 'List of options available in the select drop down',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -490,50 +478,42 @@ export default [
         toggle: false,
         helper: null,
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          name: 'Variable Name',
-          helper: 'The variable name for this field',
-          validation: 'required',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'helper',
+          config: {
+            label: 'Help Text',
+            helper: 'Help text is meant to provide additional guidance on the field\'s value',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'helper',
-        config: {
-          label: 'Help Text',
-          helper: 'Help text is meant to provide additional guidance on the field\'s value',
+        {
+          type: 'OptionsList',
+          field: 'options',
+          config: {
+            label: 'Options List',
+            helper: 'List of options available in the radio button group',
+          },
         },
-      },
-      {
-        type: 'OptionsList',
-        field: 'options',
-        config: {
-          label: 'Options List',
-          helper: 'List of options available in the radio button group',
+        {
+          type: 'FormCheckbox',
+          field: 'toggle',
+          config: {
+            label: 'Toggle Style?',
+            helper: '',
+          },
         },
-      },
-      {
-        type: 'FormCheckbox',
-        field: 'toggle',
-        config: {
-          label: 'Toggle Style?',
-          helper: '',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -555,50 +535,42 @@ export default [
         validation: '',
         toggle: false,
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          name: 'Variable Name',
-          validation: 'required',
-          helper: 'The name of the group for the checkbox. All checkboxes which share the same name will work together.',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'helper',
+          config: {
+            label: 'Help Text',
+            helper: 'Help text is meant to provide additional guidance on the field\'s value',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'helper',
-        config: {
-          label: 'Help Text',
-          helper: 'Help text is meant to provide additional guidance on the field\'s value',
+        {
+          type: 'FormCheckbox',
+          field: 'toggle',
+          config: {
+            label: 'Toggle Style?',
+            helper: '',
+          },
         },
-      },
-      {
-        type: 'FormCheckbox',
-        field: 'toggle',
-        config: {
-          label: 'Toggle Style?',
-          helper: '',
+        {
+          type: 'FormCheckbox',
+          field: 'initiallyChecked',
+          config: {
+            label: 'Initially Checked?',
+            helper: 'Should the checkbox be checked by default',
+          },
         },
-      },
-      {
-        type: 'FormCheckbox',
-        field: 'initiallyChecked',
-        config: {
-          label: 'Initially Checked?',
-          helper: 'Should the checkbox be checked by default',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -618,34 +590,26 @@ export default [
         name: '',
         placeholder: '',
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          name: 'Variable Name',
-          validation: 'required',
-          helper: 'The variable name for this field',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'Field Label',
+            helper: 'The label describes the fields name',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'Field Label',
-          helper: 'The label describes the fields name',
+        {
+          type: 'FormInput',
+          field: 'placeholder',
+          config: {
+            label: 'Placeholder',
+            helper: 'The placeholder is what is shown in the field when no value is provided yet',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'placeholder',
-        config: {
-          label: 'Placeholder',
-          helper: 'The placeholder is what is shown in the field when no value is provided yet',
-        },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
     },
   },
@@ -789,51 +753,43 @@ export default [
         fields: [],
         form: '',
       },
-      inspector: [{
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'List Name',
-          name: 'List Name',
-          validation: 'required',
-          helper: 'The variable name for this list',
+      inspector: [
+        variableKeyProperty,
+        {
+          type: 'FormInput',
+          field: 'label',
+          config: {
+            label: 'List Label',
+            helper: 'The label describes this record list',
+          },
         },
-      },
-      {
-        type: 'FormInput',
-        field: 'label',
-        config: {
-          label: 'List Label',
-          helper: 'The label describes this record list',
+        {
+          type: 'FormCheckbox',
+          field: 'editable',
+          config: {
+            label: 'Editable?',
+            helper: 'Should records be editable/removable and can new records be added',
+          },
         },
-      },
-      {
-        type: 'FormCheckbox',
-        field: 'editable',
-        config: {
-          label: 'Editable?',
-          helper: 'Should records be editable/removable and can new records be added',
-        },
-      },
 
-      {
-        type: 'OptionsList',
-        field: 'fields',
-        config: {
-          label: 'Fields List',
-          helper: 'List of fields to display in the record list',
+        {
+          type: 'OptionsList',
+          field: 'fields',
+          config: {
+            label: 'Fields List',
+            helper: 'List of fields to display in the record list',
+          },
         },
-      },
-      {
-        type: 'PageSelect',
-        field: 'form',
-        config: {
-          label: 'Record Form',
-          helper: 'The form to use for adding/editing records',
+        {
+          type: 'PageSelect',
+          field: 'form',
+          config: {
+            label: 'Record Form',
+            helper: 'The form to use for adding/editing records',
+          },
         },
-      },
-      bgcolorProperty,
-      colorProperty,
+        bgcolorProperty,
+        colorProperty,
       ],
 
     },
@@ -863,14 +819,7 @@ export default [
           helper: 'Image id',
         },
       },
-      {
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          helper: 'The variable name of the image',
-        },
-      },
+      variableKeyProperty,
       {
         type: 'ImageUpload',
         field: 'image',
@@ -925,16 +874,7 @@ export default [
           helper: 'The label describes the button\'s text',
         },
       },
-      {
-        type: 'FormInput',
-        field: 'name',
-        config: {
-          label: 'Variable Name',
-          validation: 'required',
-          name: 'Variable Name',
-          helper: 'The name of the button',
-        },
-      },
+      variableKeyProperty,
       {
         type: 'FormInput',
         field: 'fieldValue',

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -109,6 +109,14 @@ const variableKeyProperty = {
   },
 };
 
+const readonlyProperty = {
+  type: 'FormCheckbox',
+  field: 'readonly',
+  config: {
+    label: 'Control is read only',
+  },
+};
+
 export default [
   {
     builderComponent: FormText,
@@ -330,13 +338,7 @@ export default [
             helper: 'Help text is meant to provide additional guidance on the field\'s value',
           },
         },
-        {
-          type: 'FormCheckbox',
-          field: 'readonly',
-          config: {
-            label: 'Control is read only',
-          },
-        },
+        readonlyProperty,
         bgcolorProperty,
         colorProperty,
       ],
@@ -401,13 +403,7 @@ export default [
             helper: 'Help text is meant to provide additional guidance on the field\'s value',
           },
         },
-        {
-          type: 'FormCheckbox',
-          field: 'readonly',
-          config: {
-            label: 'Control is read only',
-          },
-        },
+        readonlyProperty,
         bgcolorProperty,
         colorProperty,
       ],


### PR DESCRIPTION
Fixes #249.

This PR removes the Configuration accordion, and replaces it with Variable and Design accordions. The Variable accordion contains a specified list of form types that correspond to variable data, while the Design accordion contains all the other (design) fields.

Video of fix: https://www.dropbox.com/s/s256p0rvucvaz69/var_reorg_working.mov?dl=0.