### PR TITLE
Debounce input change

### DIFF
--- a/src/components/renderer/form-masked-input.vue
+++ b/src/components/renderer/form-masked-input.vue
@@ -42,6 +42,8 @@ import Inputmasked from './form-input-masked';
 import { TheMask } from 'vue-the-mask';
 import { getUserDateFormat, getUserDateTimeFormat, getTimezone } from '@processmaker/vue-form-elements/src/dateUtils';
 import moment from 'moment';
+import debounce from 'debounce';
+
 
 const uniqIdsMixin = createUniqIdsMixin();
 const componentTypes = {
@@ -83,6 +85,8 @@ const masks = {
     dateTime: ['####/##/## ##:##', '####/##/## #:## SS', '####/##/## ##:## SS'],
   },
 };
+
+const delayUpdate = debounce(callback => callback() );
 
 export default {
   inheritAttrs: false,
@@ -212,9 +216,13 @@ export default {
     },
     localValue(value) {
       if (value == this.value) {
-        this.localValue = this.convertFromData(value);
+        delayUpdate(() => {
+          this.localValue = this.convertFromData(value);
+        });
       } else {
-        this.$emit('input', this.convertToData(value));
+        delayUpdate(() => {
+          this.$emit('input', this.convertToData(value));
+        });
       }
     },
   },


### PR DESCRIPTION
Fixes: #727 

This PR debounce the input changes so the reactivity, calculated fields and watchers do not saturate the screen performance.
