### PR TITLE
FOUR-3043 for v2.5.2

### DIFF
--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -136,7 +136,10 @@ export const notIn = (list) => helpers.withParams({list}, (value) => {
 });
 
 export const regex = (expression) => helpers.withParams({expression}, (value) => {
-  const regexp = new RegExp(expression);
+  const matches = expression.match(/(\/?)(.+)\1([a-z]*)/i);
+  const searchPattern = matches[2];
+  const flags = matches[3];
+  const regexp = new RegExp(searchPattern, flags);
   return !!String(value).match(regexp);
 });
 


### PR DESCRIPTION
Regex validation supports expressions with or without delimiters and flags. (original PR by @GooseCoder)