### PR TITLE
Remove Datatype dropdown 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15629,9 +15629,9 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "15.7.1",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.1.tgz",
-      "integrity": "sha512-fwIKtA23Pl/rqfYP5TSGK7gkEuLhoTvRYW+TU7ER3q9GpNLt/PjG5NLv3XHRDiTg7OPM1JcckBgds+VnAc+HbA==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.2.tgz",
+      "integrity": "sha512-H/P9xt/nkocyu4hZKg5TzPqyCT1oKOaCSk9zs0JCbJuy0Q8KtR0bjJpnT/5R5x/Ckd1GFkkLQnQ1C4x6xXeLZg==",
       "requires": {
         "@vue/component-compiler-utils": "^3.0.0",
         "hash-sum": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15629,9 +15629,9 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.2.tgz",
-      "integrity": "sha512-H/P9xt/nkocyu4hZKg5TzPqyCT1oKOaCSk9zs0JCbJuy0Q8KtR0bjJpnT/5R5x/Ckd1GFkkLQnQ1C4x6xXeLZg==",
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.1.tgz",
+      "integrity": "sha512-fwIKtA23Pl/rqfYP5TSGK7gkEuLhoTvRYW+TU7ER3q9GpNLt/PjG5NLv3XHRDiTg7OPM1JcckBgds+VnAc+HbA==",
       "requires": {
         "@vue/component-compiler-utils": "^3.0.0",
         "hash-sum": "^1.0.2",

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -151,7 +151,7 @@
           </div>
         </b-modal>
       </div>
-      
+
       <a @click="editAsOptionList()" href="#" class="text-right">
         <small class="form-text text-muted mb-3"><b>&#x3C;/&#x3E;</b> {{ $t('Edit as Option List') }}</small>
       </a>
@@ -185,7 +185,6 @@
 import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
-require('monaco-editor/esm/vs/editor/editor.main');
 
 export default {
   components: {
@@ -332,27 +331,27 @@ export default {
     this.allowMultiSelect = this.options.allowMultiSelect;
   },
   methods: {
-    jsonDataChange() {	
-      let jsonList = [];	
-      try {	
-        jsonList = JSON.parse(this.jsonData);	
-        if (jsonList.constructor !== Array && jsonList.constructor !== Object) {	
-          throw Error('String does not represent a valid JSON');	
-        }	
+    jsonDataChange() {
+      let jsonList = [];
+      try {
+        jsonList = JSON.parse(this.jsonData);
+        if (jsonList.constructor !== Array && jsonList.constructor !== Object) {
+          throw Error('String does not represent a valid JSON');
+        }
       }	
-      catch (err) {	
-        this.jsonError = err.message;	
-        return;	
-      }	
-      this.optionsList = [];	
-      const that = this;	
-      jsonList.forEach (item => {	
-        that.optionsList.push({	
-          [that.keyField] : item[that.keyField],	
-          [that.valueField] : item[that.valueField],	
-        });	
-      });	
-      this.jsonError = '';	
+      catch (err) {
+        this.jsonError = err.message;
+        return;
+      }
+      this.optionsList = [];
+      const that = this;
+      jsonList.forEach (item => {
+        that.optionsList.push({
+          [that.keyField] : item[that.keyField],
+          [that.valueField] : item[that.valueField],
+        });
+      });
+      this.jsonError = '';
     },
     defaultOptionClick() {
       if (this.defaultOptionKey === event.target.value) {
@@ -457,7 +456,7 @@ export default {
   .editor-container {
     height: 70vh;
   }
-  
+
   .editor-container .editor {
     height: inherit;
   }

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -43,7 +43,7 @@
 <script>
 import Vue from 'vue';
 import * as VueDeepSet from 'vue-deepset';
-import debounce from 'lodash/debounce';
+import _ from 'lodash';
 import { getValidPath, HasColorProperty, shouldElementBeVisible } from '@/mixins';
 import * as editor from './editor';
 import * as renderer from './renderer';
@@ -157,7 +157,7 @@ export default {
     },
   },
   created() {
-    this.parseCss = debounce(this.parseCss, 500, {leading: true});
+    this.parseCss = _.debounce(this.parseCss, 500, {leading: true});
   },
   mounted() {
     this.parseCss();

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -3,7 +3,7 @@ import FormButton from './components/renderer/form-button';
 import FormMultiColumn from './components/renderer/form-multi-column';
 import FormRecordList from './components/renderer/form-record-list';
 import FormImage from './components/renderer/form-image';
-import {DataTypeProperty, DataTypeWithoutDateProperty, DataTypeBooleanProperty, DataTypeDateTimeProperty} from './VariableDataTypeProperties';
+import {DataTypeProperty, DataTypeWithoutDateProperty, DataTypeDateTimeProperty} from './VariableDataTypeProperties';
 import {
   FormInput,
   FormTextArea,

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -309,6 +309,7 @@ export default [
       },
       inspector: [
         keyNameProperty,
+        DataTypeBooleanProperty,
         labelProperty,
         helperTextProperty,
         validationRulesProperty,

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -309,7 +309,6 @@ export default [
       },
       inspector: [
         keyNameProperty,
-        DataTypeBooleanProperty,
         labelProperty,
         helperTextProperty,
         validationRulesProperty,

--- a/tests/unit/ConditionalHide.spec.js
+++ b/tests/unit/ConditionalHide.spec.js
@@ -27,7 +27,7 @@ describe('Hide or show controls', () => {
               'validation': '',
               'helper': null,
               'type': 'text',
-              'conditionalHide': 'field1=="field2"',
+              'conditionalHide': 'field1==="field2"',
             },
           },
           {
@@ -38,7 +38,7 @@ describe('Hide or show controls', () => {
               'validation': '',
               'helper': null,
               'type': 'text',
-              'conditionalHide': 'field1=="field3"',
+              'conditionalHide': 'field1==="field3"',
             },
           },
           {
@@ -60,43 +60,43 @@ describe('Hide or show controls', () => {
   it('Hide control with evaluation success', () => {
 
     //The fields that not contain a conditional are displayed by default
-    expect(wrapper.vm.showElement.field1).toBe(true);
-    expect(wrapper.vm.showElement.field4).toBe(true);
+    expect(wrapper.contains('#field1')).toBe(true);
+    expect(wrapper.contains('#field4')).toBe(true);
 
     //The fields that contain a conditional and evaluation is false are hidden.
-    expect(wrapper.vm.showElement.field2).toBe(false);
-    expect(wrapper.vm.showElement.field3).toBe(false);
-
-    //When changing the value, the condition is calculated automatically to verify if it is hidden or not
-    wrapper.setData({'model': {'field1': 'field2'}});
-    expect(wrapper.vm.showElement.field1).toBe(true); //visible
-    expect(wrapper.vm.showElement.field2).toBe(true); //visible
-    expect(wrapper.vm.showElement.field4).toBe(true); //visible
-    expect(wrapper.vm.showElement.field3).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field2')).toBe(false);
+    expect(wrapper.contains('#field3')).toBe(false);
 
     //When changing the value, the condition is calculated automatically to verify if it is hidden or not
     wrapper.setData({'model': {'field1': 'field3'}});
-    expect(wrapper.vm.showElement.field1).toBe(true); //visible
-    expect(wrapper.vm.showElement.field3).toBe(true); //visible
-    expect(wrapper.vm.showElement.field4).toBe(true); //visible
-    expect(wrapper.vm.showElement.field2).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field1')).toBe(true); //visible
+    expect(wrapper.contains('#field2')).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field4')).toBe(true); //visible
+    expect(wrapper.contains('#field3')).toBe(false); //The field was hidden because it did not meet the condition.
+
+    //When changing the value, the condition is calculated automatically to verify if it is hidden or not
+    wrapper.setData({'model': {'field1': 'field3'}});
+    expect(wrapper.contains('#field1')).toBe(true); //visible
+    expect(wrapper.contains('#field3')).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field4')).toBe(true); //visible
+    expect(wrapper.contains('#field2')).toBe(false); //The field was hidden because it did not meet the condition.
   });
 
   it('Not Hide control with evaluation failure', () => {
 
     //When changing the value, the condition is calculated automatically to verify if it is hidden or not
     wrapper.setData({'model': {'field1': ''}});
-    expect(wrapper.vm.showElement.field1).toBe(true); //visible
-    expect(wrapper.vm.showElement.field4).toBe(true); //visible
-    expect(wrapper.vm.showElement.field2).toBe(false); //The field was hidden because it did not meet the condition.
-    expect(wrapper.vm.showElement.field3).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field1')).toBe(true); //visible
+    expect(wrapper.contains('#field4')).toBe(true); //visible
+    expect(wrapper.contains('#field2')).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field3')).toBe(false); //The field was hidden because it did not meet the condition.
 
     //When changing the value, the condition is calculated automatically to verify if it is hidden or not
     wrapper.setData({'model': {'field1': 'other value'}});
-    expect(wrapper.vm.showElement.field1).toBe(true); //visible
-    expect(wrapper.vm.showElement.field4).toBe(true); //visible
-    expect(wrapper.vm.showElement.field2).toBe(false); //The field was hidden because it did not meet the condition.
-    expect(wrapper.vm.showElement.field3).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field1')).toBe(true); //visible
+    expect(wrapper.contains('#field4')).toBe(true); //visible
+    expect(wrapper.contains('#field2')).toBe(false); //The field was hidden because it did not meet the condition.
+    expect(wrapper.contains('#field3')).toBe(false); //The field was hidden because it did not meet the condition.
   });
 
 });

--- a/tests/unit/VueFormBuilder.spec.js
+++ b/tests/unit/VueFormBuilder.spec.js
@@ -19,6 +19,9 @@ const i18n = new VueI18Next(i18next);
 function isFormHtmlEditor(config) {
   return config.control.component === 'FormHtmlEditor' || config.control.component === 'FormHtmlViewer';
 }
+function isFormCheckbox(config) {
+  return config.control.component === 'FormCheckbox';
+}
 
 describe('App', () => {
   it('Contains Rich Text control', () => {
@@ -42,5 +45,24 @@ describe('App', () => {
     );
 
     expect(wrapper.vm.controls).toHaveLength(1);
+  });
+
+  it('should not contain datatype select drop down ', function() {
+    let store = new Vuex.Store();
+    const wrapper = shallowMount(VueFormBuilder, {i18n, store, localVue});
+    const checkboxConfig = controlConfig.find(isFormCheckbox);
+
+    wrapper.vm.addControl(
+      checkboxConfig.control,
+      checkboxConfig.rendererComponent,
+      checkboxConfig.rendererBinding,
+      checkboxConfig.builderComponent,
+      checkboxConfig.builderBinding,
+      checkboxConfig.inspector
+    );
+
+    checkboxConfig.control.inspector.forEach(item => {
+      expect(item.field.dataFormat).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
The purpose of this pull request is to remove the Data Type dropdown from the Checkbox inspector.

**Acceptance Criteria** 
The checkbox inspector panel does not contain DataType Dropdown.

<img width="1675" alt="Screen Shot 2019-11-25 at 2 15 54 PM" src="https://user-images.githubusercontent.com/26545455/69570680-4673fa80-0f8e-11ea-8f1c-c931bc2824f8.png">


Fixes #440 