### PR TITLE
Select List - Error generated when using "Edit as JSON" 

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -204,6 +204,8 @@
 import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
+require('monaco-editor/esm/vs/editor/editor.main');
+
 
 export default {
   components: {


### PR DESCRIPTION
Resolves #489 

In commit 65b64c132c3e250badbce1789b843c2c05057172 the importing of Monaco editor was deleted. This line has been restored and no more errors are generated and the Monaco editor correctly formats JSON strings

 
![Peek 2020-01-06 09-57](https://user-images.githubusercontent.com/14875032/71822372-12025c80-306b-11ea-8de7-9c26c3b215d0.gif)



