### PR TITLE
Fix 'The undefined field is required' error when creating a new page.

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -211,6 +211,7 @@
       :title="$t('Add New Page')"
     >
       <form-input v-model="addPageName"
+        :name="$t('Page Name')"
         :label="$t('Page Name')"
         :helper="$t('The name of the new page to add')"
         validation="unique-page-name|required"


### PR DESCRIPTION
This PR fixes the `The undefined field is required` bug when creating a new page. 

![Screen Shot 2019-10-09 at 10 14 32 AM](https://user-images.githubusercontent.com/52755494/66504308-b8938d00-ea7d-11e9-9b1b-0cb532ca38ac.png)


closes #377 