### PR TITLE
FormInput: Add Password option to the Data Type dropdown

### DIFF
--- a/src/VariableDataTypeProperties.js
+++ b/src/VariableDataTypeProperties.js
@@ -3,13 +3,14 @@ import SelectDataTypeMask from './components/inspector/select-data-type-mask';
 const string = { value: 'string', content: 'Text' };
 const int = { value: 'int', content: 'Integer' };
 const currency = { value: 'currency', content: 'Currency' };
+const password = { value: 'password', content: 'Password' };
 const percentage = { value: 'percentage', content: 'Percentage' };
 const float = { value: 'float', content: 'Decimal' };
 const datetime = { value: 'datetime', content: 'Datetime' };
 const date = { value: 'date', content: 'Date' };
 const boolean = { value: 'boolean', content: 'Boolean' };
 
-const allOptions = [string, int, currency, percentage, float, datetime, date];
+const allOptions = [string, int, currency, percentage, float, datetime, date, password];
 const allOptionsWithoutDate = [string, int, float];
 
 function dataTypeFactory(options) {

--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -19,7 +19,7 @@
       :name="name"
       class="form-control"
       :class="classList"
-      type="text"
+      :type="dataType"
       :maxlength="maxlength"
     >
     <template v-if="validator && validator.errorCount">
@@ -137,6 +137,13 @@ export default {
         'is-invalid': (this.validator && this.validator.errorCount) || this.error,
         [this.controlClass]: !!this.controlClass,
       };
+    },
+    dataType() {
+      if (this.dataFormat === 'password') {
+        return 'password';
+      }
+
+      return 'text';
     },
   },
   watch: {

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -85,24 +85,6 @@ export default [
         DataTypeProperty,
         DataFormatProperty,
         labelProperty,
-        {
-          type: 'FormMultiselect',
-          field: 'type',
-          config: {
-            label: 'Type',
-            name: 'Type',
-            helper: 'The type for this field',
-            options: [{
-              value: 'text',
-              content: 'Text',
-            },
-            {
-              value: 'password',
-              content: 'Password',
-            },
-            ],
-          },
-        },
         validationRulesProperty,
         placeholderProperty,
         helperTextProperty,


### PR DESCRIPTION
<h2>Changes</h2>

- Remove the 'Type' dropdown under the Input Configurations.
- Add the 'Password' option to the 'Data Type' dropdown.

![Screen Shot 2020-01-13 at 1 54 37 PM](https://user-images.githubusercontent.com/52755494/72295743-01bf2400-360d-11ea-9a5f-acee3833368d.png)
![Screen Shot 2020-01-13 at 1 54 16 PM](https://user-images.githubusercontent.com/52755494/72295752-071c6e80-360d-11ea-942d-08407113d36f.png)


<h2>To Test</h2>

- Add a FormInput and change the Data Type to Password.
- Render the form.

**Expected Behavior**
Input is masked. 

![Screen Shot 2020-01-13 at 1 55 02 PM](https://user-images.githubusercontent.com/52755494/72295762-0a175f00-360d-11ea-8dd3-b02247f94cf1.png)

closes #496 
