### PR TITLE
[ZenDesk 22843] Watchers in record lists are not working in nested screens

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -80,6 +80,7 @@
         :config="popupConfig"
         :current-page="form"
         :computed="formComputed"
+        :watchers="formWatchers"
         debug-context="Record List Add"
         :key="Array.isArray(value) ? value.length : 0"
         :_parent="validationData"
@@ -104,6 +105,7 @@
         :config="popupConfig"
         :current-page="form"
         :computed="formComputed"
+        :watchers="formWatchers"
         debug-context="Record List Edit"
         :_parent="validationData"
       />
@@ -155,7 +157,7 @@ const jsonOptionsActionsColumn = {
 
 export default {
   mixins: [mustacheEvaluation],
-  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig', 'formComputed'],
+  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig', 'formComputed', 'formWatchers'],
   data() {
     return {
       single: '',

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -54,6 +54,7 @@ export default {
       properties.disabled = element.config.interactive || element.config.disabled;
       properties[':form-config'] = this.byRef(this.configRef || definition.config);
       properties[':form-computed'] = JSON.stringify(definition.computed);
+      properties[':form-watchers'] = JSON.stringify(definition.watchers);
       // Events
       properties['@submit'] = 'submitForm';
     },


### PR DESCRIPTION
Fixed [FOUR-2465](https://processmaker.atlassian.net/browse/FOUR-2465)

- Enable watchers in modal recordlist