### PR TITLE
Add readonly props to inputs

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -326,6 +326,13 @@ export default [
           helper: 'Help text is meant to provide additional guidance on the field\'s value',
         },
       },
+      {
+        type: 'FormCheckbox',
+        field: 'readonly',
+        config: {
+          label: 'Control is read only',
+        },
+      },
       bgcolorProperty,
       colorProperty,
       ],
@@ -395,6 +402,13 @@ export default [
         config: {
           label: 'Help Text',
           helper: 'Help text is meant to provide additional guidance on the field\'s value',
+        },
+      },
+      {
+        type: 'FormCheckbox',
+        field: 'readonly',
+        config: {
+          label: 'Control is read only',
         },
       },
       bgcolorProperty,


### PR DESCRIPTION
Fixes #250.

This PR adds readonly attributes to form inputs: `Line Input` and `Textarea`.
This PR requires changes in `vue-form-elements`: https://github.com/ProcessMaker/vue-form-elements/pull/47.

Video of fix: https://www.dropbox.com/s/vsc8nvdrg5t63y7/readonly_working.mov?dl=0.