### PR TITLE
Add monaco json editor/402

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -185,7 +185,7 @@
 import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
-import * as editor from 'monaco-editor/esm/vs/editor/editor.main';
+require('monaco-editor/esm/vs/editor/editor.main');
 
 export default {
   components: {

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -137,7 +137,7 @@
           <button type="button" @click="expandEditor" class="btn-sm float-right"><i class="fas fa-expand"/></button>
         </div>
         <div class="small-editor-container">
-          <MonacoEditor :options="monacoOptions" class="editor" v-model="jsonData" language="json" />
+          <MonacoEditor :options="monacoOptions" class="editor" v-model="jsonData" language="json" @change="jsonDataChange"/>
         </div>
 
         <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak>
@@ -311,6 +311,28 @@ export default {
         editIndex: this.editIndex,
         removeIndex: this.removeIndex,
       };
+    },
+     jsonDataChange() {	
+      let jsonList = [];	
+      try {	
+        jsonList = JSON.parse(this.jsonData);	
+        if (jsonList.constructor !== Array && jsonList.constructor !== Object) {	
+          throw Error('String does not represent a valid JSON');	
+        }	
+      }	
+      catch (err) {	
+        this.jsonError = err.message;	
+        return;	
+      }	
+      this.optionsList = [];	
+      const that = this;	
+      jsonList.forEach (item => {	
+        that.optionsList.push({	
+          [that.keyField] : item[that.keyField],	
+          [that.valueField] : item[that.valueField],	
+        });	
+      });	
+      this.jsonError = '';	
     },
   },
   mounted() {

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -132,11 +132,13 @@
     </div>
     <div v-if="showJsonEditor && dataSource === dataSourceValues.provideData">
       <div v-if="dataSource === dataSourceValues.provideData">
-        <div class="mb-1">
+        <div class="mb-2">
           <label for="json-data">{{ $t('JSON Data') }}</label>
           <button type="button" @click="expandEditor" class="btn-sm float-right"><i class="fas fa-expand"/></button>
         </div>
-        <MonacoEditor  :options="monacoOptions" class="editor" v-model="jsonData" language="json" />
+        <div class="small-editor-container">
+          <MonacoEditor :options="monacoOptions" class="editor" v-model="jsonData" language="json" />
+        </div>
 
         <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak>
           <div class="editor-container">
@@ -183,6 +185,7 @@
 import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
+import * as editor from 'monaco-editor/esm/vs/editor/editor.main';
 
 export default {
   components: {
@@ -421,8 +424,16 @@ export default {
     background-color: rgba(0,0,0,.05);
   }
 
-  .editor {
+  .small-editor-container .editor {
     width: inherit;
     height: 150px;
+  }
+
+  .editor-container {
+    height: 70vh;
+  }
+
+  .editor-container .editor {
+    height: inherit;
   }
 </style>

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -432,7 +432,7 @@ export default {
   .editor-container {
     height: 70vh;
   }
-
+  
   .editor-container .editor {
     height: inherit;
   }


### PR DESCRIPTION
This PR removes the standard `textarea` being used for editing the JSON Data in Data Sources and replaces it with the Moncao Editor. 

closes #405 

![Screen Shot 2019-09-26 at 11 01 32 AM](https://user-images.githubusercontent.com/52755494/65713150-69953300-e04d-11e9-9ec6-765c0568f269.png)
![Screen Shot 2019-09-26 at 11 04 00 AM](https://user-images.githubusercontent.com/52755494/65713151-69953300-e04d-11e9-9eb6-4530aab86ce9.png)
