### PR TITLE
Watcher UI overhaul

### DIFF
--- a/src/components/basic-search.vue
+++ b/src/components/basic-search.vue
@@ -1,0 +1,93 @@
+<template>
+    <div class="basic-search">
+        <div class="d-flex">
+            <div class="flex-grow-1">
+                <div class="search-bar-basic d-flex w-100">
+                    <div class="search-bar-inputs flex-grow w-100">
+                        <input ref="search_input" type="text" class="search-bar-manual-input form-control" :placeholder="placeholder ? placeholder : $t('Search')" v-model="query" @keyup.enter="runSearch">
+                    </div>
+                    <div class="search-bar-actions d-flex flex-shrink">
+                        <b-btn class="btn-search-run" variant="primary" @click="runSearch" v-b-tooltip.hover :title="$t('Search')"><i class="fas fa-search"></i></b-btn>
+                    </div>
+                </div>
+            </div>
+            <div class="search-bar-buttons">
+              <slot name="buttons"></slot> 
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+
+export default {
+  props: {
+    placeholder: {
+      type: String
+    },
+    value: {
+      type: String
+    }
+  },
+  data() {
+    return {
+      query: '',
+    };
+  },
+  watch: {
+    query(value) {
+        this.$emit('input', value);
+    },
+  },
+  methods: {
+    runSearch(advanced) {
+      this.$emit('submit', this.query);
+    },
+    hasButtons() {
+      return !!this.$slots.buttons;
+    }
+  },
+  mounted() {
+    this.query = this.value;
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.basic-search {
+  width: 100%;
+  
+  .btn {
+    height: 40px;
+  }
+  
+  .search-bar-buttons > * {
+    margin-left: 8px;
+  }
+}
+
+.search-bar-basic {
+  .form-control,
+  .form-control:active,
+  .form-control:focus {
+    border-bottom-right-radius: 0;
+    border-right-width: 0;
+    border-top-right-radius: 0;
+    color: gray;
+    height: 40px;
+  }
+  
+  .btn:active,
+  .btn:focus {
+    box-shadow: none !important;
+    outline: 0 !important;
+  }
+  
+  .btn-search-run {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 2px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 2px;
+  }
+}
+</style>

--- a/src/components/inspector/data-mapping.vue
+++ b/src/components/inspector/data-mapping.vue
@@ -1,43 +1,43 @@
 <template>
   <div>
-    <div class="d-flex">
-      <label class="flex-grow-1">{{ $t('Form Data') }}</label>
+    <div class="d-flex mb-1">
+      <label class="flex-grow-1 m-0">{{ $t('Output Data Mapping') }}</label>
       <button
         type="button"
-        class="btn-special-assignment-action btn btn-secondary btn-sm"
+        class="btn-special-assignment-action btn btn-secondary btn-sm px-2"
         @click="addMapping"
       >+ {{ $t('Data') }}
       </button>
     </div>
-    <table class="table table-striped table-sm">
+    <table class="table table-striped table-sm border mb-1">
       <thead>
         <tr>
-          <th scope="col">{{ $t('key') }}</th>
-          <th scope="col">{{ $t('value') }}</th>
+          <th scope="col">{{ $t('Key') }}</th>
+          <th scope="col">{{ $t('Value') }}</th>
           <th scope="col">&nbsp;</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="(row,i) in dataMapping" :key="i">
-          <td>
+          <td class="p-1">
             <input
               v-model="row.key"
               name="key"
-              :placeholder="$t('new key')"
+              :placeholder="$t('New Key')"
               type="text"
               class="form-control form-control-sm"
             >
           </td>
-          <td>
+          <td class="p-1">
             <input
               v-model="row.value"
               name="value"
-              :placeholder="$t('value')"
+              :placeholder="$t('New Value')"
               type="text"
               class="form-control form-control-sm"
             >
           </td>
-          <td class="align-middle">
+          <td class="align-middle text-right p-1">
             <a href="javascript:void(0)" class="btn btn-sm btn-danger" @click="removeRowIndex(i)">
               <i class="fa fa-trash-alt" />
             </a>
@@ -45,6 +45,7 @@
         </tr>
       </tbody>
     </table>
+    <small class="form-text text-muted mb-3">Keys and values to map from the Data Connector into the output variable</small>
   </div>
 </template>
 

--- a/src/components/inspector/data-mapping.vue
+++ b/src/components/inspector/data-mapping.vue
@@ -1,12 +1,12 @@
 <template>
   <div>
     <div class="d-flex mb-1">
-      <label class="flex-grow-1 m-0">{{ $t('Output Data Mapping') }}</label>
+      <label class="flex-grow-1 m-0">{{ $t('Output Variable Property Mapping') }}</label>
       <button
         type="button"
         class="btn-special-assignment-action btn btn-secondary btn-sm px-2"
         @click="addMapping"
-      >+ {{ $t('Data') }}
+      >+ {{ $t('Property') }}
       </button>
     </div>
     <table class="table table-striped table-sm border mb-1">
@@ -45,7 +45,11 @@
         </tr>
       </tbody>
     </table>
-    <small class="form-text text-muted mb-3">{{ $t('Keys and values to map from the Data Connector into the output variable') }}</small>
+    <small class="form-text text-muted mb-3">
+      {{ $t('Properties to map from the Data Connector into the output variable') }}
+      <br>
+      {{ $t('(If empty, all data returned will be mapped to the output variable)') }}
+    </small>
   </div>
 </template>
 

--- a/src/components/inspector/data-mapping.vue
+++ b/src/components/inspector/data-mapping.vue
@@ -45,7 +45,7 @@
         </tr>
       </tbody>
     </table>
-    <small class="form-text text-muted mb-3">Keys and values to map from the Data Connector into the output variable</small>
+    <small class="form-text text-muted mb-3">{{ $t('Keys and values to map from the Data Connector into the output variable') }}</small>
   </div>
 </template>
 

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -100,7 +100,7 @@
                         <div>{{ $t('The Input Data field is required.') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
-                        <div>{{ $t('It must be a correct json format') }}</div>
+                        <div>{{ $t('This must be valid JSON') }}</div>
                       </div>
                     </div>
 
@@ -118,7 +118,7 @@
                         <div>{{ $t('The Script Configuration field is required.') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('script_configuration')" class="invalid-feedback d-block">
-                        <div>{{ $t('It must be a correct json format') }}</div>
+                        <div>{{ $t('This must be valid JSON') }}</div>
                       </div>
                     </div>
                   </div>
@@ -151,7 +151,7 @@
                         <div>{{ $t('The Input Data field is required.') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
-                        <div>{{ $t('It must be a correct json format') }}</div>
+                        <div>{{ $t('This must be valid JSON') }}</div>
                       </div>
                     </div>
 

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -4,7 +4,7 @@
     
     
     <div class="accordion" id="watcherAccordion">
-        <div class="card">
+        <div class="card card-overflow">
             <div class="card-header p-0">
                 <div class="mb-0">
                     <button class="p-3 btn btn-link d-flex w-100 text-capitalize text-reset justify-content-between" type="button" data-toggle="collapse" data-target="#watcherConfig">
@@ -417,6 +417,10 @@ export default {
 
 <style lang="scss" scoped>
   .accordion {
+    .card-overflow {
+      overflow: visible;
+    }
+    
     .card-body label {
       display: block;
     }

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -97,7 +97,7 @@
                       />
                       <small class="form-text text-muted">{{ $t('Data to pass to the script (valid JSON object, variables supported)') }}</small>
                       <div v-if="inputDataInvalid" class="invalid-feedback d-block">
-                        <div>{{ $t('The Input Data field is required.') }}</div>
+                        <div>{{ $t('The Input Data field is required') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
                         <div>{{ $t('This must be valid JSON') }}</div>
@@ -115,7 +115,7 @@
                       />
                       <small class="form-text text-muted">{{ $t('Configuration data for the script (valid JSON object, variables supported)') }}</small>
                       <div v-if="scriptConfigurationInvalid" class="invalid-feedback d-block">
-                        <div>{{ $t('The Script Configuration field is required.') }}</div>
+                        <div>{{ $t('The Script Configuration field is required') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('script_configuration')" class="invalid-feedback d-block">
                         <div>{{ $t('This must be valid JSON') }}</div>
@@ -148,7 +148,7 @@
                       />
                       <small class="form-text text-muted">{{ $t('Data to pass to the Data Connector (valid JSON object, variables supported)') }}</small>
                       <div v-if="inputDataInvalid" class="invalid-feedback d-block">
-                        <div>{{ $t('The Input Data field is required.') }}</div>
+                        <div>{{ $t('The Input Data field is required') }}</div>
                       </div>
                       <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
                         <div>{{ $t('This must be valid JSON') }}</div>

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -1,149 +1,194 @@
 <template>
-  <div class="form-group">
-    <form-input
-      ref="name"
-      v-model="config.name"
-      :label="$t('Watcher Name')"
-      :name="$t('Watcher Name')"
-      :validation="ruleWatcherName"
-    />
+  <div>
+    
+    
+    
+    <div class="accordion" id="watcherAccordion">
+        <div class="card">
+            <div class="card-header p-0">
+                <div class="mb-0">
+                    <button class="p-3 btn btn-link d-flex w-100 text-capitalize text-reset justify-content-between" type="button" data-toggle="collapse" data-target="#watcherConfig">
+                        <div><i class="fas fa-fw fa-cog"></i> Configuration</div>
+                        <div><i class="fas fa-angle-down arrow-open mr-2"></i> <i class="fas fa-angle-right arrow-closed mr-2"></i></div>  
+                    </button>
+                </div>
+            </div>
+            <div id="watcherConfig" class="collapse show" data-parent="#watcherAccordion">
+                <div class="card-body pt-3 px-3 pb-0">
+                  <form-input
+                    ref="name"
+                    v-model="config.name"
+                    :label="$t('Watcher Name')"
+                    :name="$t('Watcher Name')"
+                    :validation="ruleWatcherName"
+                    :helper="$t('A name to describe this Watcher')"
+                  />
 
-    <form-multi-select
-      :name="$t('Variable to Watch')"
-      :label="$t('Variable to Watch')"
-      :options="variables"
-      v-model="config.watching"
-      :placeholder="$t('None')"
-      :multiple="false"
-      :show-labels="false"
-      :internal-search="true"
-      :validation="ruleWatcherVariable"
-      @open="loadVariables"
-    />
-    <div v-if="!config.watching" class="invalid-feedback d-block">
-      <div>{{ $t('The Variable to Watch field is required') }}</div>
+                  <form-multi-select
+                    :name="$t('Variable to Watch')"
+                    :label="$t('Variable to Watch')"
+                    :options="variables"
+                    v-model="config.watching"
+                    :placeholder="$t('None')"
+                    :multiple="false"
+                    :show-labels="false"
+                    :internal-search="true"
+                    :validation="ruleWatcherVariable"
+                    :helper="$t('The variable to watch on this screen')"
+                    @open="loadVariables"
+                  />
+                  <div v-if="ruleWatcherVariable && !config.watching" class="mt-n2 mb-3 invalid-feedback d-block">
+                    <div>{{ $t('The Variable to Watch field is required') }}</div>
+                  </div>
+                  
+                  <form-checkbox
+                    :name="$t('Run Synchronously')"
+                    :label="$t('Run Synchronously')"
+                    v-model="config.synchronous"
+                    :toggle="true"
+                    :helper="$t('Wait for the Watcher to run before accepting more input')"
+                  />
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header p-0">
+                <div class="mb-0">
+                    <button class="p-3 btn btn-link collapsed d-flex w-100 text-capitalize text-reset justify-content-between" type="button" data-toggle="collapse" data-target="#watcherSource">
+                        <div><i class="fas fa-fw fa-file-upload"></i> Source</div>
+                        <div><i class="fas fa-angle-down arrow-open mr-2"></i> <i class="fas fa-angle-right arrow-closed mr-2"></i></div>  
+                    </button>
+                </div>
+            </div>
+            <div id="watcherSource" class="collapse" data-parent="#watcherAccordion">
+                <div class="card-body pt-3 px-3 pb-0">
+                  <form-multi-select
+                    :name="$t('Source')"
+                    :label="$t('Source')"
+                    :options="scripts"
+                    v-model="config.script"
+                    :placeholder="$t('None')"
+                    :multiple="false"
+                    :show-labels="false"
+                    :searchable="true"
+                    :internal-search="false"
+                    optionValue="id"
+                    optionContent="title"
+                    group-values="items"
+                    group-label="type"
+                    :validation="ruleWatcherScript"
+                    @open="loadSources"
+                    @search-change="loadSources"
+                    :helper="$t('The source to access when this Watcher runs')"
+                  />
+                  <div v-if="ruleWatcherScript && !config.script" class="invalid-feedback d-block mt-n2 mb-3">
+                    <div>{{ $t('The Source field is required') }}</div>
+                  </div>
+
+                  <div v-if="isScript">
+                    <div class="form-group">
+                      <label>{{ $t('Input Data') }}</label>
+                      <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
+                      <monaco-editor
+                        :options="monacoOptions"
+                        class="editor"
+                        v-model="config.input_data"
+                        language="json"
+                      />
+                      <small class="form-text text-muted">{{ $t('Data to pass to the script (valid JSON object, variables supported)') }}</small>
+                      <div v-if="inputDataInvalid" class="invalid-feedback d-block">
+                        <div>{{ $t('The Input Data field is required.') }}</div>
+                      </div>
+                      <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
+                        <div>{{ $t('It must be a correct json format') }}</div>
+                      </div>
+                    </div>
+
+                    <div class="form-group">
+                      <label>{{ $t('Script Configuration') }}</label>
+                      <div class="editor-border" :class="{'is-invalid':scriptConfigurationInvalid}"/>
+                      <monaco-editor
+                        :options="monacoOptions"
+                        class="editor"
+                        v-model="config.script_configuration"
+                        language="json"
+                      />
+                      <small class="form-text text-muted">{{ $t('Configuration data for the script (valid JSON object, variables supported)') }}</small>
+                      <div v-if="scriptConfigurationInvalid" class="invalid-feedback d-block">
+                        <div>{{ $t('The Script Configuration field is required.') }}</div>
+                      </div>
+                      <div v-if="!jsonIsValid('script_configuration')" class="invalid-feedback d-block">
+                        <div>{{ $t('It must be a correct json format') }}</div>
+                      </div>
+                    </div>
+                  </div>
+                  <div v-if="isDatasource">
+                    <form-multi-select
+                      :name="$t('Endpoint')"
+                      :label="$t('Endpoint')"
+                      :options="endpoints"
+                      v-model="endpoint"
+                      :placeholder="$t('Select an endpoint')"
+                      :multiple="false"
+                      :show-labels="false"
+                      :searchable="true"
+                      :internal-search="false"
+                      @search-change="loadEndpoints"
+                      @open="loadEndpoints"
+                      :helper="$t('The Data Connector endpoint to access when this Watcher runs')"
+                    />
+                    <div class="form-group">
+                      <label>{{ $t('Input Data') }}</label>
+                      <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
+                      <monaco-editor
+                        :options="monacoOptions"
+                        class="editor"
+                        v-model="config.input_data"
+                        language="json"
+                      />
+                      <small class="form-text text-muted">{{ $t('Data to pass to the Data Connector (valid JSON object, variables supported)') }}</small>
+                      <div v-if="inputDataInvalid" class="invalid-feedback d-block">
+                        <div>{{ $t('The Input Data field is required.') }}</div>
+                      </div>
+                      <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
+                        <div>{{ $t('It must be a correct json format') }}</div>
+                      </div>
+                    </div>
+
+
+                  </div>
+                </div>
+            </div>
+        </div>
+        <div class="card">
+            <div class="card-header p-0">
+                <div class="mb-0">
+                    <button class="p-3 btn btn-link collapsed d-flex w-100 text-capitalize text-reset justify-content-between" type="button" data-toggle="collapse" data-target="#watcherOutput">
+                        <div><i class="fas fa-fw fa-file-download"></i> Output</div>
+                        <div><i class="fas fa-angle-down arrow-open mr-2"></i> <i class="fas fa-angle-right arrow-closed mr-2"></i></div>  
+                    </button>
+                </div>
+            </div>
+            <div id="watcherOutput" class="collapse" data-parent="#watcherAccordion">
+                <div class="card-body pt-3 px-3 pb-0">
+                  <form-input
+                    ref="propOutputVariableName"
+                    v-model="config.output_variable"
+                    :label="$t('Output Variable')"
+                    :name="$t('Output Variable')"
+                    :helper="$t('The variable that will store the output of the Watcher')"
+                    :validation="ruleWatcherOutputVariable"
+                  />
+                  <data-mapping v-if="isDatasource" v-model="config.script_configuration" />
+                </div>                
+            </div>
+        </div>        
     </div>
 
-    <form-multi-select
-      :name="$t('Source')"
-      :label="$t('Source')"
-      :options="scripts"
-      v-model="config.script"
-      :placeholder="$t('None')"
-      :multiple="false"
-      :show-labels="false"
-      :searchable="true"
-      :internal-search="false"
-      optionValue="id"
-      optionContent="title"
-      group-values="items"
-      group-label="type"
-      :validation="ruleWatcherScript"
-      @open="loadSources"
-      @search-change="loadSources"
-    />
-    <div v-if="!config.script" class="invalid-feedback d-block">
-      <div>{{ $t('The Script field is required') }}</div>
-    </div>
-
-    <div v-if="isScript">
-      <div class="form-group" style='position: relative;'>
-        <label>{{ $t('Input Data') }}</label>
-        <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
-        <monaco-editor
-          :options="monacoOptions"
-          class="editor"
-          v-model="config.input_data"
-          language="json"
-        />
-        <small class="form-text text-muted">{{ $t('Valid JSON Object, Variables Supported') }}</small>
-        <div v-if="inputDataInvalid" class="invalid-feedback d-block">
-          <div>{{ $t('The Input Data field is required.') }}</div>
-        </div>
-        <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
-          <div>{{ $t('It must be a correct json format') }}</div>
-        </div>
-      </div>
-
-      <div class="form-group" style='position: relative;'>
-        <label>{{ $t('Script Configuration') }}</label>
-        <div class="editor-border" :class="{'is-invalid':scriptConfigurationInvalid}"/>
-        <monaco-editor
-          :options="monacoOptions"
-          class="editor"
-          v-model="config.script_configuration"
-          language="json"
-        />
-        <small class="form-text text-muted">{{ $t('Valid JSON Object, Variables Supported') }}</small>
-        <div v-if="scriptConfigurationInvalid" class="invalid-feedback d-block">
-          <div>{{ $t('The Script Configuration field is required.') }}</div>
-        </div>
-        <div v-if="!jsonIsValid('script_configuration')" class="invalid-feedback d-block">
-          <div>{{ $t('It must be a correct json format') }}</div>
-        </div>
-      </div>
-
-      <form-input
-        ref="propOutputVariableName"
-        v-model="config.output_variable"
-        :label="$t('Output Variable Name')"
-        :name="$t('Output Variable Name')"
-        :helper="$t('Name of Variable to store the output')"
-        :validation="ruleWatcherOutputVariable"
-      />
-    </div>
-    <div v-if="isDatasource">
-      <form-multi-select
-        :name="$t('Endpoint')"
-        :label="$t('Endpoint')"
-        :options="endpoints"
-        v-model="endpoint"
-        :placeholder="$t('Select an endpoint')"
-        :multiple="false"
-        :show-labels="false"
-        :searchable="true"
-        :internal-search="false"
-        @search-change="loadEndpoints"
-        @open="loadEndpoints"
-      />
-      <div class="form-group" style='position: relative;'>
-        <label>{{ $t('Input Data') }}</label>
-        <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
-        <monaco-editor
-          :options="monacoOptions"
-          class="editor"
-          v-model="config.input_data"
-          language="json"
-        />
-        <small class="form-text text-muted">{{ $t('Valid JSON Object, Variables Supported') }}</small>
-        <div v-if="inputDataInvalid" class="invalid-feedback d-block">
-          <div>{{ $t('The Input Data field is required.') }}</div>
-        </div>
-        <div v-if="!jsonIsValid('input_data')" class="invalid-feedback d-block">
-          <div>{{ $t('It must be a correct json format') }}</div>
-        </div>
-      </div>
-      <data-mapping v-model="config.script_configuration" />
-
-      <form-input
-        ref="propOutputVariableName"
-        v-model="config.output_variable"
-        :label="$t('Output Variable Name')"
-        :name="$t('Output Variable Name')"
-        :helper="$t('Name of Variable to store the output')"
-        :validation="ruleWatcherOutputVariable"
-      />
-    </div>
-
-    <form-checkbox
-      :name="$t('Run Synchronously')"
-      :label="$t('Run Synchronously')"
-      v-model="config.synchronous"
-    />
-    <div class="float-right mb-3">
+    <div class="d-flex justify-content-end mt-3">
       <button class="btn btn-outline-secondary" @click.stop="displayTableList">{{ $t('Cancel') }}</button>
       <button
-        class="btn btn-secondary ml-2"
+        class="btn btn-secondary ml-3"
         @click="validateDataAndSave"
       >
         {{ $t('Save') }}
@@ -225,7 +270,6 @@ export default {
       deep: true,
       immediate: true,
       handler(value) {
-        this.setValidations();
         if (!value.input_data) {
           value.input_data = '{}';
         }
@@ -251,11 +295,6 @@ export default {
           this.config.datasource_script_id = value.dataSourceScriptId;
         }
         return value;
-      },
-    },
-    'config.name': {
-      handler() {
-        this.setValidations();
       },
     },
   },
@@ -377,6 +416,24 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .accordion {
+    .card-body label {
+      display: block;
+    }
+    .arrow-open {
+      display:inline-block;
+    }
+    .arrow-closed {
+      display:none;
+    }
+    .collapsed .arrow-open {
+      display: none;
+    }
+    .collapsed .arrow-closed {
+      display: inline-block;
+    }
+  }
+
   .editor {
     height: 8.5em;
     z-index: 0;

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -88,13 +88,14 @@
                   <div v-if="isScript">
                     <div class="form-group">
                       <label>{{ $t('Input Data') }}</label>
-                      <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
-                      <monaco-editor
-                        :options="monacoOptions"
-                        class="editor"
-                        v-model="config.input_data"
-                        language="json"
-                      />
+                      <div class="form-border" :class="{'is-invalid': !jsonIsValid('input_data')}">
+                        <monaco-editor
+                          :options="monacoOptions"
+                          class="editor"
+                          v-model="config.input_data"
+                          language="json"
+                        />
+                      </div>
                       <small class="form-text text-muted">{{ $t('Data to pass to the script (valid JSON object, variables supported)') }}</small>
                       <div v-if="inputDataInvalid" class="invalid-feedback d-block">
                         <div>{{ $t('The Input Data field is required') }}</div>
@@ -106,13 +107,14 @@
 
                     <div class="form-group">
                       <label>{{ $t('Script Configuration') }}</label>
-                      <div class="editor-border" :class="{'is-invalid':scriptConfigurationInvalid}"/>
-                      <monaco-editor
-                        :options="monacoOptions"
-                        class="editor"
-                        v-model="config.script_configuration"
-                        language="json"
-                      />
+                      <div class="form-border" :class="{'is-invalid': !jsonIsValid('script_configuration')}">
+                        <monaco-editor
+                          :options="monacoOptions"
+                          class="editor"
+                          v-model="config.script_configuration"
+                          language="json"
+                        />
+                      </div>
                       <small class="form-text text-muted">{{ $t('Configuration data for the script (valid JSON object, variables supported)') }}</small>
                       <div v-if="scriptConfigurationInvalid" class="invalid-feedback d-block">
                         <div>{{ $t('The Script Configuration field is required') }}</div>
@@ -139,13 +141,14 @@
                     />
                     <div class="form-group">
                       <label>{{ $t('Input Data') }}</label>
-                      <div class="editor-border" :class="{'is-invalid':inputDataInvalid}"/>
-                      <monaco-editor
-                        :options="monacoOptions"
-                        class="editor"
-                        v-model="config.input_data"
-                        language="json"
-                      />
+                      <div class="form-border" :class="{'is-invalid': !jsonIsValid('input_data')}">
+                        <monaco-editor
+                          :options="monacoOptions"
+                          class="editor"
+                          v-model="config.input_data"
+                          language="json"
+                        />
+                      </div>
                       <small class="form-text text-muted">{{ $t('Data to pass to the Data Connector (valid JSON object, variables supported)') }}</small>
                       <div v-if="inputDataInvalid" class="invalid-feedback d-block">
                         <div>{{ $t('The Input Data field is required') }}</div>
@@ -375,6 +378,7 @@ export default {
     },
     jsonIsValid(item) {
       try {
+        console.log('jsonIsValid', item);
         JSON.parse(this.config[item]);
       } catch (e) {
         return false;
@@ -443,18 +447,13 @@ export default {
     z-index: 0;
   }
 
-  .editor-border {
-    border: 1px solid #ced4da;
-    border-radius: 4px;
+  .form-border {
     overflow: hidden;
-    height: 8.5em;
-    position: absolute;
-    pointer-events: none;
+    position: relative;
     width: 100%;
-    z-index: 1;
   }
 
-  .editor-border.is-invalid {
+  .form-border.is-invalid {
     border-color: #dc3545;
   }
 </style>

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -25,8 +25,8 @@
     </div>
 
     <form-multi-select
-      :name="$t('Script Source')"
-      :label="$t('Script Source')"
+      :name="$t('Source')"
+      :label="$t('Source')"
       :options="scripts"
       v-model="config.script"
       :placeholder="$t('None')"

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -1,66 +1,51 @@
 <template>
   <div>
-    <b-row class="mb-2">
-      <b-col class="d-flex">
-        <input class="form-control mr-2 flex-grow-1" v-model="filter" :placeholder="$t('Filter')">
-        <b-btn class="mr-2" size="sm" variant="primary" @click.stop="search" style="width:6em;">
-          <i class="fas fa-search" />
-        </b-btn>
-        <b-btn class="text-nowrap" size="sm" variant="secondary" @click.stop="displayFormProperty">
-          <i class="fas fa-plus" />
-          {{ $t('Watcher') }}
-        </b-btn>
+    <b-row class="mb-3">
+      <b-col>
+        <basic-search v-model="filter" @submit="search">
+          <template slot="buttons">
+            <b-btn class="text-nowrap" variant="secondary" @click.stop="displayFormProperty">
+              <i class="fas fa-plus" />
+              {{ $t('Watcher') }}
+            </b-btn>
+          </template>
+        </basic-search>
       </b-col>
     </b-row>
 
-    <b-table :items="filtered" :fields="fields" responsive striped bordered small hover fixed>
-      <template slot="HEAD_property" slot-scope="data">{{ $t(data.label) }}</template>
-      <template slot="HEAD_actions" slot-scope="data">{{ $t(data.label) }}</template>
-
-      <template v-slot:cell(actions)="row">
-        <!-- we use @click.stop here to prevent emitting of a 'row-clicked' event  -->
-        <a
-          size="lg"
-          variant="action"
-          :title="$t('edit')"
-          class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
-          @click.stop="editProperty(row.item)"
-        >
-          <i class="fa fa-edit fa-1x" />
-        </a>
-        <a
-          size="lg"
-          variant="action"
-          :title="$t('Delete')"
-          class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
-          @click.stop="deleteProperty(row.item)"
-        >
-          <i class="fa fa-trash fa-1x" />
-        </a>
-      </template>
-      <!-- Keeps compatibility with the bootstrap-vue version in ProcessMaker -->
-      <template slot="actions" slot-scope="row">
-        <!-- we use @click.stop here to prevent emitting of a 'row-clicked' event  -->
-        <a
-          size="lg"
-          variant="action"
-          :title="$t('edit')"
-          class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
-          @click.stop="editProperty(row.item)"
-        >
-          <i class="fa fa-edit fa-1x" />
-        </a>
-        <a
-          size="lg"
-          variant="action"
-          :title="$t('Delete')"
-          class="btn btn-lg p-0 mr-2 border-0 bg-transparent"
-          @click.stop="deleteProperty(row.item)"
-        >
-          <i class="fa fa-trash fa-1x" />
-        </a>
-      </template>
-    </b-table>
+    <div class="card card-body table-card">
+      <vuetable
+        :api-mode="false"
+        :css="css"
+        :fields="fields"
+        :data="filtered"
+        data-path="data"
+        :noDataTemplate="$t('No Data Available')"
+      >
+        <template slot="actions" slot-scope="row">
+          <div class="actions">
+            <div class="popout">
+              <b-btn
+                variant="link"
+                @click="editProperty(row.rowData)"
+                v-b-tooltip.hover
+                :title="$t('Edit')"
+              >
+                <i class="fas fa-edit fa-lg fa-fw"/>
+              </b-btn>
+              <b-btn
+                variant="link"
+                @click="deleteProperty(row.rowData)"
+                v-b-tooltip.hover
+                :title="$t('Delete')"
+              >
+                <i class="fas fa-trash-alt fa-lg fa-fw"/>
+              </b-btn>
+            </div>
+          </div>
+        </template>
+      </vuetable>
+    </div>
     <template slot="modal-footer">
       <span />
     </template>
@@ -68,10 +53,13 @@
 </template>
 
 <script>
+import BasicSearch from './basic-search';
 import { FormInput, FormTextArea } from '@processmaker/vue-form-elements';
+import Vuetable from "vuetable-2/src/components/Vuetable";
 
 export default {
   components: {
+    BasicSearch,
     FormInput,
     FormTextArea,
   },
@@ -84,36 +72,37 @@ export default {
   data() {
     return {
       filter: '',
+      css: {
+        tableClass: 'table table-hover table-responsive text-break mb-0',
+        loadingClass: 'loading',
+        detailRowClass: 'vuetable-detail-row',
+        handleIcon: 'grey sidebar icon',
+        sortableIcon: 'fas fa-sort',
+        ascendingIcon: 'fas fa-sort-up',
+        descendingIcon: 'fas fa-sort-down',
+        ascendingClass: 'ascending',
+        descendingClass: 'descending',
+      },
       fields: [
         {
-          key: 'name',
-          label: this.$t('Name'),
-          class: 'text-center',
-          sortable: true,
+          title: () => this.$t('Name'),
+          name: 'name',
         },
         {
-          key: 'watching',
-          label: this.$t('Watching'),
-          class: 'text-center',
-          sortable: true,
+          title: () => this.$t('Watching Variable'),
+          name: 'watching',
         },
         {
-          key: 'output_variable',
-          label: this.$t('Variable'),
-          class: 'text-center',
-          sortable: true,
+          title: () => this.$t('Output Variable'),
+          name: 'output_variable',
         },
         {
-          key: 'script.title',
-          label: this.$t('Script'),
-          class: 'text-center',
-          sortable: true,
+          title: () => this.$t('Source'),
+          name: 'script.title',
         },
         {
-          key: 'actions',
-          label: '',
-          class: 'text-center',
-          sortable: false,
+          name: '__slot:actions',
+          title: '',
         },
       ],
     };

--- a/src/components/watchers-popup.vue
+++ b/src/components/watchers-popup.vue
@@ -94,7 +94,7 @@ export default {
       if (globalObject.ProcessMaker && globalObject.ProcessMaker.confirmModal) {
         globalObject.ProcessMaker.confirmModal(
           this.$t("Caution!"),
-          this.$t("Are you sure you want to delete the watcher?"),
+          this.$t("Are you sure you want to delete the Watcher?"),
           '',
           () => {
             this.remove(item);

--- a/src/components/watchers-popup.vue
+++ b/src/components/watchers-popup.vue
@@ -9,7 +9,7 @@
     no-close-on-backdrop
   >
     <template v-if="enableList">
-      <watchers-list v-model="current" @display-form="displayForm" @edit-form="edit" @delete-form="remove"/>
+      <watchers-list v-model="current" @display-form="displayForm" @edit-form="edit" @delete-form="confirmRemoval"/>
     </template>
     <template v-else>
       <watchers-form refs="form" :config="add" @display-list="displayList" @save-form="save"/>
@@ -89,6 +89,20 @@ export default {
     edit(item) {
       this.displayForm();
       this.$set(this, 'add', item);
+    },
+    confirmRemoval(item) {
+      if (globalObject.ProcessMaker && globalObject.ProcessMaker.confirmModal) {
+        globalObject.ProcessMaker.confirmModal(
+          this.$t("Caution!"),
+          this.$t("Are you sure you want to delete the watcher?"),
+          '',
+          () => {
+            this.remove(item);
+          }
+        );
+      } else {
+        this.remove(item);
+      }
     },
     remove(item) {
       this.current = this.current.filter(val => {


### PR DESCRIPTION
## Changes
- Standardizes the Watchers list using our standard table component and search bar
- Converts the Watcher form into an accordion to better organize the information
- Improves text labels based on feedback from stakeholders
- Adds helper text to all form fields
- Confirms prior to deleting a Watcher

## Requirements
- Requires https://github.com/ProcessMaker/processmaker/pull/2841 in core

## Before

![Screen Shot 2020-02-06 at 11 11 47 AM](https://user-images.githubusercontent.com/867714/73970480-191ec380-48d2-11ea-807e-c932a30b6578.png)

![Screen Shot 2020-02-06 at 11 14 18 AM](https://user-images.githubusercontent.com/867714/73970526-2b006680-48d2-11ea-8f79-b00d1d3b3dd3.png)

## After

![Screen Shot 2020-02-06 at 11 11 18 AM](https://user-images.githubusercontent.com/867714/73970491-20de6800-48d2-11ea-8b19-2374b39a4e6f.png)

![Screen Shot 2020-02-06 at 11 12 28 AM](https://user-images.githubusercontent.com/867714/73970535-305db100-48d2-11ea-9014-9667d502c9ba.png)

![Screen Shot 2020-02-06 at 11 12 39 AM](https://user-images.githubusercontent.com/867714/73970542-33f13800-48d2-11ea-91bf-ebce79057f8a.png)

![Screen Shot 2020-02-06 at 11 12 57 AM](https://user-images.githubusercontent.com/867714/73970549-3784bf00-48d2-11ea-9eb4-d0cfcdf0b755.png)

Closes #533.