### PR TITLE
Use html viewer to render FormHtmlEditor component on render and preview

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -95,6 +95,7 @@ import {
   FormRadioButtonGroup,
   FormDatePicker,
   FormHtmlEditor,
+  FormHtmlViewer,
 } from '@processmaker/vue-form-elements';
 
 const defaultColumnWidth = 1;
@@ -112,6 +113,7 @@ export default {
     FormTextArea,
     FormDatePicker,
     FormHtmlEditor,
+    FormHtmlViewer,
     ...renderer,
   },
   data() {

--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -53,6 +53,7 @@ import {
   FormRadioButtonGroup,
   FormDatePicker,
   FormHtmlEditor,
+  FormHtmlViewer,
 } from '@processmaker/vue-form-elements';
 
 const defaultColumnWidth = 1;
@@ -70,6 +71,7 @@ export default {
     FormRadioButtonGroup,
     FormDatePicker,
     FormHtmlEditor,
+    FormHtmlViewer,
     ...renderer,
   },
   data() {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -291,6 +291,7 @@ import {
   FormRadioButtonGroup,
   FormDatePicker,
   FormHtmlEditor,
+  FormHtmlViewer,
 } from '@processmaker/vue-form-elements';
 
 import '@processmaker/vue-form-elements/dist/vue-form-elements.css';
@@ -327,6 +328,7 @@ export default {
     FormTextArea,
     FormDatePicker,
     FormHtmlEditor,
+    FormHtmlViewer,
     FormMultiColumn,
     ...editor,
     ...inspector,

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -58,6 +58,7 @@ import {
   FormRadioButtonGroup,
   FormDatePicker,
   FormHtmlEditor,
+  FormHtmlViewer,
 } from '@processmaker/vue-form-elements';
 import { Parser } from 'expr-eval';
 
@@ -124,6 +125,7 @@ export default {
     FormTextArea,
     FormDatePicker,
     FormHtmlEditor,
+    FormHtmlViewer,
     FormMultiColumn,
     CustomCSS,
     ...editor,

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -36,7 +36,7 @@ export default [
     rendererBinding: 'FormHtmlEditor',
     control: {
       label: 'Rich Text',
-      component: 'FormHtmlEditor',
+      component: 'FormHtmlViewer',
       'editor-component': 'FormHtmlEditor',
       'editor-control': 'FormHtmlEditor',
       config: {

--- a/tests/unit/VueFormBuilder.spec.js
+++ b/tests/unit/VueFormBuilder.spec.js
@@ -17,7 +17,7 @@ const i18n = new VueI18Next(i18next);
 
 
 function isFormHtmlEditor(config) {
-  return config.control.component === 'FormHtmlEditor';
+  return config.control.component === 'FormHtmlEditor' || config.control.component === 'FormHtmlViewer';
 }
 
 describe('App', () => {


### PR DESCRIPTION
Resolves #80 
Requires: https://github.com/ProcessMaker/vue-form-elements/pull/81

This PR fix the unclickable `links` in screens rendered at preview and task runtime.

- Add a FormHTMLViewer component to render the rich text controls for preview and runtime mode (which enable the use of links).
- When a new RichText elements is added, it will use FormHTMLViewer to render the result.
- The already created RichText elements **will have the fix**, even if they not use FormHTMLViewer, so the user does not need to edit or migrate its forms.
