### PR TITLE
Fix data sources inspector for select list

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -447,6 +447,7 @@ export default {
 
 <style lang="scss">
     @import "~bootstrap/dist/css/bootstrap";
+    @import '~bootstrap-vue/dist/bootstrap-vue';
 
     $validation-panel-bottom: 3.5rem;
     $validation-panel-right: 0;

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -1,0 +1,46 @@
+import axios from 'axios';
+
+export default {
+  apiInstance: null,
+  install(Vue, options) {
+    Vue.prototype.$dataProvider = this;
+    
+    // make sure we're not using the stub in main.js
+    // temporary until the stub is moved here.
+    if (window && window.ProcessMaker && !window.ProcessMaker.isStub) {
+      this.apiInstance = window.ProcessMaker.apiClient;
+      return;
+    }
+
+    if (this.token() && !this.apiInstance) {
+      axios.defaults.baseURL = this.baseURL();
+      axios.defaults.headers.common = {
+        'Authorization': 'Bearer ' + this.token(),
+      };
+      this.apiInstance = axios;
+    }
+
+    // use a dummy api client
+    if (!this.axiosInstance) {
+      this.axiosInstance = {
+        get(...args) {
+          return Promise.resolve({
+            data: {
+              data: []
+            }
+          });
+        },
+      }
+    }
+
+  },
+  get(...args) {
+   return this.apiInstance.get(...args);
+  },
+  token() {
+    return localStorage.getItem('token');
+  },
+  baseURL() {
+    return localStorage.getItem('baseURL');
+  },
+}

--- a/src/components/inspector/mustache-helper.vue
+++ b/src/components/inspector/mustache-helper.vue
@@ -1,0 +1,18 @@
+<template>
+    <div class="mustache" :title="$t('This field accepts mustache syntax')" v-b-tooltip.hover>{}</div>
+</template>
+
+<script>
+export default {
+}
+</script>
+
+<style scoped>
+  .mustache {
+    float: right;
+    font-size: 1em;
+    color: #ced4da;
+    font-weight: bold;
+    cursor: pointer;
+  }
+</style>

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -120,9 +120,10 @@
       </div>
     </div>
     <div v-if="dataSource === dataSourceValues.dataObject || dataSource === dataSourceValues.dataConnector">
-      <label for="element-name">{{ $t('Existing Request Data Variable') }}</label>
+      <label for="element-name">{{ $t('Options Variable') }}</label>
+      <mustache-helper></mustache-helper>
       <b-form-input id="element-name" v-model="dataName" placeholder="Request Variable Name"/>
-      <small class="form-text text-muted mb-3">{{ $t('Enter the request data variable to populate values of the select list. This variable must contain an array or an array of objects.') }}</small>
+      <small class="form-text text-muted mb-3">{{ $t('Get options from this variable. Must be an array.') }}</small>
     </div>
 
     <div v-if="dataSource === dataSourceValues.dataObject">
@@ -175,16 +176,28 @@
       </button>
     </div>
 
-    <div>
-      <label for="value-type-returned">{{ $t('Type of Value Returned') }}</label>
-      <b-form-select id="value-type-returded" v-model="valueTypeReturned" :options="returnValueOptions" />
-      <small class="form-text text-muted mb-3">{{ $t('Select whether to return a Single Value or an Object containing all properties from the Request Variable Object.') }}</small>
-
-      <div v-if="valueTypeReturned === 'single' && dataSource === dataSourceValues.dataObject">
-        <label for="key">{{ $t('Variable Data Property') }}</label>
-        <b-form-input id="key" v-model="key" @change="keyChanged" placeholder="Request Variable Property"/>
-        <small class="form-text text-muted mb-3">{{ $t('Enter the property name from the Request data variable that will be passed as the value when selected.') }}</small>
+    <label for="value-type-returned">{{ $t('Type of Value Returned') }}</label>
+    <b-form-select id="value-type-returded" v-model="valueTypeReturned" :options="returnValueOptions" />
+    <small class="form-text text-muted mb-3">{{ $t("Select 'Single Value' to use parts of the selected object. Select 'Object' to use the entire selected value.") }}</small>
+  
+    <div v-if="dataSource === dataSourceValues.dataConnector">
+      <div v-if="valueTypeReturned === 'single'">
+        <label for="key">{{ $t('Value') }}</label>
+        <mustache-helper></mustache-helper>
+        <b-form-input id="key" v-model="key" @change="keyChanged"/>
+        <small class="form-text text-muted mb-3">{{ $t('Key name in the selected object to use as the value of this control. Leave blank to use the entire selected value.') }}</small>
       </div>
+
+      <label for="value">{{ $t('Content') }}</label>
+      <mustache-helper></mustache-helper>
+      <b-form-input id="value" v-model="value" @change="valueChanged"/>
+      <small class="form-text text-muted mb-3">{{ $t('Key name in the selected object to display to the user in the select list. Leave blank to show the entire selected value.') }}</small>
+    </div>
+
+    <div v-if="valueTypeReturned === 'single' && dataSource === dataSourceValues.dataObject">
+      <label for="key">{{ $t('Variable Data Property') }}</label>
+      <b-form-input id="key" v-model="key" @change="keyChanged" placeholder="Request Variable Property"/>
+      <small class="form-text text-muted mb-3">{{ $t('Enter the property name from the Request data variable that will be passed as the value when selected.') }}</small>
     </div>
 
     <div v-if="dataSource === dataSourceValues.dataConnector">
@@ -199,19 +212,9 @@
       <small class="form-text text-muted mb-3">{{ $t('Endpoint to populate select') }}</small>
     </div>
 
-
-    <div v-if="dataSource === dataSourceValues.dataConnector">
-      <label for="key">{{ $t('Value') }}</label>
-      <b-form-input id="key" v-model="key" @change="keyChanged"/>
-      <small class="form-text text-muted mb-3">{{ $t('Field to save to the data object') }}</small>
-
-      <label for="value">{{ $t('Content') }}</label>
-      <b-form-input id="value" v-model="value" @change="valueChanged"/>
-      <small class="form-text text-muted mb-3">{{ $t('Field to show in the select box') }}</small>
-    </div>
-
     <div v-if="dataSource === dataSourceValues.dataConnector">
       <label for="pmql-query">{{ $t('PMQL') }}</label>
+      <mustache-helper></mustache-helper>
       <b-form-textarea id="json-data" rows="4" v-model="pmqlQuery"/>
       <small class="form-text text-muted">{{ $t('Advanced data search') }}</small>
     </div>
@@ -223,6 +226,7 @@
 import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
+import MustacheHelper from './mustache-helper'
 require('monaco-editor/esm/vs/editor/editor.main');
 
 
@@ -230,6 +234,7 @@ export default {
   components: {
     draggable,
     MonacoEditor,
+    MustacheHelper
   },
   props: ['options'],
   model: {

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -119,7 +119,7 @@
         </div>
       </div>
     </div>
-    <div v-if="dataSource === dataSourceValues.dataObject">
+    <div v-if="dataSource === dataSourceValues.dataObject || dataSource === dataSourceValues.dataConnector">
       <label for="element-name">{{ $t('Existing Request Data Variable') }}</label>
       <b-form-input id="element-name" v-model="dataName" placeholder="Request Variable Name"/>
       <small class="form-text text-muted mb-3">{{ $t('Enter the request data variable to populate values of the select list. This variable must contain an array or an array of objects.') }}</small>
@@ -250,7 +250,7 @@ export default {
       selectedDataSource: '',
       dataSourcesList: [],
       selectedEndPoint: '',
-      endPointList: [],
+      endpoints: {},
       pmqlQuery: '',
       optionsList: [],
       showOptionCard: false,
@@ -298,29 +298,12 @@ export default {
     };
   },
   watch: {
-    options() {
-      this.dataSource = this.options.dataSource;
-      this.jsonData = this.options.jsonData;
-      this.dataName = this.options.dataName;
-      this.selectedDataSource = this.options.selectedDataSource;
-      this.dataSourcesList = this.options.dataSourcesList;
-      this.selectedEndPoint = this.options.selectedEndPoint;
-      this.endPointList = this.options.endPointList;
-      this.key = this.options.key;
-      this.value = this.options.value;
-      this.pmqlQuery = this.options.pmqlQuery;
-      this.defaultOptionKey = this.options.defaultOptionKey;
-      this.selectedOptions = this.options.selectedOptions;
-      this.optionsList = this.options.optionsList;
-      this.showRenderAs = this.options.showRenderAs;
-      this.renderAs = this.options.renderAs;
-      this.allowMultiSelect = this.options.allowMultiSelect;
-      this.showOptionCard = this.options.showOptionCard;
-      this.showRemoveWarning = this.options.showRemoveWarning;
-      this.showJsonEditor = this.options.showJsonEditor;
-      this.editIndex = this.options.editIndex;
-      this.removeIndex = this.options.removeIndex;
-      this.valueTypeReturned = this.options.valueTypeReturned;
+    options(newOptions) {
+      Object.keys(newOptions).forEach(key => {
+        if (typeof newOptions[key] !== 'undefined') {
+          this.$set(this, key, newOptions[key]);
+        }
+      });
     },
     dataSource(val) {
       this.showRenderAs = true;
@@ -329,6 +312,7 @@ export default {
           this.jsonData = '';
           this.dataName = '';
           this.getDataSourceList();
+          break;
         case 'dataObject':
           this.jsonData = '';
           this.selectedDataSource = '';
@@ -339,14 +323,33 @@ export default {
           break;
       }
     },
-    selectedDataSource() {
-      this.getEndPointsList();
-    },
     dataObjectOptions(dataObjectOptions) {
       this.$emit('change', dataObjectOptions);
     },
+    dataSourcesList() {
+      if (this.dataSourcesList.some(ds => ds.value === this.selectedDataSource)) {
+        return;
+      }
+      
+      if (this.dataSourcesList.length > 0) {
+        console.log("SETTING TO DEFAULT selectedDataSource")
+        this.selectedDataSource = this.dataSourcesList[0].value;
+      }
+    },
+    endPointList() {
+      if (this.endPointList.some(e => e.value === this.selectedEndPoint)) {
+        return;
+      }
+
+      if (this.endPointList.length > 0) {
+        this.selectedEndPoint = this.endPointList[0].value;
+      }
+    },
   },
   computed: {
+    endPointList() {
+      return _.get(this.endpoints, this.selectedDataSource, []);
+    },
     dataSourceTypes() {
       if (typeof this.options.allowMultiSelect === 'undefined') {
         return [this.dataSources[0], this.dataSources[1]];
@@ -381,9 +384,7 @@ export default {
         jsonData: this.jsonData,
         dataName: this.dataName,
         selectedDataSource: this.selectedDataSource,
-        dataSourcesList: this.dataSourcesList,
         selectedEndPoint: this.selectedEndPoint,
-        endPointList: this.endPointList,
         key: this.key,
         value: this.value,
         pmqlQuery: this.pmqlQuery,
@@ -407,9 +408,7 @@ export default {
     this.jsonData = this.options.jsonData;
     this.dataName = this.options.dataName;
     this.selectedDataSource = this.options.selectedDataSource,
-    this.dataSourcesList = this.options.dataSourcesList,
     this.selectedEndPoint = this.options.selectedEndPoint,
-    this.endPointList = this.options.endPointList,
     this.key = this.options.key;
     this.value = this.options.value;
     this.pmqlQuery = this.options.pmqlQuery;
@@ -424,58 +423,31 @@ export default {
   },
   methods: {
     getDataSourceList() {
-      //If no ProcessMaker is found, datasources can't be loaded
-      if (typeof ProcessMaker === 'undefined') {
-        this.dataSourcesList = [];
-        return;
-      }
-
-      var currentDataSource = this.selectedDataSource;
-      ProcessMaker.apiClient
+      this.$dataProvider
         .get('/data_sources')
         .then(response => {
           let jsonData = response.data.data;
-          const convertToSelectOptions = option => ({
-            value: option['id'],
-            text: option['name'],
-          });
           // Map the data sources response to value/text items list
-          this.dataSourcesList = jsonData.map(convertToSelectOptions);
-          this.selectedDataSource = currentDataSource;
-        })
-        .catch(() => {
-          this.dataSourcesList = [];
+          this.dataSourcesList = jsonData.map(this.convertToSelectOptions);
+          this.setEndpointList(jsonData);
         });
     },
-
-    getEndPointsList() {
-      this.endPointList = [];
-      //If no ProcessMaker is found, datasources can't be loaded
-      if (typeof ProcessMaker === 'undefined'
-        || typeof this.selectedDataSource === 'undefined'
-        || this.selectedDataSource === '') {
-        return;
-      }
-
-      var currentEndPoint = this.selectedEndPoint;
-      ProcessMaker.apiClient
-        .get('/data_sources/' + this.selectedDataSource)
-        .then(response => {
-          let jsonData = response.data.endpoints;
-
-          for (var endpoint in jsonData) {
-            this.endPointList.push({
-              text: endpoint,
-              value: endpoint,
-            });
-          }
-
-          this.selectedEndPoint = currentEndPoint;
-        })
-        .catch(() => {
-          this.endPointList = [];
+    setEndpointList(dataSources) {
+      const endpoints = {};
+      dataSources.forEach(ds => {
+        endpoints[ds.id] = Object.keys(ds.endpoints).map(name => {
+          return { text: name, value: name };
         });
+      });
+      this.endpoints = endpoints;
     },
+    convertToSelectOptions(option) {
+      return {
+        value: option['id'],
+        text: option['name'],
+      };
+    },
+
     jsonDataChange() {
       let jsonList = [];
       try {

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -75,6 +75,7 @@ import { ValidatorFactory } from '../factories/ValidatorFactory';
 import currencies from '../currency.json';
 import Inputmask from 'inputmask';
 import Mustache from 'mustache';
+import DataProvider from '../DataProvider';
 
 const csstree = require('css-tree');
 const Scrollparent = require("scrollparent");
@@ -86,6 +87,7 @@ Vue.component('custom-css', {
 });
 
 Vue.use(VueDeepSet);
+Vue.use(DataProvider);
 
 export default {
   name: 'VueFormRenderer',

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ Vue.use(ScreenBuilder);
 const store = new Vuex.Store({ modules: {} });
 
 window.ProcessMaker = {
+  isStub: true,
   apiClient: {
     get(url) {
       return new Promise((resolve) => {


### PR DESCRIPTION
Re #747 

Requires https://github.com/ProcessMaker/processmaker/pull/3169

This PR adds a number of changes to the inspector as requested in https://github.com/ProcessMaker/package-data-sources/issues/76

From the issue:

- The value field seems to be empty after filling it out, saving, and reloading the screen builder
- Changing the content field does not always take effect in the Preview pane immediately
- It's not clear which fields accept mustache and which don't
- It's not clear whether dot notation is acceptable in either field

This PR attempts to address these issues with the following fixes:

- Fix the bug that causes the value field to empty
- Fix the bug that causes the preview pane to behave inconsistently
- Add an icon to the field(s) that accepts Mustache syntax
- Update the helper text to be more descriptive

The following where NOT addressed in this PR: 
- It's not clear whether dot notation is acceptable in either field
- Add sections to the inspector to make it less confusing
- Future: add autocomplete to display a list of fields returned from the data source