### PR TITLE
Added missing button mouseover text

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -26,7 +26,7 @@
                 {{ $t('CSS') }}
               </button>
             </div>
-            <button type="button" class="btn btn-secondary btn-sm ml-1"><i class="fas fa-save"/></button>
+            <button type="button" class="btn btn-secondary btn-sm ml-1" title="Save Screen"><i class="fas fa-save"/></button>
           </b-col>
 
         </b-row>

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,16 +17,16 @@
 
           <b-col class="text-right" v-if="displayBuilder && !displayPreview">
             <div class="btn-group btn-group-sm" role="group" aria-label="Basic example">
-              <button type="button" class="btn btn-secondary" title="Calculated Properties" @click="openComputedProperties">
+              <button type="button" class="btn btn-secondary" :title="$t('Calculated Properties')" @click="openComputedProperties">
                 <i class="fas fa-flask"/>
                 {{ $t('Calcs') }}
               </button>
-              <button type="button" class="btn btn-secondary mr-2" title="Custom CSS" @click="openCustomCSS">
+              <button type="button" class="btn btn-secondary mr-2" :title="$t('Custom CSS')" @click="openCustomCSS">
                 <i class="fab fa-css3"/>
                 {{ $t('CSS') }}
               </button>
             </div>
-            <button type="button" class="btn btn-secondary btn-sm ml-1" title="Save Screen"><i class="fas fa-save"/></button>
+            <button type="button" class="btn btn-secondary btn-sm ml-1" :title="$t('Save Screen')"><i class="fas fa-save"/></button>
           </b-col>
 
         </b-row>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -50,7 +50,7 @@
           size="sm"
           variant="secondary"
           class="ml-1"
-          title="Edit Page Title"
+          :title="$t('Edit Page Title')"
           @click="openEditPageModal(currentPage)"
         >
           <i class="far fa-edit"/>
@@ -60,14 +60,14 @@
           size="sm"
           variant="danger"
           class="ml-1"
-          title="Delete Page"
+          :title="$t('Delete Page')"
           @click="confirmDelete()"
           :disabled="!displayDelete"
         >
           <i class="far fa-trash-alt"/>
         </b-button>
 
-        <b-button size="sm" variant="secondary" class="ml-1" title="Add New Page" v-b-modal.addPageModal>
+        <b-button size="sm" variant="secondary" class="ml-1" :title="$t('Add New Page')" v-b-modal.addPageModal>
           <i class="fas fa-plus"/>
         </b-button>
 
@@ -110,7 +110,7 @@
               {{ element.config.name || element.label || $t('Field Name') }}
               <button
                 class="btn btn-sm btn-danger ml-auto"
-                title="Delete Control"
+                :title="$t('Delete Control')"
                 @click="deleteItem(index)"
               >
                 <i class="far fa-trash-alt text-light"/>
@@ -139,7 +139,7 @@
               {{ element.config.name || $t('Key Name') }}
               <button
                 class="btn btn-sm btn-danger ml-auto"
-                title="Delete Control"
+                :title="$t('Delete Control')"
                 @click="deleteItem(index)"
               >
                 <i class="far fa-trash-alt text-light"/>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -50,6 +50,7 @@
           size="sm"
           variant="secondary"
           class="ml-1"
+          title="Edit Page Title"
           @click="openEditPageModal(currentPage)"
         >
           <i class="far fa-edit"/>
@@ -59,13 +60,14 @@
           size="sm"
           variant="danger"
           class="ml-1"
+          title="Delete Page"
           @click="confirmDelete()"
           :disabled="!displayDelete"
         >
           <i class="far fa-trash-alt"/>
         </b-button>
 
-        <b-button size="sm" variant="secondary" class="ml-1" v-b-modal.addPageModal>
+        <b-button size="sm" variant="secondary" class="ml-1" title="Add New Page" v-b-modal.addPageModal>
           <i class="fas fa-plus"/>
         </b-button>
 
@@ -108,6 +110,7 @@
               {{ element.config.name || element.label || $t('Field Name') }}
               <button
                 class="btn btn-sm btn-danger ml-auto"
+                title="Delete Control"
                 @click="deleteItem(index)"
               >
                 <i class="far fa-trash-alt text-light"/>
@@ -136,6 +139,7 @@
               {{ element.config.name || $t('Key Name') }}
               <button
                 class="btn btn-sm btn-danger ml-auto"
+                title="Delete Control"
                 @click="deleteItem(index)"
               >
                 <i class="far fa-trash-alt text-light"/>


### PR DESCRIPTION
Added mouseover text for the following buttons:

- Save Screen
- Add Page
- Edit Page
- Delete Page

_(we'll probably need a separate commit on PM4 core to add the title strings to the en.json file for future translation)_