### PR TITLE
Calculated Field Javascript Size

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -362,7 +362,7 @@ export default {
     border: 1px solid #ced4da;
     border-radius: 4px;
     overflow: hidden;
-    height: 8.5em;
+    height: 8.8em;
     position: absolute;
     pointer-events: none;
     width: 100%;


### PR DESCRIPTION
Resolves #423 

Css class was fixed to use a better height for the box.

Before the change:
![image](https://user-images.githubusercontent.com/14875032/67291695-ecc07200-f4af-11e9-898e-cf8242d6ed7d.png)

With the correction
![image](https://user-images.githubusercontent.com/14875032/67291711-f2b65300-f4af-11e9-830a-9a7dbbdbfd2e.png)
