### PR TITLE
Update wording of submit button type

### DIFF
--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -228,16 +228,16 @@ export const buttonTypeEvent = {
   type: 'FormMultiselect',
   field: 'event',
   config: {
-    label: 'Type Button',
-    helper: 'Determine execution of button',
+    label: 'Type',
+    helper: 'Choose whether the button should submit the form',
     options: [
       {
         value: 'submit',
-        content: 'Submit',
+        content: 'Submit Button',
       },
       {
         value: 'script',
-        content: 'Script',
+        content: 'Regular Button',
       },
     ],
   },


### PR DESCRIPTION
## Changes
- Updates confusing wording when choosing type of button

## Related
- Requires https://github.com/ProcessMaker/processmaker/pull/3107 for translations

## After
<img width="279" alt="Screen Shot 2020-05-07 at 2 40 07 PM" src="https://user-images.githubusercontent.com/867714/81347724-955fa900-9071-11ea-8fec-ef541c37e761.png">
<img width="284" alt="Screen Shot 2020-05-07 at 2 40 15 PM" src="https://user-images.githubusercontent.com/867714/81347726-98f33000-9071-11ea-9b63-43edddb37bac.png">

## Before
<img width="270" alt="Screen Shot 2020-05-07 at 1 24 50 PM" src="https://user-images.githubusercontent.com/867714/81347734-9db7e400-9071-11ea-8df9-35b3f93bd46e.png">

Closes #697.