### PR TITLE
Fix Select List Data Connector Error

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -21,8 +21,8 @@ export default {
     }
 
     // use a dummy api client
-    if (!this.axiosInstance) {
-      this.axiosInstance = {
+    if (!this.apiInstance) {
+      this.apiInstance = {
         get(...args) {
           return Promise.resolve({
             data: {

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -194,6 +194,7 @@ export default [
           optionsList: [],
           key:'value',
           value:'content',
+          valueTypeReturned: 'single'
         },
         helper: null,
       },


### PR DESCRIPTION
<h2>Changes</h2>

- Fix misnamed variable causing console error when selecting 'Data Connector' as a data source.

- Fix blank 'Type of value returned` select list.

closes #761 