### PR TITLE
Determine number of times to loop from existing data

### DIFF
--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -1,15 +1,17 @@
 <template>
   <div class="form-group">
     <div v-for="loopIndex in times" :key="loopIndex">
-      <vue-form-renderer
-        @submit="submit"
-        :data="getMatrixValue(loopIndex)"
-        @update="setMatrixValue(loopIndex, $event)"
-        :config="rendererConfig"
-        :computed="null"
-        :custom-css="null"
-        :watchers="null"
+      <form>
+        <vue-form-renderer
+          @submit="submit"
+          :data="getMatrixValue(loopIndex)"
+          @update="setMatrixValue(loopIndex, $event)"
+          :config="rendererConfig"
+          :computed="null"
+          :custom-css="null"
+          :watchers="null"
         />
+      </form>
     </div>
   </div>
 </template>

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -36,6 +36,12 @@ export default {
       }];
     },
     times() {
+      // If there is existing data, set the length to what ever it is
+      const itemsFromData = _.get(this.transientData, this.name, null);
+      if (Array.isArray(itemsFromData)) {
+        return [...itemsFromData.keys()];
+      }
+
       if (!this.config) {
         return [];
       }

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -371,8 +371,8 @@ export default [
           type: 'FormInput',
           field: 'times',
           config: {
-            label: 'Number of times',
-            helper: 'Enter the number of times to repeat the element(s)',
+            label: 'Default Number Of Times',
+            helper: 'Enter the number of times to repeat if the data does not exist.',
           },
         },
       ],


### PR DESCRIPTION
Fixes #534 

- If data is present for a loop control, use its length as the number of loops to render. If not, use the value set in the inspector.
- Wrap each loop iteration in a `form` tag to isolate radio buttons. They have the same name attribute so the browser will otherwise treat them as the same input value.