### PR TITLE
Fix nested screen validation when submitting from another page

### DIFF
--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -112,6 +112,11 @@ export default {
 
             if (this.ancestorScreens.includes(this.screenTitle)) {
               globalObject.ProcessMaker.alert(`Rendering of nested "${this.screenTitle}" screen was disallowed to prevent loop.`, 'warning');
+            } else {
+              if (!globalObject['nestedScreens']) {
+                globalObject['nestedScreens'] = {};
+              }
+              globalObject.nestedScreens["id_" + id] = this.config;
             }
           });
       }

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -334,13 +334,6 @@ export default {
       this.dataTypeValidator = ValidatorFactory(config, this.data);
       this.errors = this.dataTypeValidator.getErrors();
 
-      this.$children.forEach(child => {
-        const childErrors = this.checkForNestedScreenErrors(child);
-        if (!childErrors) {
-          return;
-        }
-        this.errors = Object.assign(this.errors, childErrors);
-      });
       if (this.errors) {
         this.formSubmitErrorClass = 'invalid-form-submission';
       }

--- a/src/factories/ValidatorFactory.js
+++ b/src/factories/ValidatorFactory.js
@@ -1,4 +1,5 @@
 import customValidationRules from './CustomValidationRules';
+import _ from 'lodash';
 const Validator = require('validatorjs');
 
 export function ValidatorFactory(config, data) {
@@ -40,6 +41,13 @@ export function ValidatorFactory(config, data) {
           validate.ruleFormLoop(item.config.name, item.items);
         } else {
           validate.getDataAndRules(item.items);
+        }
+      }
+
+      if (item.component === 'FormNestedScreen') {
+        const nestedScreen = _.get(window, 'nestedScreens.id_' + item.config.screen);
+        if (nestedScreen) {
+          validate.getDataAndRules(nestedScreen);
         }
       }
 

--- a/src/main.js
+++ b/src/main.js
@@ -41,7 +41,13 @@ window.ProcessMaker = {
                     'label': 'First name',
                     'name': 'firstname',
                     'placeholder': '',
-                    'validation': '',
+                    "validation": [
+                      {
+                        "value": "required",
+                        "helper": "Checks if the length of the String representation of the value is >",
+                        "content": "Required"
+                      }
+                    ],
                     'helper': null,
                     'type': 'text',
                     'dataFormat': 'string',


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2550

We were checking validation using $children. This only has items for the current page. This fix saves nested screens in the global object when loaded then retrieves them when validating.