### PR TITLE
Remove vuetable watcher not required anymore

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -251,15 +251,6 @@ export default {
       return this.form && this.form === this.$parent.currentPage;
     },
   },
-  watch: {
-    tableFields() {
-      this.$nextTick(() => {
-        if (this.$refs.vuetable) {
-          this.$refs.vuetable.normalizeFields();
-        }
-      });
-    },
-  },
   methods: {
     isImage(field, item) {
       const content = _.get(item, field.key);


### PR DESCRIPTION
This code was incorrectly restored in the PR #878.
This PR removes a watcher referencing old vuetable2 component