### PR TITLE
FOUR-2710: Watcher UI not being cleaned up when switching source type

### DIFF
--- a/src/components/inspector/outbound-config.vue
+++ b/src/components/inspector/outbound-config.vue
@@ -164,7 +164,7 @@ export default {
             []);
 
             //add url parameters:
-            const matchedParams = endpointData.url.matchAll(/\{\{(.+?)\}\}/gm);
+            const matchedParams = (endpointData.url || '').matchAll(/\{\{(.+?)\}\}/gm);
             for (const match of matchedParams) {
               const urlParam = match[1];
               // Add url param if it is not defined withing the connector's param list
@@ -175,7 +175,7 @@ export default {
           }
 
           if (rowType === 'BODY') {
-            const matchedParams = endpointData.body.matchAll(/\{\{(.+?)\}\}/gm);
+            const matchedParams = (endpointData.body || '').matchAll(/\{\{(.+?)\}\}/gm);
             for (const match of matchedParams) {
               const urlParam = match[1];
               // Add url param if it is not defined withing the connector's param list

--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -306,15 +306,24 @@ export default {
       },
     },
     'config.script': {
-      handler(value) {
+      handler(value, oldValue) {
         if (!value) {
           this.config.script_id = '';
           this.config.script_key = '';
           this.config.datasource_script_id = '';
         } else if (typeof value === 'object') {
           let id = value.id.split('-');
+          let oldSourceType = (oldValue && oldValue.id && oldValue.id.split('-').length > 0)
+            ? oldValue.id.split('-')[0]
+            : '';
           this.config.script_id = id[1];
           this.config.script_key = value.key;
+
+          // If the type of the data source has changed (from script to data source or the other way around)
+          if (oldSourceType !== id[0]) {
+            this.config.script_configuration = '{}';
+          }
+
           if (id[0] === 'data_source') {
             this.setConfig('dataSource', this.config.script_id);
           }
@@ -455,7 +464,7 @@ export default {
     validateDataAndSave() {
       this.setValidations();
       this.$nextTick(() => { // allow validations to do their thing
-        
+
         if (!this.isFormValid()) {
           globalObject.ProcessMaker.alert(this.$t('An error occurred. Check the form for errors in red text.'), 'danger');
           return;
@@ -480,7 +489,7 @@ export default {
     .card-overflow {
       overflow: visible;
     }
-    
+
     .card-body label {
       display: block;
     }


### PR DESCRIPTION
Fixes: [https://processmaker.atlassian.net/browse/FOUR-2710](https://processmaker.atlassian.net/browse/FOUR-2710)

When the source type (from script to data_source for example) the script configuration is reset to {}
