### PR TITLE
Only update old validation if the key already existed

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -441,8 +441,8 @@ export default {
       items.forEach(item => {
         if (item.inspector) {
           item.inspector.forEach((inspector) => {
-            if (inspector.field === 'name') {
-              inspector.config = keyNameProperty.config;
+            if (inspector.field === 'name' && 'validation' in inspector.config) {
+              inspector.config.validation = keyNameProperty.config.validation;
             }
           });
         }


### PR DESCRIPTION
Fixes #512 

Fix for supporting old screens was adding validation to key name on all elements, even the ones that shouldn't have them (submit button, image)