### PR TITLE
Fix screen interstitial endless reload bug

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -232,7 +232,7 @@ export default {
             this.task = response.data;
             this.checkTaskStatus();
           })
-          .catch((e) => {
+          .catch(() => {
             this.hasErrors = true;
           });
       });


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2979

- Removed the request queue, it wasn't doing anything
- Checks if we're already showing the appropriate task and doesn't attempt to reload it if we are

TESTING

You can trigger the endless reloading/flashing more often by doing this in CORE. 

- In ProcessMaker/Http/Controllers/Api/TaskController.php show function, add a sleep if the node matches the first form task:
```
public function show(ProcessRequestToken $task)
    {
        if ($task->element_id === 'node_1') {
            sleep(2);
        }
        return new Resource($task);
    }
```
- in ProcessMaker/Repositories/TokenRepository.php at the end of persistActivityCompleted but before calling notifyProcessUpdated, add another sleep
```
$request = $token->getInstance();
sleep(2);
$request->notifyProcessUpdated('ACTIVITY_COMPLETED');
```

Try it first with master to verify you can see it flashing and endless reloading, then switch use this branch