### PR TITLE
FOUR-2953: The files of a record list that are in loop control, are not deleted after deleting the entire row of record lists

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -215,7 +215,6 @@ export default {
           }
         }
       }
-      return null;
     },
     deleteFile(fileId) {
       if (fileId) {

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -195,21 +195,29 @@ export default {
   },
   methods: {
     listenRemovedLoop(loop, removed) {
-      const fileId = removed[this.name];
-      if (fileId) {
-        window.ProcessMaker.apiClient
-          .delete(`files/${fileId}`)
-          .catch(() => {
-            /** ignore exception **/
-          });
-      }
+      this.deleteAssociatedFiles(removed);
     },
     listenRemovedRecord(recordList, record) {
       const parent = this.parentRecordList(this);
       if (parent !== recordList) {
         return;
       }
-      const fileId = record[this.name];
+      this.deleteAssociatedFiles(record);
+    },
+    deleteAssociatedFiles(object) {
+      for (const prop in object) {
+        if (prop === this.name) {
+          this.deleteFile(object[prop]);
+        }
+        if (Array.isArray(object[prop])) {
+          for (const item of object[prop]) {
+            this.deleteAssociatedFiles(item);
+          }
+        }
+      }
+      return null;
+    },
+    deleteFile(fileId) {
       if (fileId) {
         window.ProcessMaker.apiClient
           .delete(`files/${fileId}`)


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2953](https://processmaker.atlassian.net/browse/FOUR-2953)

Code that deletes all files withing a record or loop (even if they are nested) has been added.
