### PR TITLE
Fix Currency Null Amount

### DIFF
--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -140,8 +140,8 @@ export default {
       return {
         decimal: separators[1],
         thousands: separators[0],
-        prefix: this.dataMask ? this.dataMask.symbol + ' ' : '',
-        suffix: this.dataMask ? ' ' + this.dataMask.code : '',
+        prefix: this.dataMask && this.dataMask.symbol ? this.dataMask.symbol + ' ' : '',
+        suffix: this.dataMask && this.dataMask.code ? ' ' + this.dataMask.code : '',
         precision: presicion,
         masked: false,
       };


### PR DESCRIPTION
<h2>Change</h2>

Add conditional to check if the currency symbol & code are set.

![Screen Shot 2020-03-24 at 2 12 15 PM](https://user-images.githubusercontent.com/52755494/77477662-ed03c700-6dd9-11ea-8121-05465f913c68.png)

<h2>To Test</h2>

- Create a Form screen

- Add a line input control

- Configure the control to use the `Currency` data type, and use a currency that does not have a symbol, like JPY or EUR

- Save the screen, reload the page, and go to the preview

**Expected Result**

`null` Does not appear as the currency prefix 

closes #637 