### PR TITLE
Bug/305

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -187,8 +187,6 @@ export default {
         lineNumbers: 'off',
         minimap: false,
       },
-      childNodes: [],
-      currentPage: 0,
     };
   },
   components: {
@@ -245,7 +243,6 @@ export default {
     validationErrors() {
       const validationErrors = [];
       this.config.forEach(page => {
-        this.validateChildNodes(validationErrors, page);
         page.items.forEach(item => {
           let data = item.config ? item.config : {};
           let rules = {};
@@ -289,18 +286,6 @@ export default {
         config.builderBinding
       );
     });
-
-    this.$root.$on('validation', (errors) => {
-      this.childNodes = this.childNodes.concat(errors);
-    });
-
-    this.$root.$on('current-page', (index) => {
-      this.currentPage = index;
-    });
-
-    this.$root.$on('deleted-child', (item) => {
-     this.childNodes.splice(item,1);
-    });
   },
   methods: {
     focusInspector(validate) {
@@ -323,38 +308,6 @@ export default {
       this.$refs.renderer.$options.components[rendererBinding] = rendererComponent;
       // Add it to the form builder
       this.$refs.builder.addControl(control, builderComponent, builderBinding);
-    },
-    validateChildNodes(validationErrors, page) {
-      let pageIndex = this.config.indexOf(page);
-      if (pageIndex === this.currentPage && this.childNodes.length > 0) {
-        this.childNodes.forEach(item => {
-          let data = item.config ? item.config : {};
-          let rules = {};
-          item.inspector.forEach(property => {
-            if (property.config.validation) {
-              rules[property.field] = property.config.validation;
-            }
-          });
-          let validator = new Validator(data, rules);
-            // To include another language in the Validator with variable processmaker
-            if (window.ProcessMaker && window.ProcessMaker.user && window.ProcessMaker.user.lang) {
-              validator.useLang(window.ProcessMaker.user.lang);
-            }
-            // Validation will not run until you call passes/fails on it
-            if (!validator.passes()) {
-              Object.keys(validator.errors.errors).forEach(field => {
-                validator.errors.errors[field].forEach(error => {
-                  validationErrors.push({
-                    message: error,
-                    page,
-                    item,
-                  });
-                });
-              });
-            }
-            return validationErrors;
-        });
-      }
     },
   },
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -187,6 +187,8 @@ export default {
         lineNumbers: 'off',
         minimap: false,
       },
+      childNodes: [],
+      currentPage: 0,
     };
   },
   components: {
@@ -243,6 +245,7 @@ export default {
     validationErrors() {
       const validationErrors = [];
       this.config.forEach(page => {
+        this.validateChildNodes(validationErrors, page);
         page.items.forEach(item => {
           let data = item.config ? item.config : {};
           let rules = {};
@@ -286,6 +289,18 @@ export default {
         config.builderBinding
       );
     });
+
+    this.$root.$on('validation', (errors) => {
+      this.childNodes = this.childNodes.concat(errors);
+    });
+
+    this.$root.$on('current-page', (index) => {
+      this.currentPage = index;
+    });
+
+    this.$root.$on('deleted-child', (item) => {
+     this.childNodes.splice(item,1);
+    });
   },
   methods: {
     focusInspector(validate) {
@@ -308,6 +323,38 @@ export default {
       this.$refs.renderer.$options.components[rendererBinding] = rendererComponent;
       // Add it to the form builder
       this.$refs.builder.addControl(control, builderComponent, builderBinding);
+    },
+    validateChildNodes(validationErrors, page) {
+      let pageIndex = this.config.indexOf(page);
+      if (pageIndex === this.currentPage && this.childNodes.length > 0) {
+        this.childNodes.forEach(item => {
+          let data = item.config ? item.config : {};
+          let rules = {};
+          item.inspector.forEach(property => {
+            if (property.config.validation) {
+              rules[property.field] = property.config.validation;
+            }
+          });
+          let validator = new Validator(data, rules);
+            // To include another language in the Validator with variable processmaker
+            if (window.ProcessMaker && window.ProcessMaker.user && window.ProcessMaker.user.lang) {
+              validator.useLang(window.ProcessMaker.user.lang);
+            }
+            // Validation will not run until you call passes/fails on it
+            if (!validator.passes()) {
+              Object.keys(validator.errors.errors).forEach(field => {
+                validator.errors.errors[field].forEach(error => {
+                  validationErrors.push({
+                    message: error,
+                    page,
+                    item,
+                  });
+                });
+              });
+            }
+            return validationErrors;
+        });
+      }
     },
   },
 };

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -10,7 +10,6 @@
             @input="updateContainerConfig($event, index)"
             :options="{group: {name: 'controls'}}"
             :key="index"
-            @change="getItems($event)"
           >
             <div class="control-item"
               :class="{selected: selected === element}"
@@ -40,7 +39,7 @@
               </div>
 
               <div v-else :id="element.config.name ? element.config.name : undefined">
-                <div class="m-2" :class="{ 'card' : selected === element, 'card hasError ' : hasErrors(element) }">
+                <div class="m-2" :class="{ 'card' : selected === element }">
                   <button
                     v-if="selected === element"
                     class="element-delete-btn btn btn-sm btn-danger-outline ml-auto position-absolute"
@@ -69,7 +68,6 @@
 </template>
 
 <script>
-import Vue from 'vue';
 import draggable from 'vuedraggable';
 import { HasColorProperty } from '@/mixins';
 import * as renderer from '@/components/renderer';
@@ -83,7 +81,6 @@ import {
   FormHtmlEditor,
 } from '@processmaker/vue-form-elements';
 
-import Validator from 'validatorjs';
 const defaultColumnWidth = 1;
 
 export default {
@@ -147,39 +144,10 @@ export default {
       this.$emit('inspect', element);
     },
     deleteItem(col, index) {
-      this.$root.$emit('deleted-child', index);
       // Remove the item from the array in currentPage
       this.items[col].splice(index, 1);
       this.$emit('update-state');
     },
-    hasErrors(item) {
-      let validationErrors = [];
-      let rules = {};
-      item.inspector.forEach(property => {
-        if (property.config.validation) {
-          rules[property.field] = property.config.validation;
-        }
-      });
-      let validator = new Validator(item.config, rules);
-      // Validation will not run until you call passes/fails on it
-      if (!validator.passes()) {
-        Object.keys(validator.errors.errors).forEach(field => {
-          validator.errors.errors[field].forEach(error => {
-            validationErrors.push({
-              message: error,
-              item,
-            });
-          });
-        });
-      }
-      return validationErrors.some(({ col }) => col === col); 
-    },
-    getItems(event) {
-      
-      if (event.added) {
-        this.$root.$emit('validation', event.added.element);
-      }
-    }
   },
 };
 </script>
@@ -226,9 +194,5 @@ export default {
       top: 10px;
       right: 10px;
       z-index: 1;
-    }
-
-    .hasError {
-      border-color: red;
     }
 </style>

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -10,6 +10,7 @@
             @input="updateContainerConfig($event, index)"
             :options="{group: {name: 'controls'}}"
             :key="index"
+            @change="getItems($event)"
           >
             <div class="control-item"
               :class="{selected: selected === element}"
@@ -39,7 +40,7 @@
               </div>
 
               <div v-else :id="element.config.name ? element.config.name : undefined">
-                <div class="m-2" :class="{ 'card' : selected === element }">
+                <div class="m-2" :class="{ 'card' : selected === element, 'card hasError ' : hasErrors(element) }">
                   <button
                     v-if="selected === element"
                     class="element-delete-btn btn btn-sm btn-danger-outline ml-auto position-absolute"
@@ -68,6 +69,7 @@
 </template>
 
 <script>
+import Vue from 'vue';
 import draggable from 'vuedraggable';
 import { HasColorProperty } from '@/mixins';
 import * as renderer from '@/components/renderer';
@@ -81,6 +83,7 @@ import {
   FormHtmlEditor,
 } from '@processmaker/vue-form-elements';
 
+import Validator from 'validatorjs';
 const defaultColumnWidth = 1;
 
 export default {
@@ -144,10 +147,39 @@ export default {
       this.$emit('inspect', element);
     },
     deleteItem(col, index) {
+      this.$root.$emit('deleted-child', index);
       // Remove the item from the array in currentPage
       this.items[col].splice(index, 1);
       this.$emit('update-state');
     },
+    hasErrors(item) {
+      let validationErrors = [];
+      let rules = {};
+      item.inspector.forEach(property => {
+        if (property.config.validation) {
+          rules[property.field] = property.config.validation;
+        }
+      });
+      let validator = new Validator(item.config, rules);
+      // Validation will not run until you call passes/fails on it
+      if (!validator.passes()) {
+        Object.keys(validator.errors.errors).forEach(field => {
+          validator.errors.errors[field].forEach(error => {
+            validationErrors.push({
+              message: error,
+              item,
+            });
+          });
+        });
+      }
+      return validationErrors.some(({ col }) => col === col); 
+    },
+    getItems(event) {
+      
+      if (event.added) {
+        this.$root.$emit('validation', event.added.element);
+      }
+    }
   },
 };
 </script>
@@ -194,5 +226,9 @@ export default {
       top: 10px;
       right: 10px;
       z-index: 1;
+    }
+
+    .hasError {
+      border-color: red;
     }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -361,7 +361,6 @@ export default {
     },
     currentPage() {
       this.inspect();
-      this.$root.$emit('current-page', this.currentPage);
     },
     inspection(e) {
       if (this.translated.includes(e)) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -361,6 +361,7 @@ export default {
     },
     currentPage() {
       this.inspect();
+      this.$root.$emit('current-page', this.currentPage);
     },
     inspection(e) {
       if (this.translated.includes(e)) {


### PR DESCRIPTION
Issue: Validation was not being run on the nested nodes within 'Multicolumn'. 

Fix: All nested nodes are now in a 'childNodes' array that runs in the `validationErrors` method.

Known Issues:
1. Nested Nodes are not properly linked by page within the console.
2. Deleting a nested node does not remove the correct validation message within the console.

closes #305 
