### PR TITLE
Fix Record List in Multicolumn & Loop Component

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -6,7 +6,7 @@
       </div>
       <div class="col text-right">
         <button class="btn btn-primary" v-if="editable && !selfReferenced" @click="showAddForm">
-          {{ $t('Add Record') }}
+          {{ $t('Add') }}
         </button>
       </div>
     </div>

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -56,7 +56,7 @@
       ref="addModal"
       :ok-title="$t('Ok')"
       :cancel-title="$t('Cancel')"
-      :title="$t('Add Record')"
+      :title="$t('Add')"
     >
       <vue-form-renderer
         :page="form"

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -208,7 +208,6 @@ export default {
   watch: {
     tableFields() {
       this.$nextTick(() => {
-        this.$refs.vuetable.normalizeFields();
         if (this.$refs.vuetable) {
           this.$refs.vuetable.normalizeFields();
         }
@@ -275,12 +274,9 @@ export default {
         // User has not chosen an add/edit page yet
         return [{items: []}];
       }
-      let config = JSON.parse(JSON.stringify(this.$parent.config));
-
-      if (config.name && config.name.includes('multi_column') || config[0].name && config[0].name === 'LoopItem') {
-        config = JSON.parse(JSON.stringify(this.$root.$children[0].config));
-      }
-
+      
+      let config = JSON.parse(JSON.stringify(this.$root.$children[0].config));
+      
       for (let index = 0; index < config.length; index++) {
         if (index != this.form) {
           config[index].items = [];

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -209,6 +209,9 @@ export default {
     tableFields() {
       this.$nextTick(() => {
         this.$refs.vuetable.normalizeFields();
+        if (this.$refs.vuetable) {
+          this.$refs.vuetable.normalizeFields();
+        }
       });
     },
   },
@@ -274,12 +277,8 @@ export default {
       }
       let config = JSON.parse(JSON.stringify(this.$parent.config));
 
-      if (config.name && config.name.includes('multi_column')) {
-        config = JSON.parse(JSON.stringify(this.$parent.$parent.config));
-      }
-
-      if (config[0].name && config[0].name === 'LoopItem') {
-        config = JSON.parse(JSON.stringify(this.$parent.$parent.$parent.config));
+      if (config.name && config.name.includes('multi_column') || config[0].name && config[0].name === 'LoopItem') {
+        config = JSON.parse(JSON.stringify(this.$root.$children[0].config));
       }
 
       for (let index = 0; index < config.length; index++) {


### PR DESCRIPTION
<h2>Changes</h2>

A Record List `config` variable defaults to the `$parent.config`. However when a Record list is nested within a `Multicolumn` or `Loop` component, this `$parent.config` is set to the component's config object instead of the `$root` config. 

This PR updates the `config`  variable to the `$root.children[0].config` in a cleaner way when a Record List is nested within a Multicolumn or Loop component. 

<h2>To Test</h2>

- Add a configured Record List within a Multicolumn or Loop component

- Run a process

- Select the `Add Record` button

**Expected Result**

The configured record list form appears in the Modal.

Ref [#582](https://github.com/ProcessMaker/screen-builder/issues/582#issuecomment-594490189)