### PR TITLE
prevent data name from being overwritten in data source

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -263,9 +263,12 @@ export default {
       this.editIndex = this.options.editIndex;
       this.removeIndex = this.options.removeIndex;
     },
-    dataSource() {
-      this.jsonData = '';
-      this.dataName = '';
+    dataSource(val) {
+      if (val === 'dataObject') {
+        this.jsonData = '';
+      } else {
+        this.dataName = '';
+      }
     },
     dataObjectOptions(dataObjectOptions) {
       this.$emit('change', dataObjectOptions);


### PR DESCRIPTION
This PR fixes an issue for the Data Source type Data Object Name from being cleared when saving and or selecting another element.

Dependent on [#111](https://github.com/ProcessMaker/vue-form-elements/pull/111) in vue-form-elements.