### PR TITLE
Fix issue with mustache rendering fields it should ignore

### DIFF
--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -129,7 +129,7 @@ export default {
       return name.replace(/_\w/g, m => m.substr(1,1).toUpperCase());
     },
     updateComponentConfig(nodeName, properties) {
-      this.updatedConfigs.push({name: nodeName, properties: properties});
+      this.updatedConfigs.push({name: nodeName, properties});
     },
     mergeUpdatedConfig(nodeName, properties) {
       let updatedConfig = this.updatedConfigs.find(config => config.name === nodeName);

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -132,7 +132,7 @@ export default {
         if (value !== false && value !== null && value !== undefined) {
           if (property.substr(0,1) === ':' || (typeof value === 'string' && value.indexOf('{{') === -1)) {
             node.setAttribute(this.escapeVuePropertyName(property), value);
-          } else if (typeof value === 'string' && value.indexOf('{{') !== -1) {
+          } else if (typeof value === 'string' && value.indexOf('{{') !== -1 && !properties.ignoreMustache) {
             node.setAttribute(':' + this.escapeVuePropertyName(property), 'mustache('+this.byValue(value)+')');
           } else if (value !== undefined) {
             node.setAttribute(':' + this.escapeVuePropertyName(property), this.byValue(value));


### PR DESCRIPTION
## Changes
- Allows components to set a property `ignoreMustache` to `true` to avoid having their properties rendered by mustache
  - This is necessary for components that render mustache internally; specifically in this case, the Collection Record component
- Allow components to update their configuration
  - Components can update their configuration by listening for the `screen-renderer-build-component` event and calling the `updateComponentConfig` method with the component name and the updated configuration (for an example of this, see the [corresponding Collections PR](https://github.com/ProcessMaker/package-collections/pull/233/files#diff-0ee38169882816d584d23f4eb5cf4d4265b7912d93e5875be6df481dc2610a2eR21-R23))
  - This is necessary to allow older versions of components on older screens to utilize the `ignoreMustache` property; otherwise, older screens with previous versions of the component would exhibit the behavior this ticket is designed to fix

## Requirements
- https://github.com/ProcessMaker/package-collections/pull/233

Closes https://processmaker.atlassian.net/browse/FOUR-2530