### PR TITLE
Fix loops with same name freezing and auto-increment names

### DIFF
--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -43,6 +43,7 @@ export default {
       additionalItems: 0,
       transientDataCopy: null,
       parentObjectChanges: [],
+      lastSetMatrix: {},
     };
   },
   computed: {
@@ -132,14 +133,12 @@ export default {
     },
     matrix: {
       handler() {
-        let result = this.matrix.map(row => {
-          let rowCopy = _.clone(row);
-          delete rowCopy._parent;
-          return rowCopy;
-        });
-        this.$set(this.$parent.transientData, this.name, result);
-        
-        this.setChagnedParentVariables();
+        if (_.isEqual(this.lastSetMatrix, this.matrix)) {
+          return;
+        }
+
+        this.lastSetMatrix = _.cloneDeep(this.matrix);
+        this.$set(this.$parent.transientData, this.name, _.cloneDeep(this.matrix));
       },
       deep: true,
     },
@@ -194,8 +193,10 @@ export default {
       }
     },
     setMatrixValue(i, v) {
+      let { _parent, ...item } = v;
       this.registerParentVariableChanges(v);
-      this.$set(this.matrix, i, v);
+      this.$set(this.matrix, i, item);
+      this.setChagnedParentVariables();
     },
     registerParentVariableChanges(obj) {
       if (obj._parent) {
@@ -213,7 +214,7 @@ export default {
       this.parentObjectChanges = [];
     },
     getMatrixValue(i) {
-      let val = this.matrix[i];
+      let val = _.cloneDeep(this.matrix[i]);
       if (!val) {
         val = {};
       }

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -715,8 +715,11 @@ export default {
       }
 
       //Generate Variable Name
-      if (control.inspector.indexOf(keyNameProperty) !== -1) {
+      if (control.inspector.indexOf(keyNameProperty) !== -1 || control.component === 'FormLoop') {
         [this.variables, copy.config.name] = this.generator.generate(this.config, copy['editor-control'] ? copy['editor-control'] :  copy['component']);
+        if (_.has(copy, 'config.settings.varname')) {
+          copy.config.settings.varname = copy.config.name;
+        }
       }
 
       return copy;


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1832

There were 2 issues. First is that the the default variable names were not auto incrementing like they do for other controls so if you dragged 2 loops onto a screen with out configuring them, they would both have the name "loop".

The loop stores its config differently than other components so the name generator wasn't finding the variable name field.

The solution was to explicitly check if it's a loop control and set the generated value if it is.

Having 2 loops with the same name shouldn't be a problem but it was causing the page to freeze. This was caused by back-and-forth updates between the 2 loops that never finished.

The solution was to check if the loop value had changed after an update. If it did not change, do not try to update the data.