### PR TITLE
Fix Date Mask Errors

### DIFF
--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -190,7 +190,17 @@ export default {
       value !== this.localValue ? this.localValue = this.convertFromData(value) : null;
     },
     localValue(value) {
-      moment(value).toISOString() !== this.value ? this.$emit('input', this.convertToData(value)) : null;
+      switch(this.dataFormat) {
+        case 'date': 
+          value.length >= 10 && moment(value).toISOString() !== this.value ? this.$emit('input', this.convertToData(value)) : null;  
+          break;
+        case 'datetime':
+          value.length >= 10 && moment(value).toISOString() !== moment(this.value).toISOString() ? this.$emit('input', this.convertToData(value)) : null;  
+          break;
+        default:
+          value !== this.value ? this.$emit('input', this.convertToData(value)) : null;    
+          break;
+      }
     },
   },
   data() {

--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -190,7 +190,7 @@ export default {
       value !== this.localValue ? this.localValue = this.convertFromData(value) : null;
     },
     localValue(value) {
-      value !== this.value ? this.$emit('input', this.convertToData(value)) : null;
+      moment(value).toISOString() !== this.value ? this.$emit('input', this.convertToData(value)) : null;
     },
   },
   data() {


### PR DESCRIPTION
<h2>Changes</h2>

1. Add switch statement to handle formatting different data types.
2. Convert `localValue` to an ISO string when comparing with the emitted date `value`. Preventing an infinite loop.
3. When using a data type `datetime` compare the `localValue` ISO string with the emitted date `value` ISO string. Preventing the time from not updating correctly.

Dependent PR:
https://github.com/ProcessMaker/vue-form-elements/pull/184

https://www.loom.com/share/125a8f1445954e0c86f38302d4cf5a91

<h2> To Test</h2>

1. Using the above VFE PR `npm link` with screen builder
2. Create a screen with 2 input controls setting the data type to `date` and `datetime`
3. Enter preview mode and input dates, open your console.

**Expected Behavior**
Dates properly format and no errors are in your console.

closes #694 