### PR TITLE
Convert dataFormat to validation rule just for LineInputs

### DIFF
--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -46,7 +46,7 @@ export function ValidatorFactory(config, data) {
       }
 
       //If the element has dataformat configurated
-      if (item.config && item.config.name && item.config.dataFormat) {
+      if (item.component ===  'FormInput' && item.config && item.config.name && item.config.dataFormat ){
         validate.addRuleFormat(item.config.name, item.config.dataFormat);
       }
     });


### PR DESCRIPTION
Resolves [FOUR-1761](https://processmaker.atlassian.net/browse/FOUR-1761)

The code that converts dataFormats to validation rules has been restricted to LineInputs, so Select Lists (that generated the problem) aren't affected.


