### PR TITLE
Fix recordlist editor-control config

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -392,7 +392,7 @@ export default [
       label: 'Record List',
       component: 'FormRecordList',
       'editor-component': 'FormText',
-      'editor-control': 'FormText',
+      'editor-control': 'FormRecordList',
       config: {
         name: '',
         icon: 'fas fa-th-list',


### PR DESCRIPTION
<h2>Changes</h2>

The issue occurs when adding a File Download control, saving the screen, and refreshing.  The RecordList Control was overwriting the File Download inspector configurations after refreshing because they shared the same `editor-control`. This PR prevents the File Download inspector configurations from being overwritten by updating the RecordList `editor-control` key value to `RecordList.` 

<h2>Before</h2>
<a href="https://www.loom.com/share/e6fc964315ca4d84b2afb459807dce8a"> <p>Edit Screen - ProcessMaker - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/e6fc964315ca4d84b2afb459807dce8a-with-play.gif"> </a>

<h2>After</h2>
<a href="https://www.loom.com/share/02f47d20fea74f7989518d29524a480b"> <p>11 March, 2020 - Loom Recording - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/02f47d20fea74f7989518d29524a480b-with-play.gif"> </a>

<h2>To Test</h2>

- Drag a File Download control onto the screen. 

- Check the Inspector Configurations

- Save the screen & refresh

- Select the File Download control and check the inspector configurations.

**Expected Results**
The inspector configurations are the same as when the control was first added onto the screen.

Dependency: [Processmaker/#2950 ](https://github.com/ProcessMaker/processmaker/pull/2950)

Closes #628 