### PR TITLE
Fix Default Values in Record Lists Modal

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -327,9 +327,6 @@ export default {
       this.$emit('input', data);
     },
     showAddForm() {
-      // Reset our add item
-      this.addItem = {};
-
       if (!this.form) {
         this.$refs.infoModal.show();
         return;

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -51,6 +51,7 @@
     <b-modal
       :static="true"
       @ok="handleOk"
+      @hidden="addItem = initFormValues"
       size="lg"
       v-if="editable && !selfReferenced"
       ref="addModal"
@@ -161,6 +162,7 @@ export default {
           return `<i class="${classes.join(' ')}"></i>`;
         },
       },
+      initFormValues: {},
     };
   },
   computed: {
@@ -334,6 +336,9 @@ export default {
       // Open form
       this.setUploadDataNamePrefix();
       this.$refs.addModal.show();
+
+      let {_parent, ...result} = this.addItem;
+      this.initFormValues = _.cloneDeep(result);
     },
     handleOk(bvModalEvt) {
       bvModalEvt.preventDefault();


### PR DESCRIPTION
<h2>Changes</h2>

Create an `initFormValue` object that restores default values when clearing modal fields. 

https://www.loom.com/share/ede3fb54b4fd434b8694ab99de282aad

<h2>To Test</h2>

- Create an editable Record List some default values
- Select the `Add` button and then select `cancel` or `x` buttons. 
- Select the `Add` button

**Expected Results**

The default value is visible. 

closes #769 