### PR TITLE
Invalid Form Submission Class

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="containerClass">
-    <div class="page">
+    <div class="page" :class="formSubmitErrorClass">
       <div
         v-for="(element, index) in visibleElements"
         :key="index"
@@ -162,6 +162,7 @@ export default {
         },
       },
       scrollable: null,
+      formSubmitErrorClass: '',
     };
   },
   watch: {
@@ -321,6 +322,9 @@ export default {
         }
         this.errors = Object.assign(this.errors, childErrors);
       });
+      if (this.errors) {
+        this.formSubmitErrorClass = 'invalid-form-submission';
+      }
       return _.size(this.errors) === 0;
     },
     pageNavigate(page) {


### PR DESCRIPTION
<h2>Changes</h2>

This PR adds an `invalid-form-submission` class when submitting a form with errors. This class is needed to identify when a submitted form contains errors, allowing for the custom CSS to target and display the validation error styling. 

The class may not be required in the future when we refactor how the validation runs. 

Below is the custom CSS needed to remove the validation errors from displaying on page load. 

Validation errors will appear when an element with the class `is-invalid` is selected & when the form submits with errors.

```
/* set the is-invalid class to the default form-control styling */
.is-invalid,
.is-invalid .multiselect__tags {
    border-color: #ced4da!important;
    padding-right: 0.375rem 0.75rem;
    background-position: -99999px!important;
    color:#000;
}

.invalid-feedback {
    display: none;
}

/* On element focus & on invalid form submission, revert the is-invalid styling */
.focus-visible.is-invalid,
.is-invalid .multiselect--active .multiselect__tags,
.invalid-form-submission .is-invalid,
.invalid-form-submission .is-invalid .multiselect__tags {
    border-color: #dc3545!important;
    padding-right: calc(1.5em + 0.75rem);
    background-position: right calc(0.375em + 0.1875rem) center!important;
}

.focus-visible.is-invalid + .invalid-feedback,
.invalid-form-submission .invalid-feedback {
    display: block;
}
```

<a href="https://www.loom.com/share/14383cee04c8410db40d9e153170dbc2"> <p>vue-form-builder - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/14383cee04c8410db40d9e153170dbc2-with-play.gif"> </a>

<h2>To Test:</h2>

- Add the above CSS into a screens 'Custom CSS' 
- Add inputs with a required validation
- Run a process 

**Expected Behavior**
 
Errors do not appear until the input field is selected or the form is submitted.

closes #685 


