### PR TITLE
Fix interstitial after advanced screen not showing

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -177,8 +177,9 @@ export default {
         if (this.screen.type === 'CONVERSATIONAL') {
           this.renderComponent = 'ConversationalForm';
         } else {
+          const isInterstitial = _.get(this.screen, '_interstitial', false);
           let component = _.get(this, 'task.component', 'task-screen');
-          if (component === null) {
+          if (component === null || isInterstitial) {
             component = 'task-screen';
           }
           this.renderComponent = component;
@@ -289,6 +290,7 @@ export default {
         this.processCompleted();
 
       } else if (this.task.allow_interstitial) {
+        this.task.interstitial_screen['_interstitial'] = true;
         this.screen = this.task.interstitial_screen;
         this.loadNextAssignedTask();
 
@@ -337,6 +339,7 @@ export default {
       });
 
       if (this.task && this.task.allow_interstitial) {
+        this.task.interstitial_screen['_interstitial'] = true;
         this.screen = this.task.interstitial_screen;
       }
     },


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3175

Interstitials after advanced screens were not showing because we were checking the task component, which in this case was "AdvancedScreen". In reality, the interstitial is always a "task-screen" so we needed to set a property when switching to an interstitial indicating it is one. Then the screen watch checks for that property and, if set, always renders it as a "task-screen"

NOTE: need separate PR to add fix to develop (4.2)