### PR TITLE
Bootstrap vue table field key should be label, not title

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -141,7 +141,7 @@ import _ from 'lodash';
 
 const jsonOptionsActionsColumn = {
   key: '__actions',
-  title: 'Actions',
+  label: 'Actions',
   thClass: 'text-right',
   tdClass: 'text-right',
 };
@@ -261,7 +261,7 @@ export default {
         return {
           key: option[key || 'value'],
           sortable: true,
-          title: option[value || 'content'],
+          label: option[value || 'content'],
         };
       };
 


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2415

The key name for setting a table header title was wrong. It's supposed to be `label`