### PR TITLE
Refactor & Add Signature Package Support

### DIFF
--- a/src/components/inspector/image-variable.vue
+++ b/src/components/inspector/image-variable.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="form-group">
+    <form-checkbox :label="$t('Render image from a variable name')" v-model="renderImage"></form-checkbox>
+    <form-input v-if="renderImage" :label="$t('Variable Name')" v-model="imageName"></form-input>
+  </div>
+</template>
+
+<script>
+import { FormInput, FormCheckbox } from '@processmaker/vue-form-elements';
+
+export default {
+  props: ['value'],
+  components: {
+    FormInput,
+    FormCheckbox
+  },
+  data() {
+    return {
+      renderImage: false,
+      imageName: null,
+    };
+  },
+  computed: {
+    mode() {
+      return this.$root.$children[0].mode;
+    },
+  },
+  watch: {
+    value() {
+        if (this.value == undefined) {
+            this.renderImage = false;
+        } else  {
+            this.renderImage = true;
+            this.imageName = this.value;
+        }
+    },
+    imageName() {
+        this.$emit('input', this.imageName);
+    },
+    renderImage(value) {
+        if (!this.renderImage) {
+            this.renderImage = false;
+            this.imageName = null
+            this.$emit('input', this.imageName);
+        }
+    }
+  },
+  mounted() {
+    if (this.value) {
+        this.renderImage = true;
+        this.imageName = this.value;
+    }
+  }
+};
+</script>

--- a/src/components/inspector/index.js
+++ b/src/components/inspector/index.js
@@ -8,3 +8,4 @@ export { default as PageSelect } from './page-select';
 export { default as ValidationSelect } from './validation-select';
 export { default as ScreenSelector } from './screen-selector';
 export { default as LoopInspector } from './loop';
+export { default as ImageVariable } from './image-variable.vue';

--- a/src/components/renderer/form-image.vue
+++ b/src/components/renderer/form-image.vue
@@ -1,21 +1,17 @@
 <template>
   <div class="form-group form-image">
-    <img v-if="renderImage" :src="imageUrl" :name="variableName">
-    <img v-if="!renderImage && image" :src="image" :width="width" :height="height" :id="id">
-    <i v-else-if="mode == 'editor'" class="empty-image far fa-image" />
+    <img v-if="image" :src="image" :width="width" :height="height" :id="id">
+    <img v-else-if="imageUrl" :src="imageUrl" :width="width" :height="height" :id="id">
+    <i v-else class="empty-image far fa-image" />
   </div>
 </template>
 
 <script>
 import Vue from 'vue';
+import Mustache from 'mustache';
 
 export default {
-  props: ['id', 'image', 'width', 'height', 'name', 'renderImage', 'variableName'],
-  data() {
-    return {
-      imageUrl: null,
-    }
-  },
+  props: ['id', 'image', 'width', 'height', 'name', 'imageName', 'validationData'],
   computed: {
     classList() {
       let variant = this.variant || 'primary';
@@ -24,16 +20,17 @@ export default {
         ['btn-' + variant]: true,
       };
     },
-    mode() {
-      return this.$root.$children[0].mode;
-    },
   },
-  watch: {
-    mode() {
-      if (this.mode == 'editor') {
+  computed: {
+    imageUrl() {
+      if (!this.validationData) {
         return;
       }
-      this.displayRenderedImage();
+      try {
+        return Mustache.render('{' + this.imageName + '}', this.validationData);
+      } catch (error) {
+        return;
+      }
     },
   },
   methods: {
@@ -50,18 +47,7 @@ export default {
       }
       this.$emit(this.event, this.eventData);
     },
-    displayRenderedImage() {      
-      if (!this.renderImage) {
-        return;
-      }
-      if (this.$parent.data) {
-        this.imageUrl = this.$parent.data[this.variableName];
-      }
-    }
   },
-  mounted() {
-    this.displayRenderedImage();
-  }
 };
 </script>
 

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -506,19 +506,11 @@ export default [
         },
       },
       {
-        type: 'FormCheckbox',
-        field: 'renderImage',
+        type: 'ImageVariable',
+        field: 'imageName',
         config: {
-          label: 'Render image from a variable name',
+          label: 'Render from a variable name',
           helper: null,
-        },
-      },
-      {
-        type: 'FormInput',
-        field: 'variableName',
-        config: {
-          label: 'Variable Name',
-          helper: 'Variable of the image to render',
         },
       },
       helperTextProperty,


### PR DESCRIPTION
<h2>Changes</h2>

1. Refactor the inspector controls for rendering images using variable names. 
2. Add support for rendering base64 images used in the Signature Package. 

closes https://github.com/ProcessMaker/screen-builder/issues/757 & https://github.com/ProcessMaker/package-signature/issues/1
