### PR TITLE
Fix computed properties not working in record lists

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -73,6 +73,7 @@
         ref="addRenderer"
         v-model="addItem"
         :config="[formConfig[form]]"
+        :computed="formComputed"
         debug-context="Record List Add"
         :key="Array.isArray(value) ? value.length : 0"
         :_parent="validationData"
@@ -95,6 +96,7 @@
         ref="editRenderer"
         v-model="editItem"
         :config="[formConfig[form]]"
+        :computed="formComputed"
         debug-context="Record List Edit"
         :_parent="validationData"
       />
@@ -146,7 +148,7 @@ const jsonOptionsActionsColumn = {
 
 export default {
   mixins: [mustacheEvaluation],
-  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig'],
+  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig', 'formComputed'],
   data() {
     return {
       single: '',

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -24,6 +24,7 @@ export default {
       properties.name = element.config.name !== undefined ? element.config.name : null;
       properties.disabled = element.config.interactive || element.config.disabled;
       properties[':form-config'] = this.byRef(this.configRef || definition.config);
+      properties[':form-computed'] = JSON.stringify(definition.computed);
       // Events
       properties['@submit'] = 'submitForm';
     },


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2221

- Pass in computed prop settings to all components as `formComputed`
- In the form-record-list component, pass it to vue-form-renderer for add and edit modals