### PR TITLE
Select List not populating from a Data Source 

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -337,7 +337,6 @@ export default {
       }
       
       if (this.dataSourcesList.length > 0) {
-        console.log("SETTING TO DEFAULT selectedDataSource")
         this.selectedDataSource = this.dataSourcesList[0].value;
       }
     },

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -440,7 +440,8 @@ export default {
     setEndpointList(dataSources) {
       const endpoints = {};
       dataSources.forEach(ds => {
-        endpoints[ds.id] = Object.keys(ds.endpoints).map(name => {
+        const dsEndpoints = ds.endpoints ? ds.endpoints : [];
+        endpoints[ds.id] = Object.keys(dsEndpoints).map(name => {
           return { text: name, value: name };
         });
       });


### PR DESCRIPTION
Fixes [FOUR-1882](https://processmaker.atlassian.net/browse/FOUR-1882)

When filling the list of data connectors if there is one that doesn’t have endpoints,  a javascript error was generated. Code that handles this null condition has been added.

To test: 
- Create a data source and not add any endpoint to it
- Create a screen and add a select list. Afterwards select as source "Data Connector" 
- With the fix no error will be present in the console and any connector can be used as source.