### PR TITLE
Remove scope variable from Nested Screen

### DIFF
--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -37,7 +37,16 @@ export default {
     },
     data: {
       get() {
-        return !this.validationData || this.name ? this.localData : this.validationData;
+        const data = !this.validationData || this.name ? this.localData : this.validationData;
+        // Add magic _ variables to nested screens
+        if (this.validationData && this.name) {
+          Object.keys(this.validationData).forEach(key => {
+            if (key.substr(0, 1) === '_') {
+              data[key] = this.validationData[key];
+            }
+          });
+        }
+        return data;
       },
       set(data) {
         if (this.name) {

--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -20,7 +20,7 @@ const defaultConfig = [
   },
 ];
 export default {
-  props: ['name', 'screen', 'value', 'validationData'],
+  props: ['screen', 'value', 'validationData'],
   data() {
     return {
       api: 'screens',
@@ -37,25 +37,12 @@ export default {
     },
     data: {
       get() {
-        const data = !this.validationData || this.name ? this.localData : this.validationData;
-        // Add magic _ variables to nested screens
-        if (this.validationData && this.name) {
-          Object.keys(this.validationData).forEach(key => {
-            if (key.substr(0, 1) === '_') {
-              data[key] = this.validationData[key];
-            }
-          });
-        }
-        return data;
+        return this.validationData || this.localData;
       },
       set(data) {
-        if (this.name) {
-          this.$emit('input', data);
-        } else {
-          Object.keys(data).forEach((variable) => {
-            this.$set(this.validationData, variable, data[variable]);
-          });
-        }
+        Object.keys(data).forEach((variable) => {
+          this.$set(this.validationData, variable, data[variable]);
+        });
       },
     },
     placeholder() {
@@ -85,18 +72,9 @@ export default {
     screen(screen) {
       this.loadScreen(screen);
     },
-    value: {
-      deep: true,
-      handler() {
-        if (this.name) {
-          this.$set(this, 'localData', this.value || {});
-        }
-      },
-    },
   },
   mounted() {
     this.loadScreen(this.screen);
-    this.name ? this.$set(this, 'localData', this.value || {}) : null;
   },
 };
 </script>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -453,6 +453,7 @@ export default {
       config.forEach(page => this.replaceFormText(page.items));
       config.forEach(page => this.migrateFormSubmit(page.items));
       config.forEach(page => this.updateFieldNameValidation(page.items));
+      config.forEach(page => this.removeDataVariableFromNestedScreens(page.items));
     },
     updateFieldNameValidation(items) {
       items.forEach(item => {
@@ -467,6 +468,17 @@ export default {
           this.replaceFormText(item.items);
         }
       });
+    },
+    removeDataVariableFromNestedScreens(items) {
+      items.forEach(item => {
+        if (item.inspector) {
+          const hasDataVariable = item.inspector.find(inspector => inspector.config.name === 'DataVariable');
+          item.inspector = item.inspector.filter(inspector => inspector.config.name !== 'DataVariable');
+          if (hasDataVariable) {
+            delete item.config.name;
+          }
+        }
+      });      
     },
     replaceFormText(items) {
       items.forEach(item => {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -673,7 +673,9 @@ export default {
       }
 
       //Generate Variable Name
-      [this.variables, copy.config.name] = this.generator.generate(this.config, copy['editor-control'] ? copy['editor-control'] :  copy['component']);
+      if (control.inspector.indexOf(keyNameProperty) !== -1) {
+        [this.variables, copy.config.name] = this.generator.generate(this.config, copy['editor-control'] ? copy['editor-control'] :  copy['component']);
+      }
 
       return copy;
     },

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -565,16 +565,6 @@ export default [
       },
       inspector: [
         {
-          type: 'FormInput',
-          field: 'name',
-          config: {
-            label: 'Data variable',
-            name: 'DataVariable',
-            validation: 'regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/',
-            helper: 'A variable name is a symbolic name to reference information.',
-          },
-        },
-        {
           type: 'ScreenSelector',
           field: 'screen',
           config: {


### PR DESCRIPTION
Resolves #562 
Resolves #561 

The scope variable was removed from nested screen to make easier the user work with variables in nested screens.

Example using tabs and share information between nested and parent screen

![NavigationAndNestdScreens](https://user-images.githubusercontent.com/8028650/75464162-2b35d400-595d-11ea-9e9b-446fc273d4ab.gif)


Screens:
Main: 
[Company.json.txt](https://github.com/ProcessMaker/screen-builder/files/4262714/Company.json.txt)
Nested:
[Company details.json.txt](https://github.com/ProcessMaker/screen-builder/files/4262717/Company.details.json.txt)

