### PR TITLE
Fix input mask on page load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -297,7 +297,7 @@ export default {
         return JSON.stringify(this.config);
       },
       set(val) {
-      }
+      },
     },
     displayBuilder() {
       return this.mode === 'editor';

--- a/src/components/renderer/form-input-masked.vue
+++ b/src/components/renderer/form-input-masked.vue
@@ -77,7 +77,9 @@ export default {
         radixPoint: this.decimal,
         groupSeparator: this.thousands,
       }).mask(this.currencyInput);
-      this.currencyInput.inputmask.setValue(this.value);
+      if (this.value) {
+        this.currencyInput.inputmask.setValue(this.value);
+      }
     },
   },
   mounted() {

--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -193,10 +193,10 @@ export default {
         let date;
         switch(this.dataFormat) {
           case 'date': 
-              date = moment(value, moment.ISO_8601, true).tz(getTimezone());
-              if (date.isValid()) {
-                this.localValue = date.format(getUserDateFormat());
-              }   
+            date = moment(value, moment.ISO_8601, true).tz(getTimezone());
+            if (date.isValid()) {
+              this.localValue = date.format(getUserDateFormat());
+            }
             break;
           case 'datetime': 
             date = moment(value, moment.ISO_8601, true).tz(getTimezone());
@@ -231,6 +231,6 @@ export default {
     if (this.value) {
       this.localValue = this.value;
     }
-  }
+  },
 };
 </script>

--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -211,17 +211,26 @@ export default {
       }      
     },
     localValue(value) {
-      value !== this.value ? this.$emit('input', this.convertToData(value)) : null;    
+      if (value == this.value) {
+        this.localValue = this.convertFromData(value);
+      } else {
+        this.$emit('input', this.convertToData(value));
+      }
     },
   },
   data() {
     return {
       validator: null,
-      localValue: this.value,
+      localValue: null,
       validationRules: {
         'percentage': 'regex:/^[+-]?\\d+(\\.\\d+)?$/',
       },
     };
   },
+  mounted() {
+    if (this.value) {
+      this.localValue = this.value;
+    }
+  }
 };
 </script>

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -62,7 +62,7 @@ export default {
     BasicSearch,
     FormInput,
     FormTextArea,
-    Vuetable
+    Vuetable,
   },
   props: {
     value: {


### PR DESCRIPTION
<h2>Changes</h2>
Masking failed for all data types when the screen/page is first loaded. Below are the changes made to fix.

- Set the `localValue` if there is already an emitted `value`. Triggering the `localValue` watcher to mask the data based on the data type.

- Fix a `split on null` console error when adding a `currency` or `percentage` data type. 

https://www.loom.com/share/87e897c18a544545966d808206ef4855


<h2>To Test</h2>

1. `npm link` this branch to pm4 core. 
2. Import and run this process - [Test masking.json.txt](https://github.com/ProcessMaker/screen-builder/files/4623554/Test.masking.json.txt)
3. Fill out all fields and take note of their values.

**Expected Behavior**
1. When navigating between the two pages the values are consistent.
2. After the process completes navigate to the summary screen, select the `forms` tab, and expand the details. All values should be consistent with your inputted values.

closes #714 & #711 