### PR TITLE
Fix calc field undefined error.

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -104,7 +104,7 @@
         </div>
         <textarea v-show="!isJS" name="formula" v-model="add.formula" class="form-control editor" :class="{'is-invalid':!add.formula}"/>
         <div v-show="isJS" class="editor-border" :class="{'is-invalid':!add.formula}"/>
-        <monaco-editor v-show="isJS" :options="monacoOptions" :minimap="{enabled:false}" class="editor" v-model="add.formula" language="javascript"/>
+        <monaco-editor v-show="isJS" :options="monacoOptions" class="editor" v-model="add.formula" language="javascript"/>
         <div v-if="!add.formula" class="invalid-feedback"><div>{{ $t('The property formula field is required.') }}</div></div>
       </div>
       <button

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,7 +6,7 @@ module.exports = {
   configureWebpack: {
     plugins: [
       new MonocoEditorPlugin({
-        languages: ['javascript', 'css', 'json'],
+        languages: ['javascript', 'typescript', 'css', 'json'],
       }),
     ],
     resolve: {


### PR DESCRIPTION
**How to test**
- Click Calc Button
- Click `Add property` button on modal

**Expected**
No console errors

Adding `typescript ` to the list of languages is required because typescript and javascript have distinct colourizers, but share the same implementation for the language smarts .

**Spark Video Demo**
https://drive.google.com/file/d/1e0twQBNRaY1NFUjaUHQ90ggVgZCmTZZP/view

Fixes #246 