### PR TITLE
Merge existing request data instead of overwriting

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -239,7 +239,8 @@ export default {
     },
     prepareTask() {
       this.resetScreenState();
-      this.requestData = _.get(this.task, 'request_data', {});
+      const requestData = _.get(this.task, 'request_data', {});
+      this.requestData = _.merge(this.requestData, requestData);
 
       this.$emit('task-updated', this.task);
 


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2778

A tasks's existing request data might load after the screen has loaded its initial variables and default values. This PR merges the request data instead of overwriting it.