### PR TITLE
Reconfigure  how the modal form data is retrieved in a record list

### DIFF
--- a/src/components/renderer/form-multi-column.vue
+++ b/src/components/renderer/form-multi-column.vue
@@ -32,6 +32,7 @@
               v-bind="element.config"
               :is="element.component"
               :disabled="element.config.interactive || element.config.disabled"
+              :formConfig="formConfig"
             />
           </div>
         </template>
@@ -61,7 +62,7 @@ const defaultColumnWidth = 1;
 export default {
   name: 'FormMultiColumn',
   mixins: [HasColorProperty, shouldElementBeVisible, getValidPath],
-  props: ['value', 'selected', 'name', 'config', 'transientData'],
+  props: ['value', 'selected', 'name', 'config', 'transientData', 'formConfig'],
   components: {
     draggable,
     FormInput: FormMaskedInput,

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -59,10 +59,10 @@
       :title="$t('Add')"
     >
       <vue-form-renderer
-        :page="form"
+        :page="0"
         ref="addRenderer"
         v-model="addItem"
-        :config="formConfig"
+        :config="[formConfig[form]]"
       />
     </b-modal>
     <b-modal
@@ -75,11 +75,11 @@
       :cancel-title="$t('Cancel')"
       :title="$t('Edit Record')"
     >
-      <vue-form-renderer
-        :page="form"
+     <vue-form-renderer
+        :page="0"
         ref="editRenderer"
         v-model="editItem"
-        :config="formConfig"
+        :config="[formConfig[form]]"
       />
     </b-modal>
     <b-modal
@@ -130,7 +130,7 @@ export default {
     Pagination,
   },
   mixins: [mustacheEvaluation],
-  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData'],
+  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig'],
   data() {
     return {
       addItem: {},
@@ -168,9 +168,6 @@ export default {
         console.log('refs vuetable not exists');
       }
 
-    },
-    formConfig() {
-      return this.fetchFormConfig();
     },
     tableData() {
       const value = this.value || [];
@@ -269,27 +266,11 @@ export default {
       }
       this.$refs.vuetable.changePage(page);
     },
-    fetchFormConfig() {
-      if (this.form === '') {
-        // User has not chosen an add/edit page yet
-        return [{items: []}];
-      }
-      
-      let config = JSON.parse(JSON.stringify(this.$root.$children[0].config));
-      
-      for (let index = 0; index < config.length; index++) {
-        if (index != this.form) {
-          config[index].items = [];
-        }
-      }
-      return config;
-    },
     showEditForm(index) {
       let pageIndex = ((this.paginatorPage-1) * this.perPage) + index;
       // Reset edit to be a copy of our data model item
       this.editItem = JSON.parse(JSON.stringify(this.value[pageIndex]));
       this.editIndex = pageIndex;
-      this.$refs.editRenderer.currentPage = this.form;
       this.setUploadDataNamePrefix(pageIndex);
       this.$refs.editModal.show();
     },
@@ -308,9 +289,6 @@ export default {
         this.$refs.infoModal.show();
         return;
       }
-      // We switch our renderer to the form specified
-      // This form is a numerical index to the form we want to show
-      this.$refs.addRenderer.currentPage = this.form;
       // Open form
       this.setUploadDataNamePrefix();
       this.$refs.addModal.show();
@@ -383,7 +361,7 @@ export default {
       this.$emit('input', data);
     },
     isValid() {
-      const validate = ValidatorFactory(this.$refs.addRenderer.config[this.form].items, this.$refs.addRenderer.transientData);
+      const validate = ValidatorFactory(this.formConfig[this.form].items, this.$refs.addRenderer.transientData);
       this.errors = validate.getErrors();
       return _.size(this.errors) === 0;
     },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -20,6 +20,7 @@
           @pageNavigate="pageNavigate"
           v-bind="element.config"
           :is="element.component"
+          :formConfig="config"
         />
 
         <div v-else :id="element.config.name ? element.config.name : undefined">
@@ -36,6 +37,7 @@
               v-bind="element.config"
               :is="element.component"
               :disabled="element.config.interactive || element.config.disabled"
+              :formConfig="config"
             />
           </keep-alive>
         </div>
@@ -114,6 +116,10 @@ export default {
       return this.$deepModel(this.transientData);
     },
     visibleElements() {
+      if (!this.config[this.currentPage]) {
+        return;
+      }
+      
       return this.config[this.currentPage].items.filter(this.shouldElementBeVisible);
     },
     containerClass() {
@@ -188,7 +194,7 @@ export default {
           });
         }
 
-        if (this.config) {
+        if (!typeof this.config == undefined) {
           this.config.forEach(page => {
             page.items.forEach(item => {
               if (item.component !== 'FormRecordList') {
@@ -202,7 +208,6 @@ export default {
                   }
                 });
               }
-
             });
           });
         }
@@ -248,12 +253,14 @@ export default {
   methods: {
     applyConfiguredDefaultValues() {
       this.$nextTick(() => {
-        getItemsFromConfig(this.config)
-          .forEach(item => {
-            if (item.config.defaultValue) {
-              this.model[this.getValidPath(item.config.name)] = Mustache.render(item.config.defaultValue, this.transientData);
-            }
-        });
+        if (!typeof this.config == undefined) {
+          getItemsFromConfig(this.config)
+            .forEach(item => {
+              if (item.config.defaultValue) {
+                this.model[this.getValidPath(item.config.name)] = Mustache.render(item.config.defaultValue, this.transientData);
+              }
+          });
+        }
       });
     },
     registerCustomFunctions(node=this) {
@@ -358,9 +365,12 @@ export default {
 
         return shouldHaveDefaultValueSet && isNotFormAccordion;
       };
-      getItemsFromConfig(this.config)
-        .filter(shouldHaveDefaultValue)
-        .forEach(item => this.model[this.getValidPath(item.config.name)] = getDefaultValueForItem(item, this.transientData));
+      if (!typeof this.config == undefined) {
+        getItemsFromConfig(this.config)
+          .filter(shouldHaveDefaultValue)
+          .forEach(item => this.model[this.getValidPath(item.config.name)] = getDefaultValueForItem(item, this.transientData));  
+      }
+      
     },
     parseCss() {
       const containerSelector = '.' + this.containerClass;


### PR DESCRIPTION
<h2>Changes</h2>

- Reconfigures how the Modal data is being rendered within a Record List. 

- Removes the function that sets variable `formConfig` data  within a record list 

- Passes the `formConfig` variable from form renderer into the record list.

Closes the reopened tickets #582 & #548 