### PR TITLE
Sort Screen Builder controls alphabetically

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -449,6 +449,8 @@ export default {
         return control.label
           .toLowerCase()
           .includes(this.filterQuery.toLowerCase());
+      }).sort((a, b) => {
+        return this.collator.compare(a.label, b.label);
       });
     },
     isCurrentPageEmpty() {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -427,6 +427,8 @@ export default {
       generator,
       variablesTree: [],
       screenRederer,
+      language: 'en',
+      collator: null,
     };
   },
   computed: {
@@ -779,6 +781,12 @@ export default {
 
       return copy;
     },
+    initiateLanguageSupport() {
+      if (document.documentElement.lang) {
+        this.language = document.documentElement.lang;
+      }
+      this.collator = Intl.Collator(this.language);
+    },
   },
   created() {
     this.loadVariablesTree = _.debounce(this.loadVariablesTree, 2000);
@@ -797,6 +805,7 @@ export default {
       this.$store.registerModule(`page-${index}`, undoRedoModule);
       this.$store.dispatch(`page-${index}/pushState`, JSON.stringify(config.items));
     });
+    this.initiateLanguageSupport();
   },
   mounted() {
     this.loadVariablesTree();


### PR DESCRIPTION
## Changes
- Sorts screen builder controls alphabetically by translated label
- Utilizes JavaScript's Internationalization API to sort properly per language

## Before
<img width="193" alt="Screen Shot 2020-12-09 at 3 42 13 PM" src="https://user-images.githubusercontent.com/867714/101702135-25653700-3a35-11eb-9289-f6d19f8fddf2.png">

## After
<img width="193" alt="Screen Shot 2020-12-09 at 3 40 30 PM" src="https://user-images.githubusercontent.com/867714/101702146-2b5b1800-3a35-11eb-96f0-398b519e8e4e.png">

Closes https://processmaker.atlassian.net/browse/FOUR-2507.