### PR TITLE
Fix screen freezing when calculated property returns an array

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -33,10 +33,37 @@ export default {
       if (object && value !== undefined) {
         const splittedName = name.split('.');
         splittedName.forEach((attr, index) => {
-          const setValue = index < splittedName.length - 1 ? get(object, attr) || get(defaults, attr) || {} : value;
-          if (isEqual(setValue, get(object, attr))) {
+
+          let isLastElement, setValue;
+          const originalValue = get(object, attr);
+
+          if (index === splittedName.length - 1) {
+            isLastElement = true;
+          } else {
+            isLastElement = false;
+          }
+
+          if (isLastElement) {
+            setValue = value;
+
+          } else {
+            setValue = originalValue;
+
+            if (!setValue) {
+              // Check defaults
+              setValue = get(defaults, attr);
+            }
+            
+            if (!setValue) {
+              // Still no value? Set empty object
+              setValue = {};
+            }
+          }
+
+          if (isLastElement && isEqual(setValue, originalValue)) {
             return;
-          } 
+          }
+
           this.$set(
             object,
             attr,

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash';
+import { get, isEqual } from 'lodash';
 import Mustache from 'mustache';
 import { ValidationMsg } from './ValidationRules';
 
@@ -33,10 +33,14 @@ export default {
       if (object && value !== undefined) {
         const splittedName = name.split('.');
         splittedName.forEach((attr, index) => {
+          const setValue = index < splittedName.length - 1 ? get(object, attr) || get(defaults, attr) || {} : value;
+          if (isEqual(setValue, get(object, attr))) {
+            return;
+          } 
           this.$set(
             object,
             attr,
-            index < splittedName.length - 1 ? get(object, attr) || get(defaults, attr) || {} : value
+            setValue
           );
           object = get(object, attr);
         });


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2148

The watcher was being re-triggered when a value was set even if it was the same. This was only effecting arrays, not single values. Added logic to check if the values are the same.