### PR TITLE
Fix Required_if, Required_unless & Same validations in Loops

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -198,7 +198,7 @@ export default {
         },
         {
           value: '',
-          field: 'same:',
+          field: 'custom-same:',
           content: this.$t('Same'),
           helper: this.$t('The given field must match the field under validation.'),
           visible: true,

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -43,7 +43,6 @@ export default {
       additionalItems: 0,
       transientDataCopy: null,
       parentObjectChanges: [],
-      lastSetMatrix: {},
     };
   },
   computed: {
@@ -133,11 +132,11 @@ export default {
     },
     matrix: {
       handler() {
-        if (_.isEqual(this.lastSetMatrix, this.matrix)) {
+        if (_.isEqual(lastSetMatrix, this.matrix)) {
           return;
         }
 
-        this.lastSetMatrix = _.cloneDeep(this.matrix);
+        const lastSetMatrix = _.cloneDeep(this.matrix);
         this.$set(this.$parent.transientData, this.name, _.cloneDeep(this.matrix));
       },
       deep: true,

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -43,6 +43,7 @@ export default {
       additionalItems: 0,
       transientDataCopy: null,
       parentObjectChanges: [],
+      lastSetMatrix: {}
     };
   },
   computed: {
@@ -132,11 +133,10 @@ export default {
     },
     matrix: {
       handler() {
-        if (_.isEqual(lastSetMatrix, this.matrix)) {
+        if (_.isEqual(this.lastSetMatrix, this.matrix)) {
           return;
         }
-
-        const lastSetMatrix = _.cloneDeep(this.matrix);
+        this.lastSetMatrix = _.cloneDeep(this.matrix);
         this.$set(this.$parent.transientData, this.name, _.cloneDeep(this.matrix));
       },
       deep: true,
@@ -237,5 +237,8 @@ export default {
       this.$emit('submit');
     },
   },
+  mounted() {
+    this.$set(this.$parent.transientData, this.name, _.cloneDeep(this.matrix));
+  }
 };
 </script>

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -43,7 +43,6 @@ export default {
       additionalItems: 0,
       transientDataCopy: null,
       parentObjectChanges: [],
-      lastSetMatrix: {}
     };
   },
   computed: {
@@ -133,10 +132,9 @@ export default {
     },
     matrix: {
       handler() {
-        if (_.isEqual(this.lastSetMatrix, this.matrix)) {
+        if (_.isEqual(this.$parent.transientData[this.name], this.matrix)) {
           return;
         }
-        this.lastSetMatrix = _.cloneDeep(this.matrix);
         this.$set(this.$parent.transientData, this.name, _.cloneDeep(this.matrix));
       },
       deep: true,

--- a/src/factories/CustomValidationRules.js
+++ b/src/factories/CustomValidationRules.js
@@ -1,0 +1,59 @@
+const Validator = require('validatorjs');
+import moment from 'moment-timezone';
+
+Validator.register('custom-same', function(val, req) {
+    let val1;
+    let val2 = val;
+    if (!req.includes('.')) {
+      val1 = this.validator._flattenObject(this.validator.input)[req];
+    } else {
+      val1 = req.split('.').reduce((obj,i)=>obj[i], this.validator.input);
+    }
+    console.log('here', this.validator.input, req, val2);
+  
+    if (val1 === val2) {
+      return true;
+    }
+  
+    return false;
+}, 'The :attribute and :custom-same fields must match.');
+  
+Validator.register('after', function(date, params) {
+    // checks if incoming 'params' is a date or a key reference.
+    let checkDate = moment(params);
+    
+    const inputDate = moment(date).toISOString();
+    const afterDate = moment(params).toISOString();
+
+    return inputDate > afterDate;
+}, 'The :attribute must be after :after.');
+
+Validator.register('after_or_equal', function(date, params) {
+    // checks if incoming 'params' is a date or a key reference.
+    let checkDate = moment(params);
+    
+    const inputDate = moment(date).toISOString();
+    const equalOrAfterDate = moment(params).toISOString();
+    
+    return inputDate >= equalOrAfterDate;
+}, 'The :attribute must be equal or after :after_or_equal.');
+
+Validator.register('before', function(date, params) {
+    // checks if incoming 'params' is a date or a key reference.
+    let checkDate = moment(params);
+    
+    const inputDate = moment(date).toISOString();
+    const beforeDate = moment(params).toISOString();
+    
+    return inputDate < beforeDate;
+}, 'The :attribute must be before :before.');
+
+Validator.register('before_or_equal', function(date, params) {
+    // checks if incoming 'params' is a date or a key reference.
+    let checkDate = moment(params);
+    
+    const inputDate = moment(date).toISOString();
+    const beforeDate = moment(params).toISOString();
+    
+    return inputDate <= beforeDate;
+}, 'The :attribute must be equal or before :before_or_equal.');

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -106,7 +106,10 @@ export function ValidatorFactory(config, data) {
           let fieldName = validation.value.split(':')[1];
           let newValidationRule;
           if (rule.includes('required_') || rule.includes('same')) {
-            if (!fieldName.includes(',')) {
+            if (fieldName.includes('_parent')) {
+              fieldName = fieldName.split('_parent.').pop();
+              newValidationRule = rule + ':' + fieldName;
+            } else if (!fieldName.includes(',')) {
               newValidationRule = rule + ':' + loopName + '.*.' + fieldName;
             } else {
               fieldName = fieldName.split(',')[0];

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -98,15 +98,24 @@ export function ValidatorFactory(config, data) {
       ) {
         
         itemLoop.config.validation.forEach(validation => {
-          let newValidationRule;
+          if (!validation.value.includes(':')) {
+            return;
+          } 
           const rule = validation.value.split(':')[0];
-          const fieldName = validation.value.split(':')[1].split(',')[0];
-          const fieldValue = validation.value.split(':')[1].split(',')[1];
-          newValidationRule = rule + ':' + loopName + '.*.' + fieldName + ',' + fieldValue;
-          
-          validation.value = newValidationRule
+          let fieldName = validation.value.split(':')[1];
+          let newValidationRule;
+          if (rule.includes('required_') || rule.includes('same')) {
+            if (!fieldName.includes(',')) {
+              newValidationRule = rule + ':' + loopName + '.*.' + fieldName;
+            } else {
+              fieldName = fieldName.split(',')[0];
+              const fieldValue = validation.value.split(':')[1].split(',')[1];
+              newValidationRule = rule + ':' + loopName + '.*.' + fieldName + ',' + fieldValue;
+            }
+            validation.value = newValidationRule;  
+          }
         });
-        
+
         validate.addRule(
           loopName + '.*.' + itemLoop.config.name,
           itemLoop.config.validation

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -106,7 +106,6 @@ export function ValidatorFactory(config, data) {
           
           validation.value = newValidationRule
         });
-        console.log('validation', itemLoop.config);
         
         validate.addRule(
           loopName + '.*.' + itemLoop.config.name,

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -1,3 +1,4 @@
+import customValidationRules from './CustomValidationRules';
 const Validator = require('validatorjs');
 
 export function ValidatorFactory(config, data) {

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -96,6 +96,18 @@ export function ValidatorFactory(config, data) {
         itemLoop.config.name &&
         itemLoop.config.validation
       ) {
+        
+        itemLoop.config.validation.forEach(validation => {
+          let newValidationRule;
+          const rule = validation.value.split(':')[0];
+          const fieldName = validation.value.split(':')[1].split(',')[0];
+          const fieldValue = validation.value.split(':')[1].split(',')[1];
+          newValidationRule = rule + ':' + loopName + '.*.' + fieldName + ',' + fieldValue;
+          
+          validation.value = newValidationRule
+        });
+        console.log('validation', itemLoop.config);
+        
         validate.addRule(
           loopName + '.*.' + itemLoop.config.name,
           itemLoop.config.validation


### PR DESCRIPTION
Closes Jira Tickets

- [FOUR-1814](https://processmaker.atlassian.net/browse/FOUR-1814)
- [FOUR-1813](https://processmaker.atlassian.net/browse/FOUR-1813)
- [FOUR-1811](https://processmaker.atlassian.net/browse/FOUR-1811)
- [FOUR-1790](https://processmaker.atlassian.net/browse/FOUR-1790)

This PR fixes the following validations in a Loop control:
`required_if`, `required_unless` & `same`

Issue was due to the validation not running on nested values.

<h2>Changes</h2>

- Register new `custom-same` validation to replace Validator JS `same` validation. 
- Fixes nested validation values to include the loop control name and index.
- Include all missing custom validations with screen builder.
- Fixes the`transientData`variable  from returning empty when mounting a loop element



<h2>Dependency</h2>
https://github.com/ProcessMaker/vue-form-elements/pull/212

<h2>Video</h2>
<a href="https://www.loom.com/share/969f0db8f75d47fa9970887f85a44e27"> <p>Edit Screen - ProcessMaker - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/969f0db8f75d47fa9970887f85a44e27-with-play.gif"> </a>

<h2>To Test</h2>

1. Add two input controls inside a loop control
2. Add the validation rule to the second control, configured to point at the first control. Example: `form_input_2` is required if `form_input_1` has a variable value of `foobar`
4. Add a submit button and preview the form
5. Add a matching string to the first control, then press submit

**Expected Behavior**

Validation error displays for the second control and the form does not submit.
