### PR TITLE
Add min/max settings to date picker

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -260,8 +260,26 @@ export default [
         type: 'datetime',
         name: '',
         placeholder: '',
+        minDate: '',
+        maxDate: '',
       },
       inspector: [
+        {
+          type: 'FormInput',
+          field: 'minDate',
+          config: {
+            label: 'Minimum Date',
+            validation: 'date_or_mustache',
+          },
+        },
+        {
+          type: 'FormInput',
+          field: 'maxDate',
+          config: {
+            label: 'Maximum Date',
+            validation: 'date_or_mustache',
+          },
+        },
         keyNameProperty,
         labelProperty,
         DataTypeDateTimeProperty,


### PR DESCRIPTION
Fixes #655 
Needs https://github.com/ProcessMaker/vue-form-elements/pull/176

Adds min and max date settings to inspector with validations. Can use mustache syntax

![image](https://user-images.githubusercontent.com/2546850/78694027-ed5b9200-78b0-11ea-9c37-6ce4f702b6fc.png)
![image](https://user-images.githubusercontent.com/2546850/78694125-0d8b5100-78b1-11ea-8734-54694fac3a9d.png)
