### PR TITLE
Fix validation select 

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -8,7 +8,7 @@
       <div class="card-body p-2">
         <multiselect
           label="content"
-          track-by="value"
+          track-by="content"
           v-model="selectedOption"
           :placeholder="$t('Select...')"
           :show-labels="false"


### PR DESCRIPTION
<h2>Changes</h2>

Set the multi-select `track-by` config to `content` instead of `value` using `value` highlighted similar values within the options list as preselected when they weren't causing users to double click to select those items.

https://www.loom.com/share/e3c5acfce77b4f2f8c6cf080adf552f4

closes https://github.com/ProcessMaker/screen-builder/issues/691#issuecomment-631449160