### PR TITLE
Do not emit if parent var does not exist yet

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -177,7 +177,7 @@ export default {
       },
       set(val) {
         let { _parent, ...item } = val;
-        if (this.parentReference) {
+        if (this.parentReference && _parent) {
           this.$set(this.parentReference, 'transientData', _parent);
         }
         this.addItem = item;
@@ -193,7 +193,7 @@ export default {
       },
       set(val) {
         let { _parent, ...item } = val;
-        if (this.parentReference) {
+        if (this.parentReference && _parent) {
           this.$set(this.parentReference, 'transientData', _parent);
         }
         this.editItem = item;


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1742

The console errors were shown because a watcher was run when the component is mounted that emits the _parent variable,  but the parent variable was still undefined. The _parent variable is what allows a record to read and modify the main screen's data from within a record list entry.

This was showing a console error but did not effect functionality.

The fix was to check that the _parent variable exists before emitting it.