### PR TITLE
Setup watchers after the component mounts so defaults are already set

### DIFF
--- a/src/mixins/extensions/Watchers.js
+++ b/src/mixins/extensions/Watchers.js
@@ -13,7 +13,7 @@ export default {
       if (definition.watchers) {
         screen.mixins.push(watchersMixin);
         definition.watchers.forEach((watcher) => {
-          this.addWatch(screen, watcher.watching, `this.queueWatcher(${JSON.stringify(watcher)});`);
+          this.addMounted(screen, 'var that = this; this.$watch("' + watcher.watching + '", function() { that.queueWatcher(' + JSON.stringify(watcher) + '); });');
         });
       }
     },

--- a/src/mixins/extensions/Watchers.js
+++ b/src/mixins/extensions/Watchers.js
@@ -13,7 +13,11 @@ export default {
       if (definition.watchers) {
         screen.mixins.push(watchersMixin);
         definition.watchers.forEach((watcher) => {
-          this.addMounted(screen, 'var that = this; this.$watch("' + watcher.watching + '", function() { that.queueWatcher(' + JSON.stringify(watcher) + '); });');
+          this.addMounted(screen, `
+            this.$watch('${watcher.watching}', () => {
+              this.queueWatcher(${JSON.stringify(watcher)});
+            });
+          `);
         });
       }
     },


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2367

The watchers were being set up before the defaults were set. This caused the watcher to fire when the defaults were set. Since theres no guarantee what order the extensions are run in, this PR sets up the watchers to listen for changes after the component is mounted (after all the extensions have run)