### PR TITLE
Fix Data Connector Select List

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -1,41 +1,32 @@
 import axios from 'axios';
-
 export default {
-  apiInstance: null,
   install(Vue, options) {
     Vue.prototype.$dataProvider = this;
-    
-    // make sure we're not using the stub in main.js
-    // temporary until the stub is moved here.
-    if (window && window.ProcessMaker && !window.ProcessMaker.isStub) {
-      this.apiInstance = window.ProcessMaker.apiClient;
-      return;
+  },
+  apiInstance() {
+    if (_.has(window, 'ProcessMaker.apiClient') && !window.ProcessMaker.isStub) {
+      return window.ProcessMaker.apiClient;
     }
-
-    if (this.token() && !this.apiInstance) {
+    if (this.token()) {
       axios.defaults.baseURL = this.baseURL();
       axios.defaults.headers.common = {
         'Authorization': 'Bearer ' + this.token(),
       };
-      this.apiInstance = axios;
+      return axios;
     }
-
     // use a dummy api client
-    if (!this.apiInstance) {
-      this.apiInstance = {
-        get(...args) {
-          return Promise.resolve({
-            data: {
-              data: []
-            }
-          });
-        },
-      }
+    return {
+      get(...args) {
+        return Promise.resolve({
+          data: {
+            data: []
+          }
+        });
+      },
     }
-
   },
   get(...args) {
-   return this.apiInstance.get(...args);
+   return this.apiInstance().get(...args);
   },
   token() {
     return localStorage.getItem('token');


### PR DESCRIPTION
<h2>Changes</h2>

The Api Instance variable was not being set and defaulting to an empty array due to how screen builder is being loaded. This PR converts the Api Instance variable to a function.

<h2>To Test</h2>

- Install the data connector package
- Create a data connector with endpoints
- Create a new form screen and add the select list control.
- Select the Data Sources accordion and select Data Connector in the drop-down.

**Expected Results**

The `Data Connector` & `Endpoint` select lists are populated with the created data connector.



closes #772  & https://github.com/ProcessMaker/package-data-sources/issues/95