### PR TITLE
Read Only Controls

### DIFF
--- a/src/components/accordions.js
+++ b/src/components/accordions.js
@@ -7,6 +7,7 @@ export default [
       'dataFormat',
       'validation',
       'readonly',
+      'disabled',
       'initiallyChecked',
     ],
     open: true,

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -31,7 +31,7 @@
             :name="element.config.name !== undefined ? element.config.name : null"
             v-bind="element.config"
             :is="element.component"
-            :disabled="element.config.interactive"
+            :disabled="element.config.interactive ? element.config.interactive : element.config.disabled"
           />
         </div>
       </div>

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -31,7 +31,7 @@
             :name="element.config.name !== undefined ? element.config.name : null"
             v-bind="element.config"
             :is="element.component"
-            :disabled="element.config.interactive ? element.config.interactive : element.config.disabled"
+            :disabled="element.config.interactive || element.config.disabled"
           />
         </div>
       </div>

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -26,6 +26,7 @@ import {
   validationRulesProperty,
   toggleStyleProperty,
   buttonVariantStyleProperty,
+  disabledProperty,
 } from './form-control-common-properties';
 
 export default [
@@ -186,6 +187,7 @@ export default [
         labelProperty,
         placeholderProperty,
         validationRulesProperty,
+        disabledProperty,
         helperTextProperty,
         {
           type: 'OptionsList',
@@ -235,6 +237,7 @@ export default [
         colorProperty,
         bgcolorProperty,
         toggleStyleProperty,
+        disabledProperty,
       ],
     },
   },
@@ -274,6 +277,7 @@ export default [
         colorProperty,
         bgcolorProperty,
         toggleStyleProperty,
+        disabledProperty,
       ],
     },
   },
@@ -303,6 +307,7 @@ export default [
         helperTextProperty,
         colorProperty,
         bgcolorProperty,
+        disabledProperty
       ],
     },
   },

--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -136,6 +136,14 @@ export const readonlyProperty = {
   },
 };
 
+export const disabledProperty = {
+  type: 'FormCheckbox',
+  field: 'disabled',
+  config: {
+    label: 'Read Only',
+  },
+};
+
 export const validationRulesProperty = {
   type: 'FormInput',
   field: 'validation',


### PR DESCRIPTION
Resolves #384 

Bootstrap does not introduce special considerations for disabling Select, radio groups, checkbox.

- Add disabled property in Select, Radio Groups, Date Picker, checkbox.
