### PR TITLE
Fix Data Connector & Scripts per page limit in the Watcher 'Source' select

### DIFF
--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -1,8 +1,5 @@
 <template>
   <div>
-    
-    
-    
     <div class="accordion" id="watcherAccordion">
         <div class="card card-overflow">
             <div class="card-header p-0">
@@ -71,14 +68,12 @@
                     :multiple="false"
                     :show-labels="false"
                     :searchable="true"
-                    :internal-search="false"
                     optionValue="id"
                     optionContent="title"
                     group-values="items"
                     group-label="type"
                     :validation="ruleWatcherScript"
                     @open="loadSources"
-                    @search-change="loadSources"
                     :helper="$t('The source to access when this Watcher runs')"
                   />
                   <div v-if="ruleWatcherScript && !config.script" class="invalid-feedback d-block mt-n2 mb-3">
@@ -365,12 +360,11 @@ export default {
         }
       });
     },
-    loadSources(filter) {
+    loadSources() {
       this.scripts =  [];
-
       //call load data
       this.$root.$children[0].watchers_config.api.scripts.forEach( callback => {
-        callback(this.scripts, filter);
+        callback(this.scripts);
       });
     },
     displayTableList() {


### PR DESCRIPTION
<h2>Changes</h2>

Remove the 'filters' parameter from the 'Source' select when calling the GET method on the 'Data Connector' & 'Script' API.

<a href="https://www.loom.com/share/14bddb0e188b4f379599ac4802d29142"> <p>27 February, 2020 - Loom Recording - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/14bddb0e188b4f379599ac4802d29142-with-play.gif"> </a>

<h2>To Test</h2>

- Use the [ProcessMaker/#2907](https://github.com/ProcessMaker/processmaker/pull/2907) branch

- Install the Data Source package

- Create 11+ Data Connectors and or Scripts

- Create a new screen

- Add a new watcher select the 'Source' tab.

- Select the 'Source' select list. 

**Expected Result**
All configured  Data Connectors and or Scripts should be displayed. 

**Dependency**
[ProcessMaker/#2907](https://github.com/ProcessMaker/processmaker/pull/2907)

Closes #591 

