### PR TITLE
Fix infinite loop with nested screens

### DIFF
--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -1,9 +1,11 @@
 <template>
   <vue-form-renderer
+    v-if="!ancestorScreens.includes(screenTitle)"
     class="form-nested-screen"
     :placeholder="placeholder"
     v-model="data"
     :config="validatedConfig"
+    :ancestor-screens="[...ancestorScreens, screenTitle]"
     mode="preview"
     :computed="computed"
     :custom-css="customCSS"
@@ -13,14 +15,25 @@
 </template>
 
 <script>
+const globalObject = typeof window === 'undefined'
+  ? global
+  : window;
+
 const defaultConfig = [
   {
     name: 'empty',
     items: [],
   },
 ];
+
 export default {
-  props: ['name', 'screen', 'value', 'validationData'],
+  props: {
+    name: String,
+    screen: Number,
+    value: null,
+    validationData: null,
+    ancestorScreens: {type: Array, default: () => []},
+  },
   data() {
     return {
       api: 'screens',
@@ -29,6 +42,7 @@ export default {
       computed: [],
       customCSS: null,
       watchers: [],
+      screenTitle: null,
     };
   },
   computed: {
@@ -63,12 +77,18 @@ export default {
             this.computed = response.data.computed;
             this.customCSS = response.data.custom_css;
             this.watchers = response.data.watchers;
+            this.screenTitle = response.data.title;
+
+            if (this.ancestorScreens.includes(this.screenTitle)) {
+              globalObject.ProcessMaker.alert(`Rendering of nested "${this.screenTitle}" screen was disallowed to prevent loop.`, 'warning');
+            }
           });
       } else {
         this.config = defaultConfig;
         this.computed = [];
         this.customCSS = null;
         this.watchers = [];
+        this.screenTitle = null;
       }
     },
   },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -14,6 +14,7 @@
           v-model="element.items"
           @submit="submit"
           :config="element.config"
+          :ancestor-screens="ancestorScreens"
           :name="element.config.name !== undefined ? element.config.name : null"
           @pageNavigate="pageNavigate"
           v-bind="element.config"
@@ -28,6 +29,7 @@
               :validationData="transientData"
               v-model="model[getValidPath(element.config.name)]"
               @submit="submit"
+              :ancestor-screens="ancestorScreens"
               @pageNavigate="pageNavigate"
               :name="element.config.name !== undefined ? element.config.name : null"
               v-bind="element.config"
@@ -47,7 +49,7 @@
 import Vue from 'vue';
 import * as VueDeepSet from 'vue-deepset';
 import _ from 'lodash';
-import { getValidPath, HasColorProperty, shouldElementBeVisible, formWatchers } from '@/mixins';
+import { formWatchers, getValidPath, HasColorProperty, shouldElementBeVisible } from '@/mixins';
 import * as editor from './editor';
 import * as renderer from './renderer';
 import * as inspector from './inspector';
@@ -69,7 +71,7 @@ import WatchersSynchronous from '@/components/watchers-synchronous';
 import { ValidatorFactory } from '../factories/ValidatorFactory';
 import currencies from '../currency.json';
 import Inputmask from 'inputmask';
-import Mustache from 'mustache'
+import Mustache from 'mustache';
 
 const csstree = require('css-tree');
 
@@ -83,7 +85,7 @@ Vue.use(VueDeepSet);
 
 export default {
   name: 'VueFormRenderer',
-  props: ['config', 'data', 'page', 'computed', 'customCss', 'mode', 'watchers'],
+  props: ['config', 'data', 'page', 'computed', 'customCss', 'mode', 'watchers', 'ancestorScreens'],
   model: {
     prop: 'data',
     event: 'update',


### PR DESCRIPTION
Fixes #566.

<img width="1166" alt="Screen Shot 2020-02-26 at 3 41 09 PM" src="https://user-images.githubusercontent.com/7561061/75386651-0f282900-58b0-11ea-9f5a-055d000f3cf7.png">

The `form-nested-screen` component keeps track of the titles of the screens that were rendered and passes that array down to its child `vue-form-renderer` components. When a nested screen appears for the 2nd time, rendering of that screen is prevented and a warning is displayed.