### PR TITLE
Fix computed property freeze when used in default value

### DIFF
--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -172,6 +172,9 @@ export default {
     validVariableName(name) {
       return name && typeof name === 'string' && name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/);
     },
+    isComputedVariable(name, definition) {
+      return definition.computed && definition.computed.find(c => c.property === name);
+    },
     registerVariable(name, config = {}) {
       if (!this.validVariableName(name)) {
         return;

--- a/src/mixins/extensions/DataManager.js
+++ b/src/mixins/extensions/DataManager.js
@@ -2,7 +2,7 @@
 export default {
   methods: {
     dataFields(screen, definition) {
-      this.variables.filter(v => !(definition.computed && definition.computed.find(c => c.property === v.name)))
+      this.variables.filter(v => !this.isComputedVariable(v.name, definition))
         .forEach(v => {
           this.addData(screen, v.name, `this.getValue(${JSON.stringify(v.name)}, this.vdata) || this.getValue(${JSON.stringify(v.name)}, data) || null`);
           this.addWatch(screen, v.name, `this.setValue(${JSON.stringify(v.name)}, value, this.vdata);`);

--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -5,8 +5,9 @@ export default {
      * Prepare `data` configuration for the Vue Screen Component
      *
      */
-    defaultValues(screen) {
+    defaultValues(screen, definition) {
       this.variables.forEach(({name, config}) => {
+        if (this.isComputedVariable(name, definition)) return;
         if (config.defaultValue) {
           if (config.defaultValue.mode === 'basic') {
             this.setupDefaultValue(screen, name, `this.mustache(${JSON.stringify(config.defaultValue.value)})`);
@@ -38,11 +39,12 @@ export default {
   },
   mounted() {
     this.extensions.push({
-      onbuild({ screen }) {
-        this.defaultValues(screen);
+      onbuild({ screen, definition }) {
+        this.defaultValues(screen, definition);
       },
-      onloadproperties({ properties, element }) {
+      onloadproperties({ properties, element, definition }) {
         const name = element.config.name;
+        if (this.isComputedVariable(name, definition)) return;
         if (element.config.defaultValue || element.config.initiallyChecked) {
           const event = `${name}_was_filled__ |= !!$event; !${name}_was_filled__ && (vdata.${name} = default_${name}__)`;
           this.addEvent(properties, 'input', event);

--- a/tests/e2e/fixtures/default_values_with_computed_fields.json
+++ b/tests/e2e/fixtures/default_values_with_computed_fields.json
@@ -1,0 +1,1055 @@
+{
+    "type": "screen_package",
+    "version": "2",
+    "screens": [
+        {
+            "id": 364,
+            "screen_category_id": "1",
+            "title": "New Screen Freeze",
+            "description": "New Screen Freeze",
+            "type": "FORM",
+            "config": [
+                {
+                    "name": "New Screen Freeze",
+                    "items": [
+                        {
+                            "label": "Line Input",
+                            "config": {
+                                "icon": "far fa-square",
+                                "name": "uno",
+                                "type": "text",
+                                "label": "uno",
+                                "helper": null,
+                                "dataMask": {
+                                    "code": "NGN",
+                                    "name": "Nigeria, Naira",
+                                    "format": "#,###.##",
+                                    "symbol": null
+                                },
+                                "readonly": false,
+                                "dataFormat": "currency",
+                                "validation": [],
+                                "placeholder": null,
+                                "defaultValue": {
+                                    "mode": "basic",
+                                    "value": "{{ varA }}"
+                                }
+                            },
+                            "component": "FormInput",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:\/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$\/|required|not_in:break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the field's name"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "dataFormat",
+                                    "config": {
+                                        "name": "Data Type",
+                                        "label": "Data Type",
+                                        "helper": "The data type specifies what kind of data is stored in the variable.",
+                                        "options": [
+                                            {
+                                                "value": "string",
+                                                "content": "Text"
+                                            },
+                                            {
+                                                "value": "int",
+                                                "content": "Integer"
+                                            },
+                                            {
+                                                "value": "currency",
+                                                "content": "Currency"
+                                            },
+                                            {
+                                                "value": "percentage",
+                                                "content": "Percentage"
+                                            },
+                                            {
+                                                "value": "float",
+                                                "content": "Decimal"
+                                            },
+                                            {
+                                                "value": "datetime",
+                                                "content": "Datetime"
+                                            },
+                                            {
+                                                "value": "date",
+                                                "content": "Date"
+                                            },
+                                            {
+                                                "value": "password",
+                                                "content": "Password"
+                                            }
+                                        ],
+                                        "validation": "required"
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "extends": {
+                                            "props": [
+                                                "label",
+                                                "error",
+                                                "options",
+                                                "helper",
+                                                "name",
+                                                "value",
+                                                "selectedControl"
+                                            ],
+                                            "mixins": [
+                                                {
+                                                    "props": {
+                                                        "validation": {
+                                                            "type": null
+                                                        },
+                                                        "validationData": {
+                                                            "type": null
+                                                        },
+                                                        "validationField": {
+                                                            "type": null
+                                                        },
+                                                        "validationMessages": {
+                                                            "type": null
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "validationData": {
+                                                            "deep": true
+                                                        }
+                                                    },
+                                                    "methods": []
+                                                }
+                                            ],
+                                            "methods": [],
+                                            "computed": [],
+                                            "_compiled": true,
+                                            "components": {
+                                                "Multiselect": {
+                                                    "name": "vue-multiselect",
+                                                    "props": {
+                                                        "name": {
+                                                            "default": null
+                                                        },
+                                                        "limit": {
+                                                            "default": 99999
+                                                        },
+                                                        "loading": {
+                                                            "default": false
+                                                        },
+                                                        "disabled": {
+                                                            "default": false
+                                                        },
+                                                        "tabindex": {
+                                                            "default": 0
+                                                        },
+                                                        "limitText": [],
+                                                        "maxHeight": {
+                                                            "default": 300
+                                                        },
+                                                        "showLabels": {
+                                                            "default": true
+                                                        },
+                                                        "selectLabel": {
+                                                            "default": "Press enter to select"
+                                                        },
+                                                        "deselectLabel": {
+                                                            "default": "Press enter to remove"
+                                                        },
+                                                        "openDirection": {
+                                                            "default": null
+                                                        },
+                                                        "selectedLabel": {
+                                                            "default": "Selected"
+                                                        },
+                                                        "showNoOptions": {
+                                                            "default": true
+                                                        },
+                                                        "showNoResults": {
+                                                            "default": true
+                                                        },
+                                                        "selectGroupLabel": {
+                                                            "default": "Press enter to select group"
+                                                        },
+                                                        "deselectGroupLabel": {
+                                                            "default": "Press enter to deselect group"
+                                                        }
+                                                    },
+                                                    "mixins": [
+                                                        {
+                                                            "props": {
+                                                                "id": {
+                                                                    "default": null
+                                                                },
+                                                                "max": {
+                                                                    "type": [
+                                                                        null,
+                                                                        null
+                                                                    ],
+                                                                    "default": false
+                                                                },
+                                                                "label": [],
+                                                                "value": {
+                                                                    "type": null
+                                                                },
+                                                                "options": {
+                                                                    "required": true
+                                                                },
+                                                                "trackBy": [],
+                                                                "multiple": {
+                                                                    "default": false
+                                                                },
+                                                                "taggable": {
+                                                                    "default": false
+                                                                },
+                                                                "blockKeys": [],
+                                                                "allowEmpty": {
+                                                                    "default": true
+                                                                },
+                                                                "groupLabel": [],
+                                                                "resetAfter": {
+                                                                    "default": false
+                                                                },
+                                                                "searchable": {
+                                                                    "default": true
+                                                                },
+                                                                "customLabel": [],
+                                                                "groupSelect": {
+                                                                    "default": false
+                                                                },
+                                                                "groupValues": [],
+                                                                "placeholder": {
+                                                                    "default": "Select option"
+                                                                },
+                                                                "tagPosition": {
+                                                                    "default": "top"
+                                                                },
+                                                                "hideSelected": {
+                                                                    "default": false
+                                                                },
+                                                                "optionsLimit": {
+                                                                    "default": 1000
+                                                                },
+                                                                "clearOnSelect": {
+                                                                    "default": true
+                                                                },
+                                                                "closeOnSelect": {
+                                                                    "default": true
+                                                                },
+                                                                "internalSearch": {
+                                                                    "default": true
+                                                                },
+                                                                "preselectFirst": {
+                                                                    "default": false
+                                                                },
+                                                                "preserveSearch": {
+                                                                    "default": false
+                                                                },
+                                                                "tagPlaceholder": {
+                                                                    "default": "Press enter to create a tag"
+                                                                }
+                                                            },
+                                                            "watch": [],
+                                                            "methods": [],
+                                                            "computed": []
+                                                        },
+                                                        {
+                                                            "props": {
+                                                                "showPointer": {
+                                                                    "default": true
+                                                                },
+                                                                "optionHeight": {
+                                                                    "default": 40
+                                                                }
+                                                            },
+                                                            "watch": [],
+                                                            "methods": [],
+                                                            "computed": []
+                                                        }
+                                                    ],
+                                                    "computed": [],
+                                                    "_compiled": true,
+                                                    "beforeCreate": [
+                                                        null
+                                                    ],
+                                                    "staticRenderFns": []
+                                                }
+                                            },
+                                            "inheritAttrs": false,
+                                            "staticRenderFns": []
+                                        },
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "dataMask",
+                                    "config": {
+                                        "name": "Data Format",
+                                        "label": "Data Format",
+                                        "helper": "The data format for the selected type."
+                                    }
+                                },
+                                {
+                                    "type": "ValidationSelect",
+                                    "field": "validation",
+                                    "config": {
+                                        "label": "Validation Rules",
+                                        "helper": "The validation rules needed for this field"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "placeholder",
+                                    "config": {
+                                        "label": "Placeholder Text",
+                                        "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "helper",
+                                    "config": {
+                                        "label": "Helper Text",
+                                        "helper": "Help text is meant to provide additional guidance on the field's value"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "readonly",
+                                    "config": {
+                                        "label": "Read Only",
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "props": [
+                                            "value"
+                                        ],
+                                        "watch": {
+                                            "value": {
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "_scopeId": "data-v-5d32d6af",
+                                        "computed": {
+                                            "effectiveValue": []
+                                        },
+                                        "_compiled": true,
+                                        "components": {
+                                            "MonacoEditor": {
+                                                "name": "monaco-editor",
+                                                "_Ctor": [],
+                                                "props": {
+                                                    "amdRequire": []
+                                                },
+                                                "extends": {
+                                                    "name": "MonacoEditor",
+                                                    "model": {
+                                                        "event": "change"
+                                                    },
+                                                    "props": {
+                                                        "theme": {
+                                                            "default": "vs"
+                                                        },
+                                                        "value": {
+                                                            "required": true
+                                                        },
+                                                        "options": [],
+                                                        "language": [],
+                                                        "original": [],
+                                                        "amdRequire": [],
+                                                        "diffEditor": {
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "options": {
+                                                            "deep": true,
+                                                            "user": true
+                                                        }
+                                                    },
+                                                    "methods": []
+                                                },
+                                                "methods": []
+                                            }
+                                        },
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "defaultValue",
+                                    "config": {
+                                        "label": "Default Value",
+                                        "helper": "Takes precedence over value set in data."
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormInput",
+                            "editor-component": "FormInput"
+                        },
+                        {
+                            "label": "Line Input",
+                            "config": {
+                                "icon": "far fa-square",
+                                "name": "res",
+                                "type": "text",
+                                "label": "res",
+                                "helper": null,
+                                "readonly": false,
+                                "dataFormat": "string",
+                                "validation": [],
+                                "placeholder": null,
+                                "defaultValue": {
+                                    "mode": "basic",
+                                    "value": null
+                                }
+                            },
+                            "component": "FormInput",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:\/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$\/|required|not_in:break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the field's name"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "dataFormat",
+                                    "config": {
+                                        "name": "Data Type",
+                                        "label": "Data Type",
+                                        "helper": "The data type specifies what kind of data is stored in the variable.",
+                                        "options": [
+                                            {
+                                                "value": "string",
+                                                "content": "Text"
+                                            },
+                                            {
+                                                "value": "int",
+                                                "content": "Integer"
+                                            },
+                                            {
+                                                "value": "currency",
+                                                "content": "Currency"
+                                            },
+                                            {
+                                                "value": "percentage",
+                                                "content": "Percentage"
+                                            },
+                                            {
+                                                "value": "float",
+                                                "content": "Decimal"
+                                            },
+                                            {
+                                                "value": "datetime",
+                                                "content": "Datetime"
+                                            },
+                                            {
+                                                "value": "date",
+                                                "content": "Date"
+                                            },
+                                            {
+                                                "value": "password",
+                                                "content": "Password"
+                                            }
+                                        ],
+                                        "validation": "required"
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "_Ctor": [],
+                                        "extends": {
+                                            "_Ctor": [],
+                                            "props": {
+                                                "name": {
+                                                    "type": null
+                                                },
+                                                "error": {
+                                                    "type": null
+                                                },
+                                                "label": {
+                                                    "type": null
+                                                },
+                                                "value": {
+                                                    "type": null
+                                                },
+                                                "helper": {
+                                                    "type": null
+                                                },
+                                                "options": {
+                                                    "type": null
+                                                },
+                                                "selectedControl": {
+                                                    "type": null
+                                                }
+                                            },
+                                            "mixins": [
+                                                {
+                                                    "props": {
+                                                        "validation": {
+                                                            "type": null
+                                                        },
+                                                        "validationData": {
+                                                            "type": null
+                                                        },
+                                                        "validationField": {
+                                                            "type": null
+                                                        },
+                                                        "validationMessages": {
+                                                            "type": null
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "validationData": {
+                                                            "deep": true,
+                                                            "user": true
+                                                        }
+                                                    },
+                                                    "methods": []
+                                                }
+                                            ],
+                                            "methods": [],
+                                            "computed": [],
+                                            "_compiled": true,
+                                            "components": {
+                                                "Multiselect": {
+                                                    "name": "vue-multiselect",
+                                                    "_Ctor": [],
+                                                    "props": {
+                                                        "name": {
+                                                            "default": null
+                                                        },
+                                                        "limit": {
+                                                            "default": 99999
+                                                        },
+                                                        "loading": {
+                                                            "default": false
+                                                        },
+                                                        "disabled": {
+                                                            "default": false
+                                                        },
+                                                        "tabindex": {
+                                                            "default": 0
+                                                        },
+                                                        "limitText": [],
+                                                        "maxHeight": {
+                                                            "default": 300
+                                                        },
+                                                        "showLabels": {
+                                                            "default": true
+                                                        },
+                                                        "selectLabel": {
+                                                            "default": "Press enter to select"
+                                                        },
+                                                        "deselectLabel": {
+                                                            "default": "Press enter to remove"
+                                                        },
+                                                        "openDirection": {
+                                                            "default": null
+                                                        },
+                                                        "selectedLabel": {
+                                                            "default": "Selected"
+                                                        },
+                                                        "showNoOptions": {
+                                                            "default": true
+                                                        },
+                                                        "showNoResults": {
+                                                            "default": true
+                                                        },
+                                                        "selectGroupLabel": {
+                                                            "default": "Press enter to select group"
+                                                        },
+                                                        "deselectGroupLabel": {
+                                                            "default": "Press enter to deselect group"
+                                                        }
+                                                    },
+                                                    "mixins": [
+                                                        {
+                                                            "props": {
+                                                                "id": {
+                                                                    "default": null
+                                                                },
+                                                                "max": {
+                                                                    "type": [
+                                                                        null,
+                                                                        null
+                                                                    ],
+                                                                    "default": false
+                                                                },
+                                                                "label": [],
+                                                                "value": {
+                                                                    "type": null
+                                                                },
+                                                                "options": {
+                                                                    "required": true
+                                                                },
+                                                                "trackBy": [],
+                                                                "multiple": {
+                                                                    "default": false
+                                                                },
+                                                                "taggable": {
+                                                                    "default": false
+                                                                },
+                                                                "blockKeys": [],
+                                                                "allowEmpty": {
+                                                                    "default": true
+                                                                },
+                                                                "groupLabel": [],
+                                                                "resetAfter": {
+                                                                    "default": false
+                                                                },
+                                                                "searchable": {
+                                                                    "default": true
+                                                                },
+                                                                "customLabel": [],
+                                                                "groupSelect": {
+                                                                    "default": false
+                                                                },
+                                                                "groupValues": [],
+                                                                "placeholder": {
+                                                                    "default": "Select option"
+                                                                },
+                                                                "tagPosition": {
+                                                                    "default": "top"
+                                                                },
+                                                                "hideSelected": {
+                                                                    "default": false
+                                                                },
+                                                                "optionsLimit": {
+                                                                    "default": 1000
+                                                                },
+                                                                "clearOnSelect": {
+                                                                    "default": true
+                                                                },
+                                                                "closeOnSelect": {
+                                                                    "default": true
+                                                                },
+                                                                "internalSearch": {
+                                                                    "default": true
+                                                                },
+                                                                "preselectFirst": {
+                                                                    "default": false
+                                                                },
+                                                                "preserveSearch": {
+                                                                    "default": false
+                                                                },
+                                                                "tagPlaceholder": {
+                                                                    "default": "Press enter to create a tag"
+                                                                }
+                                                            },
+                                                            "watch": [],
+                                                            "methods": [],
+                                                            "computed": []
+                                                        },
+                                                        {
+                                                            "props": {
+                                                                "showPointer": {
+                                                                    "default": true
+                                                                },
+                                                                "optionHeight": {
+                                                                    "default": 40
+                                                                }
+                                                            },
+                                                            "watch": [],
+                                                            "methods": [],
+                                                            "computed": []
+                                                        }
+                                                    ],
+                                                    "computed": [],
+                                                    "_compiled": true,
+                                                    "beforeCreate": [
+                                                        null
+                                                    ],
+                                                    "staticRenderFns": []
+                                                }
+                                            },
+                                            "inheritAttrs": false,
+                                            "staticRenderFns": []
+                                        },
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "dataMask",
+                                    "config": {
+                                        "name": "Data Format",
+                                        "label": "Data Format",
+                                        "helper": "The data format for the selected type."
+                                    }
+                                },
+                                {
+                                    "type": "ValidationSelect",
+                                    "field": "validation",
+                                    "config": {
+                                        "label": "Validation Rules",
+                                        "helper": "The validation rules needed for this field"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "placeholder",
+                                    "config": {
+                                        "label": "Placeholder Text",
+                                        "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "helper",
+                                    "config": {
+                                        "label": "Helper Text",
+                                        "helper": "Help text is meant to provide additional guidance on the field's value"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "readonly",
+                                    "config": {
+                                        "label": "Read Only",
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "_Ctor": [],
+                                        "props": {
+                                            "value": {
+                                                "type": null
+                                            }
+                                        },
+                                        "watch": {
+                                            "value": {
+                                                "user": true,
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "_scopeId": "data-v-5d32d6af",
+                                        "computed": {
+                                            "effectiveValue": []
+                                        },
+                                        "_compiled": true,
+                                        "components": {
+                                            "MonacoEditor": {
+                                                "name": "monaco-editor",
+                                                "_Ctor": [],
+                                                "props": {
+                                                    "amdRequire": []
+                                                },
+                                                "extends": {
+                                                    "name": "MonacoEditor",
+                                                    "model": {
+                                                        "event": "change"
+                                                    },
+                                                    "props": {
+                                                        "theme": {
+                                                            "default": "vs"
+                                                        },
+                                                        "value": {
+                                                            "required": true
+                                                        },
+                                                        "options": [],
+                                                        "language": [],
+                                                        "original": [],
+                                                        "amdRequire": [],
+                                                        "diffEditor": {
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "options": {
+                                                            "deep": true,
+                                                            "user": true
+                                                        }
+                                                    },
+                                                    "methods": []
+                                                },
+                                                "methods": []
+                                            }
+                                        },
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "defaultValue",
+                                    "config": {
+                                        "label": "Default Value",
+                                        "helper": "Takes precedence over value set in data."
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormInput",
+                            "editor-component": "FormInput"
+                        }
+                    ]
+                }
+            ],
+            "computed": [
+                {
+                    "id": 4,
+                    "name": "varA",
+                    "type": "javascript",
+                    "formula": "return 1;",
+                    "property": "varA"
+                },
+                {
+                    "id": 5,
+                    "name": "res",
+                    "type": "javascript",
+                    "formula": "var val1 = this.uno;\nparseFloat(val1);\nreturn \"ok\";",
+                    "property": "res"
+                }
+            ],
+            "custom_css": null,
+            "created_at": "2020-11-27T02:08:34+00:00",
+            "updated_at": "2020-11-27T02:11:06+00:00",
+            "status": "ACTIVE",
+            "key": null,
+            "watchers": [],
+            "categories": [
+                {
+                    "id": 1,
+                    "name": "Uncategorized",
+                    "status": "ACTIVE",
+                    "is_system": 0,
+                    "created_at": "2020-11-06T15:53:52+00:00",
+                    "updated_at": "2020-11-06T15:53:52+00:00",
+                    "pivot": {
+                        "assignable_id": 364,
+                        "category_id": 1,
+                        "category_type": "ProcessMaker\\Models\\ScreenCategory"
+                    }
+                }
+            ]
+        }
+    ],
+    "screen_categories": [],
+    "scripts": []
+}

--- a/tests/e2e/specs/DefaultValuesWithComputedFields.spec.js
+++ b/tests/e2e/specs/DefaultValuesWithComputedFields.spec.js
@@ -1,0 +1,23 @@
+describe('Computed field and default values', () => {
+
+  it('Test default values with computed fields', () => {
+    cy.visit('/');
+    cy.server();
+    cy.loadFromJson('default_values_with_computed_fields.json', 0);
+
+    // Preview
+    cy.get('[data-cy=mode-preview]').click();
+
+    // Assertion: Calculated properties are correct:
+    //   - varA = 1
+    //   - res = ok
+    // Control with default value is correct:
+    //   - uno = {{varA}} = 1
+    cy.assertPreviewData({
+      'uno': 1,
+      'varA': 1,
+      'res': 'ok',
+    });
+
+  });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -99,6 +99,9 @@ Cypress.Commands.add('loadFromJson', (filename, index) => {
     if (index !== undefined) {
       const screen = content.screens[index];
       cy.setVueComponentProperty('#screen-builder-container', '$refs.builder.config', screen.config);
+      cy.setVueComponentProperty('#screen-builder-container', 'computed', screen.computed);
+      cy.setVueComponentProperty('#screen-builder-container', 'watchers', screen.watchers);
+      cy.setVueComponentProperty('#screen-builder-container', 'customCSS', screen.custom_css);
     }
   });
 });


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-2422

This PR fixes use of computed fields in default values

```
Test case
Define calculated properties:
       - varA = 1
       - res = ok
Control with default value:
       - uno = {{varA}}
Expected response:
{
  varA: 1,
  res: "ok",
  uno: 1
}
```

[default_values_with_computed_fields.json.txt](https://github.com/ProcessMaker/screen-builder/files/5660473/default_values_with_computed_fields.json.txt)
