### PR TITLE
Fix Deleting Rule Error

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -339,6 +339,7 @@ export default {
     },
     deleteRule(index) {
       this.rules.splice(index, 1);
+      this.cloneRules.splice(index, 1);
       this.hideDeleteConfirmCard();
     },
     setRuleConfigs() {


### PR DESCRIPTION
<h2>Changes</h2>

When rules are deleted update the `cloneRules` index. 

Ref
https://github.com/ProcessMaker/screen-builder/issues/691#issuecomment-625400937