### PR TITLE
Allow the possibility of removing de default Option in select lists and radio button groups

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -94,7 +94,7 @@
                   <span class="fas fa-arrows-alt-v"/>
                 </div>
                 <div class="col-1 d-flex align-items-center">
-                  <input type="radio" class="form-check" name="defaultOptionGroup" v-model="defaultOptionKey" :value="option[keyField]">
+                  <input type="radio" class="form-check" @click="defaultOptionClick" name="defaultOptionGroup" v-model="defaultOptionKey" :value="option[keyField]">
                 </div>
                 <div class="col-5" style="cursor:grab">
                   {{ option[valueField] }}
@@ -268,6 +268,11 @@ export default {
     this.jsonData = JSON.stringify(this.optionsList);
   },
   methods: {
+    defaultOptionClick() {
+      if (this.defaultOptionKey === event.target.value) {
+        this.defaultOptionKey = false;
+      }
+    },
     rowCss(index) {
       return index % 2 === 0 ? 'striped' : 'bg-default';
     },


### PR DESCRIPTION
Resolves #381 

- When clicking twice a radio button option, the default option is reset.

![image](https://user-images.githubusercontent.com/14875032/63972075-f4e2cf00-ca75-11e9-9905-4d004732378c.png)

![image](https://user-images.githubusercontent.com/14875032/63972078-f7ddbf80-ca75-11e9-99bb-ae835277d95d.png)

