### PR TITLE
Remove the parent variable before handling default values

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -177,7 +177,7 @@ export default {
       },
       set(val) {
         let { _parent, ...item } = val;
-        if (this.parentReference) {
+        if (this.parentReference && _parent) {
           this.$set(this.parentReference, 'transientData', _parent);
         }
         this.addItem = item;
@@ -193,7 +193,7 @@ export default {
       },
       set(val) {
         let { _parent, ...item } = val;
-        if (this.parentReference) {
+        if (this.parentReference && _parent) {
           this.$set(this.parentReference, 'transientData', _parent);
         }
         this.editItem = item;

--- a/src/mixins/defaultValues.js
+++ b/src/mixins/defaultValues.js
@@ -80,6 +80,8 @@ export default {
         this.debug('R3');
         return;
       }
+
+      this.$delete(this.defaultsFormData, '_parent');
       
       this.lastSetTransientData = _.cloneDeep(this.defaultsFormData);
       this.transientData = _.cloneDeep(this.defaultsFormData);


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1819

The problem was in the order of operations when handling data changes in the loop control. The _parent variable, used for getting and modifying data outside the loop control, is supposed to be removed before handing changes back to parent. If it's not, it creates an endless loop. However, the default value mix-in was operating on the data before the _parent value was removed. The default value mix-in then would set the screen data, including the _parent variable, causing the endless loop.

The fix was to remove the _parent variable, if it exists, in the default values mix-in.

