### PR TITLE
Fix loading loop control within a request

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -15,6 +15,7 @@
             :computed="screen.computed"
             :custom-css="screen.custom_css"
             :watchers="screen.watchers"
+            :key="refreshScreen"
             @update="onUpdate"
             @submit="submit"
           />
@@ -90,6 +91,7 @@ export default {
       requestData: {},
       reloadInProgress: false,
       hasErrors: false,
+      refreshScreen: 0,
     };
   },
   watch: {
@@ -239,8 +241,8 @@ export default {
     },
     prepareTask() {
       this.resetScreenState();
-      const requestData = _.get(this.task, 'request_data', {});
-      this.requestData = _.merge(this.requestData, requestData);
+      this.requestData = _.get(this.task, 'request_data', {});
+      this.refreshScreen++;
 
       this.$emit('task-updated', this.task);
 


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-2765

<h2>Changes</h2>
The issue was caused by the 'Task' component overwriting the screen data when loading the request data. This PR adds a `refreshScreen` variable to refresh the screens data after the request data has loaded.

<h2>To Test</h2>

- Create a screen with a loop control configured.
- Create and run a process that uses the above screen.

**Expected Behavior**

The Loop control properly loads with no console errors. 