### PR TITLE
Add custom css selector names to additional components

### DIFF
--- a/src/components/editor/loop.vue
+++ b/src/components/editor/loop.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column-draggable">
+  <div class="column-draggable" :selector="config.customCssSelector">
     <draggable
       style="min-height: 80px;"
       v-model="items"

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="classContainer" class="mb-1 mt-1 pb-0 pt-0">
-    <div>
+    <div :selector="config.customCssSelector">
       <div class="row">
         <template v-for="(item, index) in items">
           <draggable :class="classColumn(index)"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -88,7 +88,7 @@
       </div>
 
       <draggable
-        class="h-100"
+        class="h-100 custom-css-scope"
         ghost-class="form-control-ghost"
         :value="config[currentPage].items"
         @input="updateConfig"
@@ -103,6 +103,7 @@
           v-for="(element,index) in config[currentPage].items"
           :key="index"
           @click="inspect(element)"
+          :selector="element.config.customCssSelector"
         >
           <div v-if="element.container" @click="inspect(element)" class="card" data-cy="screen-element-container">
             <div

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -4,6 +4,7 @@
       <div
         v-for="(element, index) in visibleElements"
         :key="index"
+        :selector="element.config.customCssSelector"
       >
         <component
           v-if="element.container"


### PR DESCRIPTION
Fixes #572 

There were a number of container elements missing the custom selector name. This PR adds them.

It also adds the css wrapper class to the builder so CSS changes can be seen in real time in the editor, not just the preview.