### PR TITLE
Emit the correct value when the process completes

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -332,7 +332,7 @@ export default {
       // This may no longer be needed
     },
     processCompleted() {
-      this.$emit('completed', this.task.process_request_id);
+      this.$emit('completed', this.requestId);
     },
     processUpdated(data) {
       if (


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-2773

- It was emitting the wrong value with the complete event. This fixes it