### PR TITLE
Fix validation accordion not closing 

### DIFF
--- a/src/components/inspector/input-variable.vue
+++ b/src/components/inspector/input-variable.vue
@@ -55,6 +55,9 @@ export default {
       }
     },
     options() {
+      if (!this.localValue) {
+        return;
+      }
       const regexp = new RegExp(
         this.localValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
           .replace(/\.\d+/g, '.index'),

--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -388,7 +388,8 @@ export default {
       });
     },
     onUpdate(rule, index) {
-      this.$root.$emit('bv::toggle::collapse', rule.content);
+      const content = this.formatRuleContentAsId(rule.content);
+      this.$root.$emit('bv::toggle::collapse', content);
       this.$set(this.rules[index], 'visible', false);
       this.cloneRules = JSON.parse(JSON.stringify(this.rules));
     },

--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -416,7 +416,7 @@ export default {
     },
     cloneSetRules() {
       this.cloneRules = JSON.parse(JSON.stringify(this.rules));
-    }
+    },
   },
   mounted() {
     this.rules = this.value || [];

--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -314,6 +314,8 @@ export default {
     },
     value() {
       this.rules = this.value;
+      this.cloneSetRules();
+      
     },
     selectedOption: {
       deep: true,
@@ -395,7 +397,9 @@ export default {
     },
     onCancel(rule, index) {
       if (this.cloneRules && this.cloneRules[index]) {
-        Object.assign(this.rules[index], JSON.parse(JSON.stringify(this.cloneRules[index])));
+        if (!_.isEqual(rule, this.cloneRules[index])) {
+          Object.assign(this.rules[index], JSON.parse(JSON.stringify(this.cloneRules[index])));
+        }
       } else {
         rule.configs.forEach(config => {
           if (config.value) {
@@ -408,12 +412,13 @@ export default {
     formatRuleContentAsId(content) {
       return content.toLowerCase().replaceAll(' ', '-');
     },
+    cloneSetRules() {
+      this.cloneRules = JSON.parse(JSON.stringify(this.rules));
+    }
   },
   mounted() {
     this.rules = this.value || [];
-    if (this.cloneRules.length) {
-      this.cloneRules = JSON.parse(JSON.stringify(this.rules));
-    }
+    this.cloneSetRules();
   },
 };
 </script>

--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -396,6 +396,7 @@ export default {
       this.cloneRules = JSON.parse(JSON.stringify(this.rules));
     },
     onCancel(rule, index) {
+      const content = this.formatRuleContentAsId(rule.content);
       if (this.cloneRules && this.cloneRules[index]) {
         if (!_.isEqual(rule, this.cloneRules[index])) {
           Object.assign(this.rules[index], JSON.parse(JSON.stringify(this.cloneRules[index])));
@@ -408,6 +409,7 @@ export default {
         });
         this.rules[index].configs = rule.configs;
       }
+      this.$root.$emit('bv::toggle::collapse', content);
     },
     formatRuleContentAsId(content) {
       return content.toLowerCase().replaceAll(' ', '-');


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-2751

<h2>Changes</h2>

- Fixes issue where the validation 'Cancel' & 'Update' buttons were not closing the accordion. 
- Fixes issue where selecting the 'Cancel' button on one element validations updated the validation for another element. Due to the `cloneRules` variable not clearing. 
- Fixes console error due to running a 'replace' method on an empty value. 