### PR TITLE
Remove currency datatype

### DIFF
--- a/src/VariableDataTypeProperties.js
+++ b/src/VariableDataTypeProperties.js
@@ -3,11 +3,10 @@ const int = { value: 'int', content: 'Integer' };
 const float = { value: 'float', content: 'Decimal' };
 const datetime = { value: 'datetime', content: 'Datetime' };
 const date = { value: 'date', content: 'Date' };
-const currency = { value: 'currency', content: 'Currency' };
 const boolean = { value: 'boolean', content: 'Boolean' };
 
-const allOptions = [string, int, float, datetime, date, currency];
-const allOptionsWithoutDate = [string, int, float, currency];
+const allOptions = [string, int, float, datetime, date];
+const allOptionsWithoutDate = [string, int, float];
 
 function dataTypeFactory(options) {
   return {


### PR DESCRIPTION
Fixes #330. The currency data type will no longer appear in the dropdown.

Screenshot of fix:
<img width="275" alt="Screen Shot 2019-08-09 at 10 25 42 AM" src="https://user-images.githubusercontent.com/7561061/62786430-963abe80-ba90-11e9-9a9d-cba248991429.png">
