### PR TITLE
Imported screen with Select List control freezes when editing the SelectList

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -341,7 +341,7 @@ export default {
     },
     dataObjectOptions() {
       if (!this.dataName) {
-        this.dataName = this.options.dataName;
+        this.dataName = this.options.dataName ? this.options.dataName : "response";
       }
       return {
         dataSource: this.dataSource,


### PR DESCRIPTION
Resolves #482 

A default value is used if the component doesn't have a dataName option configured