### PR TITLE
Only check FormInput for dataFormat validation in loop

### DIFF
--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -104,6 +104,7 @@ export function ValidatorFactory(config, data) {
 
       //If the element has dataformat configurated
       if (
+        itemLoop.component ===  'FormInput' &&
         itemLoop.config &&
         itemLoop.config.name &&
         itemLoop.config.dataFormat


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-1872

Data format validation should only be applied for FormInput control types.

A check for FormInput was added in https://github.com/ProcessMaker/screen-builder/commit/fcf79bfda6e90b4efebbe306c74c4d321cde8fe0 but it also needs to be added explicitly in the part that handles loops.