### PR TITLE
FOUR-2534: Controls overlap on top of others

### DIFF
--- a/src/components/renderer/form-image.vue
+++ b/src/components/renderer/form-image.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group form-image">
+  <div class="form-group" style="overflow-x: hidden" >
     <img v-if="renderImage" :src="imageUrl" :width="width" :height="height" :name="variableName">
     <img v-else-if="!renderImage && image" :src="image" :width="width" :height="height" :id="id">
     <i v-else-if="mode == 'editor'" class="empty-image far fa-image" />

--- a/src/components/renderer/form-image.vue
+++ b/src/components/renderer/form-image.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group" style="overflow-x: hidden" >
+  <div class="form-group form-image" style="overflow-x: hidden" >
     <img v-if="renderImage" :src="imageUrl" :width="width" :height="height" :name="variableName">
     <img v-else-if="!renderImage && image" :src="image" :width="width" :height="height" :id="id">
     <i v-else-if="mode == 'editor'" class="empty-image far fa-image" />


### PR DESCRIPTION
Resolves [FOUR-2534](https://processmaker.atlassian.net/browse/FOUR-2534)

Fixes image styles when they overflow their container

Before:
![image](https://user-images.githubusercontent.com/14875032/102777907-ee155500-4367-11eb-88bb-8a71e7e396bd.png)

After:

![image](https://user-images.githubusercontent.com/14875032/102777920-f53c6300-4367-11eb-88d0-5ba4bb22e287.png)
