### PR TITLE
Rich Text Control: Render HTML from Variable checkbox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8183,9 +8183,10 @@
       "dev": true
     },
     "inputmask": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.3.tgz",
-      "integrity": "sha512-v1l5IoJK6NE8TapI2g6n/y1/ksMwyVLkkaIS6VPTkdvpgEITLzDtSi7n9Jpp471hL2DdJlae9HpMnFmTpf5VXA=="
+      "version": "5.0.4-beta.33",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.4-beta.33.tgz",
+      "integrity": "sha512-pet97YhTOkZcDBXmbKPPjW7xC1EziSkEWIyBZhqPehg5lhDVG7lBWG6trxoTCinX+AxEzdTN6M/Ujj/uA9/TOg==",
+      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "*.js"
   ],
   "dependencies": {
-    "inputmask": "^5.0.0",
     "lodash": "latest",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
@@ -48,6 +47,7 @@
     "expr-eval": "^2.0.2",
     "i18next": "^15.0.8",
     "identity-obj-proxy": "^3.0.0",
+    "inputmask": "^5.0.4-beta.33",
     "monaco-editor-webpack-plugin": "~1.7.0",
     "mustache": "^3.0.1",
     "node-sass": "^4.9.1",

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -49,6 +49,7 @@ export default [
         icon: 'fas fa-pencil-ruler',
         interactive: true,
         content: '<p>Rich text editor</p>',
+        renderVarHtml: null,
       },
       inspector: [
         {
@@ -61,6 +62,15 @@ export default [
             value: '',
           },
         },
+        {
+          type: 'FormCheckbox',
+          field: 'renderVarHtml',
+          config: {
+            label: 'Render HTML from a Variable',
+            helper: '',
+            value: '',
+          },
+        }
       ],
     },
   },


### PR DESCRIPTION
<h2>Changes</h2>

Add an`Render HTML from Variable` checkbox in the inspector panel.

<h3>To Test</h3>

- Add a Textarea control, set the variable name and enable the `rich text` option.
- Add a Rich Text control, in standard mustache syntax input the above Textarea variable name into the content field. `{{ var_name }}`, enable the `Render HTML from Variable` option.
- Switch to Preview Mode, In the Textarea input text and set the Heading to H1.

**Expected Results**
The Rich text control renders the same content and heading.

**Dependency:**
https://github.com/ProcessMaker/vue-form-elements/pull/182

Closes #676 