### PR TITLE
Fix dragging items into / out of loop container

### DIFF
--- a/src/components/editor/loop.vue
+++ b/src/components/editor/loop.vue
@@ -2,7 +2,7 @@
   <div class="column-draggable" :selector="config.customCssSelector">
     <draggable
       style="min-height: 80px;"
-      v-model="items"
+      :list="items"
       group="controls"
     >
       <div class="control-item"


### PR DESCRIPTION
I changed the `v-model` prop to use the provided alternative `list` as per [vuedraggable docs](https://github.com/SortableJS/Vue.Draggable#list).

Fixes #681 

![2020-04-29-1532-screen-builder-681](https://user-images.githubusercontent.com/28595383/80640940-a5650080-8a53-11ea-8828-b838755cb664.gif)
