### PR TITLE
Fix validation when adding and editing watchers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -165,6 +165,7 @@
 </template>
 
 <script>
+require("bootstrap");
 import ComputedProperties from './components/computed-properties.vue';
 import WatchersPopup from './components/watchers-popup.vue';
 import CustomCSS from './components/custom-css.vue';
@@ -193,6 +194,25 @@ Validator.register('attr-value', value => {
   return value.match(/^[a-zA-Z0-9-_]+$/);
 }, 'Must be letters, numbers, underscores or dashes');
 
+const exampleScriptsForWatchers = [
+  (items, filter) => {
+    items.push({
+      type: "Test Data Sources",
+      items: [{
+        id: 'data_source-1',
+        title: 'Test Data Source'
+      }]
+    })
+    items.push({
+      type: "Test Script",
+      items: [{
+        id: 'script-1',
+        title: 'Test Script'
+      }]
+    })
+  }
+];
+
 export default {
   name: 'app',
   mixins: [canOpenJsonFile],
@@ -203,7 +223,7 @@ export default {
       },
       watchers_config: {
         api: {
-          scripts: [],
+          scripts: exampleScriptsForWatchers,
           execute: null,
         },
       },
@@ -326,13 +346,19 @@ export default {
   methods: {
     loadFromLocalStorage() {
       const savedConfig = localStorage.getItem('savedConfig');
+      const savedWatchers = localStorage.getItem('savedWatchers');
       if (savedConfig) {
         let config = JSON.parse(savedConfig);
         this.$refs.builder.config = config;
       }
+      if (savedWatchers) {
+        let watcherConfig = JSON.parse(savedWatchers);
+        this.watchers = watcherConfig;
+      }
     },
     saveToLocalStorage() {
       localStorage.setItem('savedConfig', JSON.stringify(this.config));
+      localStorage.setItem('savedWatchers', JSON.stringify(this.watchers));
     },
     editorDidMount(editor) {
       editor.getAction('editor.action.formatDocument').run();

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -125,20 +125,25 @@
                     </div>
                   </div>
                   <div v-if="isDatasource">
-                    <form-multi-select
-                      :name="$t('Endpoint')"
-                      :label="$t('Endpoint')"
-                      :options="endpoints"
-                      v-model="endpoint"
-                      :placeholder="$t('Select an endpoint')"
-                      :multiple="false"
-                      :show-labels="false"
-                      :searchable="true"
-                      :internal-search="false"
-                      @search-change="loadEndpoints"
-                      @open="loadEndpoints"
-                      :helper="$t('The Data Connector endpoint to access when this Watcher runs')"
-                    />
+                    <div class="form-group">
+                      <form-multi-select
+                        :name="$t('Endpoint')"
+                        :label="$t('Endpoint')"
+                        :options="endpoints"
+                        v-model="endpoint"
+                        :placeholder="$t('Select an endpoint')"
+                        :multiple="false"
+                        :show-labels="false"
+                        :searchable="true"
+                        :internal-search="false"
+                        @search-change="loadEndpoints"
+                        @open="loadEndpoints"
+                        :helper="$t('The Data Connector endpoint to access when this Watcher runs')"
+                      />
+                      <div v-if="endpointError" class="invalid-feedback d-block">
+                        <div>{{ endpointError }}</div>
+                      </div>
+                    </div>
                     <div class="form-group">
                       <label>{{ $t('Input Data') }}</label>
                       <div class="form-border" :class="{'is-invalid': !jsonIsValid('input_data')}">
@@ -263,6 +268,7 @@ export default {
         lineNumbers: 'on',
         minimap: { enabled: false },
       },
+      endpointError: null,
     };
   },
   watch: {
@@ -385,7 +391,13 @@ export default {
       return true;
     },
     isFormValid() {
-      this.setValidations();
+
+      if (this.isDatasource && !this.endpoint) {
+        this.endpointError = this.$t("Endpoint is required");
+      } else {
+        this.endpointError = null;
+      }
+
       for (let item in this.$refs) {
         if (this.$refs[item].name && this.$refs[item].validator && this.$refs[item].validator.errorCount !== 0) {
           return false;
@@ -394,22 +406,27 @@ export default {
 
       return !(!this.config.watching ||
         !this.config.script ||
+        this.endpointError ||
         !this.jsonIsValid('input_data') ||
         !this.jsonIsValid('script_configuration'));
     },
     validateDataAndSave() {
-      if (!this.isFormValid()) {
-        if (globalObject.ProcessMaker && globalObject.ProcessMaker.alert) {
-          globalObject.ProcessMaker.alert(this.$t('An error occurred. Check the form for errors in red text.'), 'danger');
+      this.setValidations();
+      this.$nextTick(() => { // allow validations to do their thing
+        
+        if (!this.isFormValid()) {
+          if (globalObject.ProcessMaker && globalObject.ProcessMaker.alert) {
+            globalObject.ProcessMaker.alert(this.$t('An error occurred. Check the form for errors in red text.'), 'danger');
+          }
+          return;
         }
-        return;
-      }
 
-      if (!this.config.uid) {
-        this.config.uid = _.uniqueId(new Date().getTime());
-      }
+        if (!this.config.uid) {
+          this.config.uid = _.uniqueId(new Date().getTime());
+        }
 
-      this.save();
+        this.save();
+      });
     },
     save() {
       this.$emit('save-form');

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -62,6 +62,7 @@ export default {
     BasicSearch,
     FormInput,
     FormTextArea,
+    Vuetable
   },
   props: {
     value: {

--- a/src/components/watchers-popup.vue
+++ b/src/components/watchers-popup.vue
@@ -88,7 +88,7 @@ export default {
     },
     edit(item) {
       this.displayForm();
-      this.$set(this, 'add', item);
+      this.$set(this, 'add', _.cloneDeep(item));
     },
     confirmRemoval(item) {
       if (globalObject.ProcessMaker && globalObject.ProcessMaker.confirmModal) {

--- a/src/main.js
+++ b/src/main.js
@@ -83,6 +83,14 @@ window.ProcessMaker = {
           resolve({data:{
             data: [exampleScreen],
           }});
+        } else if (url === '/data_sources/1') {
+          resolve({
+            data: {
+              endpoints: {
+                "list": { }
+              }
+            }
+          });
         }
       });
     },


### PR DESCRIPTION
Fixes #593 

Requires https://github.com/ProcessMaker/package-data-connectors/pull/54

- Service task was failing when no request id was present. See above PR link
- When using a data connector for a watcher, the endpoint was not required. If one was not selected, the service task would fail in the background. This PR adds validation.
- Also fixes the cancel button not reverting changes
- Also fixes validation not running when editing (was only validating on create)
- Also adds ability to do basic watcher development in the standalone app