### PR TITLE
Fix Masked Inputs reactivity

### DIFF
--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -187,35 +187,31 @@ export default {
   },
   watch: {
     value(value) {
-      let date;
-      switch(this.dataFormat) {
-        case 'date': 
-          date = moment(value, moment.ISO_8601, true).tz(getTimezone());
-          if (date.isValid()) {
-            this.localValue = date.format(getUserDateFormat());
-          }
-          break;
-        case 'datetime': 
-          date = moment(value, moment.ISO_8601, true).tz(getTimezone());
-          if (date.isValid()) {
-            this.localValue = date.format(getUserDateTimeFormat());
-          }
-          break;
-        default:
-          value !== this.localValue ? this.localValue = this.convertFromData(value) : null;
-          break;
-      }
+      if (!value) {    
+        this.localValue = value;
+      } else {
+        let date;
+        switch(this.dataFormat) {
+          case 'date': 
+              date = moment(value, moment.ISO_8601, true).tz(getTimezone());
+              if (date.isValid()) {
+                this.localValue = date.format(getUserDateFormat());
+              }   
+            break;
+          case 'datetime': 
+            date = moment(value, moment.ISO_8601, true).tz(getTimezone());
+            if (date.isValid()) {
+              this.localValue = date.format(getUserDateTimeFormat());
+            }
+            break;
+          default:
+            value !== this.localValue ? this.localValue = this.convertFromData(value) : null;
+            break;
+        }
+      }      
     },
     localValue(value) {
-      switch(this.dataFormat) {
-        case 'date':
-        case 'datetime':
-          this.$emit('input', value);
-          break;
-        default:
-          value !== this.value ? this.$emit('input', this.convertToData(value)) : null;    
-          break;
-      }
+      value !== this.value ? this.$emit('input', this.convertToData(value)) : null;    
     },
   },
   data() {


### PR DESCRIPTION
<h2>Changes</h2>

The `localValue` variable was not being cleared when navigating pages. This PR clears the variable preventing reactivity issues between multipage forms.

closes #709 