### PR TITLE
Scope css inside nestead screens

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -330,9 +330,15 @@ export default {
         let config = JSON.parse(savedConfig);
         this.$refs.builder.config = config;
       }
+      
+      const customCSS = localStorage.getItem('customCSS');
+      if (customCSS) {
+        this.customCSS = customCSS;
+      }
     },
     saveToLocalStorage() {
       localStorage.setItem('savedConfig', JSON.stringify(this.config));
+      localStorage.setItem('customCSS', this.customCSS);
     },
     editorDidMount(editor) {
       editor.getAction('editor.action.formatDocument').run();

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="containerClass" class="nolantest">
+  <div :class="containerClass">
     <div class="page">
       <div
         v-for="(element, index) in visibleElements"

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -331,7 +331,7 @@ export default {
         .forEach(item => this.model[this.getValidPath(item.config.name)] = getDefaultValueForItem(item, this.transientData));
     },
     parseCss() {
-      let containerSelector = '.' + this.containerClass;
+      const containerSelector = '.' + this.containerClass;
       try {
         const ast = csstree.parse(this.customCss, {
           onParseError(error) {

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="custom-css-scope">
+  <div :class="containerClass" class="nolantest">
     <div class="page">
       <div
         v-for="(element, index) in visibleElements"
@@ -21,7 +21,7 @@
           :is="element.component"
         />
 
-        <div v-else :id="element.config.name ? element.config.name : undefined" :selector="element.config.customCssSelector">
+        <div v-else :id="element.config.name ? element.config.name : undefined">
           <keep-alive>
             <component
               :class="elementCssClass(element)"
@@ -113,6 +113,14 @@ export default {
     },
     visibleElements() {
       return this.config[this.currentPage].items.filter(this.shouldElementBeVisible);
+    },
+    containerClass() {
+      return this.parentScreen ? 'screen-' + this.parentScreen : 'custom-css-scope';
+    },
+    parentScreen() {
+      // if we are inside a nested screen, get the screen's id
+      const screen = _.get(this, '$parent.screen', null);
+      return typeof screen === 'number' ? screen : null;
     },
   },
   data() {
@@ -323,7 +331,7 @@ export default {
         .forEach(item => this.model[this.getValidPath(item.config.name)] = getDefaultValueForItem(item, this.transientData));
     },
     parseCss() {
-      const containerSelector = '.custom-css-scope';
+      let containerSelector = '.' + this.containerClass;
       try {
         const ast = csstree.parse(this.customCss, {
           onParseError(error) {

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -62,6 +62,7 @@ export default {
     BasicSearch,
     FormInput,
     FormTextArea,
+    Vuetable
   },
   props: {
     value: {

--- a/src/main.js
+++ b/src/main.js
@@ -43,6 +43,7 @@ window.ProcessMaker = {
                     'helper': null,
                     'type': 'text',
                     'dataFormat': 'string',
+                    'customCssSelector': 'first-name'
                   },
                   'inspector': [],
                   'component': 'FormInput',
@@ -61,6 +62,7 @@ window.ProcessMaker = {
                     'helper': null,
                     'type': 'text',
                     'dataFormat': 'string',
+                    'customCssSelector': ''
                   },
                   'inspector': [],
                   'component': 'FormInput',
@@ -74,7 +76,7 @@ window.ProcessMaker = {
           ],
           computed: [],
           watchers: [],
-          custom_css: null,
+          custom_css: "[selector='first-name'] label { font-style: italic; }",
           status: 'ACTIVE',
         };
         if (url === 'screens/1') {


### PR DESCRIPTION
Fixes #565 

If the screen is nested in another screen, this adds a `screen-{id}` prefix for any custom css

This means any css declarations made inside the child screen will only effect the child screen, while also inheriting any CSS from the parent screen (which I believe is the desired behavior)

For Example:
Parent CSS: `label { font-style: italic; }`
Child CSS: `label { color: blue; }`
![image](https://user-images.githubusercontent.com/2546850/75591167-e0d35680-5a33-11ea-944b-caca1a378e72.png)
