### PR TITLE
Add file upload and download to the default form controls

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -6,6 +6,8 @@ import FormRecordList from './components/renderer/form-record-list';
 import FormImage from './components/renderer/form-image';
 import FormMaskedInput from './components/renderer/form-masked-input';
 import FormNestedScreen from './components/renderer/form-nested-screen';
+import FileUpload from './components/renderer/file-upload';
+import FileDownload from './components/renderer/file-download';
 import {DataTypeProperty, DataFormatProperty, DataTypeDateTimeProperty} from './VariableDataTypeProperties';
 import {
   FormInput,
@@ -616,4 +618,89 @@ export default [
       ],
     },
   },
+  {
+    rendererComponent: FileUpload,
+    rendererBinding: "FileUpload",
+    builderComponent: FileUpload,
+    builderBinding: "FileUpload",
+    control: {
+      label: "File Upload",
+      component: "FileUpload",
+      "editor-component": "FileUpload",
+      "editor-control": "FileUpload",
+      config: {
+        label: "New File Upload",
+        icon: "fas fa-file-upload"
+      },
+      inspector: [
+        {
+          type: "FormInput",
+          field: "name",
+          config: {
+            label: "Variable Name",
+            name: 'Name',
+            helper: "A variable name is a symbolic name to reference information.",
+            validation: 'regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_. \/a-z])*$/|required'
+          }
+        },
+        {
+          type: "FormInput",
+          field: "label",
+          config: {
+            label: "Label",
+            helper: "The label describes the field's name"
+          }
+        },
+        {
+          type: "FormInput",
+          field: "accept",
+          config: {
+            label: "File Accepted",
+            helper: "Common file types: application/msword, image/gif, image/jpeg, application/pdf, application/vnd.ms-powerpoint, application/vnd.ms-excel, text/plain"
+          }
+        },
+        {
+          type: 'RequiredCheckbox',
+          field: 'validation',
+          config: {
+            label: 'Required',
+            helper: 'Prevent form from being submitted unless a file is uploaded'
+          }
+        }
+      ]
+    }
+  },
+  {
+    rendererComponent: FormText,
+    rendererBinding: "FormText",
+    builderComponent: FileDownload,
+    builderBinding: "FileDownload",
+    control: {
+        label: "File Download",
+        component: "FileDownload",
+        "editor-component": "FormText",
+        "editor-control": "FileDownload",
+        config: {
+            label: "New File Download",
+            icon: "fas fa-file-download"
+        },
+        inspector: [{
+            type: "FormInput",
+            field: "label",
+            config: {
+                label: "Label",
+                helper: "The text to display"
+            }
+        },
+        {
+            type: "FormInput",
+            field: "name",
+            config: {
+                label: "Name",
+                helper: "The name of the Download"
+            }
+        }
+        ]
+    }
+  }
 ];


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2294
Requires https://github.com/ProcessMaker/processmaker/pull/3491

Adds the file upload and download screen builder controls to the list of default controls after the components were moved into screen builder