### PR TITLE
Textarea Element: Remove Dataype dropdown

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -133,7 +133,6 @@ export default [
         labelProperty,
         placeholderProperty,
         keyNameProperty,
-        DataTypeProperty,
         helperTextProperty,
         {
           type: 'FormCheckbox',

--- a/tests/unit/VueFormBuilder.spec.js
+++ b/tests/unit/VueFormBuilder.spec.js
@@ -23,6 +23,10 @@ function isFormCheckbox(config) {
   return config.control.component === 'FormCheckbox';
 }
 
+function isTextArea(config) {
+  return config.control.component === 'FormTextArea';
+}
+
 describe('App', () => {
   it('Contains Rich Text control', () => {
     const richTextConfig = controlConfig.find(isFormHtmlEditor);
@@ -45,6 +49,25 @@ describe('App', () => {
     );
 
     expect(wrapper.vm.controls).toHaveLength(1);
+  });
+
+  it('should not contain datatype select on textarea element', function() {
+    let store = new Vuex.Store();
+    const wrapper = shallowMount(VueFormBuilder, {i18n, store, localVue});
+    const checkboxConfig = controlConfig.find(isTextArea);
+
+    wrapper.vm.addControl(
+      checkboxConfig.control,
+      checkboxConfig.rendererComponent,
+      checkboxConfig.rendererBinding,
+      checkboxConfig.builderComponent,
+      checkboxConfig.builderBinding,
+      checkboxConfig.inspector
+    );
+
+    checkboxConfig.control.inspector.forEach(item => {
+      expect(item.field.dataFormat).toBeUndefined();
+    });
   });
 
   it('should not contain datatype select drop down ', function() {


### PR DESCRIPTION
The purpose of this pull request is to remove the datatype down from the inspector.

**Acceptance Criteria.**
The text area inspector should not contain the datatype select.

<img width="1678" alt="Screen Shot 2019-11-25 at 2 31 28 PM" src="https://user-images.githubusercontent.com/26545455/69571695-a4a1dd00-0f90-11ea-9cd8-94db39d7dc67.png">

Fixes #438 