### PR TITLE
Fix Textarea Validation Message

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -145,6 +145,7 @@ export default [
           config: {
             label: 'Rows',
             helper: 'The number of rows to provide for input',
+            validation: 'integer',
           },
         },
         readonlyProperty,


### PR DESCRIPTION
The original validation bug `"The undefined must be a string" appears when adding a Textarea` could not be replicated, however, there is no validation error when adding a Textarea and inputting a string into the 'Rows' field instead of an integer. This PR adds the proper validation error for the 'Rows' field.

closes #307 