### PR TITLE
Update rich text content label

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -49,7 +49,7 @@ export default [
           field: 'content',
           config: {
             rows: 5,
-            label: 'Rich Text Content',
+            label: 'Content',
             helper: 'The HTML text to display',
             value: '',
           },


### PR DESCRIPTION
Fixes #335.

Screenshot of fix:
<img width="268" alt="Screen Shot 2019-08-12 at 11 46 23 AM" src="https://user-images.githubusercontent.com/7561061/62878320-da2efd00-bcf6-11e9-9278-e3396092192c.png">
