### PR TITLE
Modal Close Buttons Hidden

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,6 +44,7 @@
             :ok-disabled="!uploadedJson"
             cancel-variant="outline-secondary"
             ok-variant="secondary"
+            header-close-content="&times;"
             @hidden="this.clearUpload"
             @ok="loadScreenPackage"
           >
@@ -158,7 +159,7 @@
     <computed-properties v-model="computed" ref="computedProperties"/>
     <custom-CSS v-model="customCSS" ref="customCSS" :cssErrors="cssErrors"/>
     <watchers-popup v-model="watchers" ref="watchersPopup"/>
-    <b-modal id="preview-config" size="xl" title="Screen Config JSON Preview">
+    <b-modal id="preview-config" size="xl" title="Screen Config JSON Preview" header-close-content="&times;">
       <monaco-editor @editorDidMount="editorDidMount" style="height: 500px" :options="monacoOptions" v-model="previewConfig" language="json"></monaco-editor>
     </b-modal>
   </b-container>
@@ -353,7 +354,7 @@ export default {
         let config = JSON.parse(savedConfig);
         this.$refs.builder.config = config;
       }
-      
+
       if (savedWatchers) {
         let watcherConfig = JSON.parse(savedWatchers);
         this.watchers = watcherConfig;

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -11,6 +11,8 @@
     title-class="m-0"
     footer-class="m-0 p-0"
     no-close-on-backdrop
+    header-close-content="&times;"
+
   >
 
     <template v-if="displayList">

--- a/src/components/custom-css.vue
+++ b/src/components/custom-css.vue
@@ -12,6 +12,7 @@
     no-close-on-backdrop
     :ok-title="$t('Save')"
     :cancel-title="$t('Cancel')"
+    header-close-content="&times;"
   >
     <p>{{ $t("You can set CSS Selector names in the inspector. Use them here with [selector='my-selector']") }}</p>
     <div class="editor">

--- a/src/components/inspector/column-setup.vue
+++ b/src/components/inspector/column-setup.vue
@@ -137,7 +137,7 @@
           <MonacoEditor :options="monacoOptions" class="editor" v-model="jsonData" language="json" @change="jsonDataChange"/>
         </div>
 
-        <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak>
+        <b-modal v-model="showPopup" size="lg" centered :title="$t('Script Config Editor')" v-cloak header-close-content="&times;">
           <div class="editor-container">
             <MonacoEditor :options="monacoLargeOptions" v-model="jsonData" language="json" class="editor" @change="jsonDataChange"/>
           </div>

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -57,6 +57,7 @@
       :ok-title="$t('Ok')"
       :cancel-title="$t('Cancel')"
       :title="$t('Add')"
+      header-close-content="&times;"
     >
       <vue-form-renderer
         :page="0"
@@ -74,6 +75,7 @@
       :ok-title="$t('Save')"
       :cancel-title="$t('Cancel')"
       :title="$t('Edit Record')"
+      header-close-content="&times;"
     >
      <vue-form-renderer
         :page="0"
@@ -90,6 +92,7 @@
       :ok-title="$t('Save')"
       :cancel-title="$t('Cancel')"
       :title="$t('Delete Record')"
+      header-close-content="&times;"
     >
       <p>{{ $t('Are you sure you want to remove this record?') }}</p>
     </b-modal>
@@ -100,6 +103,7 @@
       ref="infoModal"
       :ok-title="$t('OK')"
       :title="$t('Information form')"
+      header-close-content="&times;"
       ok-only
     >
       <p>{{ $t('The form to be displayed is not assigned.') }}</p>
@@ -335,7 +339,7 @@ export default {
       const item = JSON.parse(JSON.stringify(this.addItem));
       delete item._parent;
       data[data.length] = item;
-      
+
       // Emit the newly updated data model
       this.$emit('input', data);
 
@@ -352,7 +356,7 @@ export default {
       this.$refs.deleteModal.show();
     },
     downloadFile(rowData, rowField, rowIndex) {
-      let requestId = this.$root.task.request_data._request.id; 
+      let requestId = this.$root.task.request_data._request.id;
       let name = this.name + "." + rowIndex + "." + rowField;
 
       ProcessMaker.apiClient

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -113,7 +113,7 @@
               <i class="fas fa-arrows-alt-v mr-1 text-muted"/>
               <i v-if="element.config.icon" :class="element.config.icon" class="mr-2 ml-1"/>
               {{ element.config.name || element.label || $t('Field Name') }}
-              <div class="ml-auto"> 
+              <div class="ml-auto">
                 <button
                   class="btn btn-sm btn-secondary mr-2"
                   :title="$t('Copy Control')"
@@ -151,7 +151,7 @@
               <i class="fas fa-arrows-alt-v mr-1 text-muted"/>
               <i v-if="element.config.icon" :class="element.config.icon" class="mr-2 ml-1"/>
               {{ element.config.name || $t('Variable Name') }}
-              <div class="ml-auto"> 
+              <div class="ml-auto">
                 <button
                   class="btn btn-sm btn-secondary mr-2"
                   :title="$t('Copy Control')"
@@ -167,7 +167,7 @@
                   <i class="far fa-trash-alt text-light"/>
                 </button>
               </div>
-            </div> 
+            </div>
             <component
               :tabindex="element.config.interactive ? 0 : -1"
               class="card-body m-0 pb-4 pt-4"
@@ -231,6 +231,7 @@
       cancel-variant="btn btn-outline-secondary"
       ok-variant="btn btn-secondary ml-2"
       :title="$t('Add New Page')"
+      header-close-content="&times;"
     >
       <form-input v-model="addPageName"
         :name="$t('Page Name')"
@@ -248,6 +249,7 @@
       :cancel-title="$t('Cancel')"
       cancel-variant="btn btn-outline-secondary"
       ok-variant="btn btn-secondary ml-2"
+      header-close-content="&times;"
     >
       <form-input v-model="editPageName"
         :label="$t('Page Name')"
@@ -265,6 +267,7 @@
       @cancel="hideConfirmModal"
       cancel-variant="btn btn-outline-secondary"
       ok-variant="btn btn-secondary ml-2"
+      header-close-content="&times;"
     >
       <p>{{ confirmMessage }}</p>
       <div slot="modal-ok">{{ $t('Delete') }}</div>
@@ -501,7 +504,7 @@ export default {
             delete item.config.name;
           }
         }
-      });      
+      });
     },
     replaceFormText(items) {
       items.forEach(item => {

--- a/src/components/watchers-popup.vue
+++ b/src/components/watchers-popup.vue
@@ -6,6 +6,7 @@
     :title="$t('Watchers')"
     @hidden="displayList"
     hide-footer
+    header-close-content="&times;"
     no-close-on-backdrop
   >
     <template v-if="enableList">


### PR DESCRIPTION
Resolves #669 

The property header-close-content="&times;" was added to interactive <b-modal>s used in the UI.

