### PR TITLE
FOUR-3182-B: Watcher is not working

### DIFF
--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -73,7 +73,6 @@
               :name="$t('Run Watcher on Screen Load')"
               :label="$t('Run watcher on Screen Load')"
               v-model="config.run_onload"
-              @change="config.watching = ''"
               :toggle="true"
               data-cy="watchers-watcher-run-onload"
             />
@@ -346,7 +345,7 @@ export default {
 
       if (dsList && currentMappings.length === 0) {
         const ds = dsList.items.find(conn => 'data_source-' + config.dataSource === conn.id);
-        const dsMappings = (ds.endpoints && ds.endpoints[endpoint]) ? ds.endpoints[endpoint].dataMapping : [] || [];
+        const dsMappings = (ds.endpoints && ds.endpoints[endpoint] ? ds.endpoints[endpoint].dataMapping : []) || [];
         config.dataMapping = [];
         dsMappings.forEach(mapping => {
           config.dataMapping.push({key: mapping.key, value: mapping.value});

--- a/src/mixins/watchers.js
+++ b/src/mixins/watchers.js
@@ -44,13 +44,15 @@ export default {
             config,
             sync: true,
           }, { timeout: 0 }).then(response => {
+            this.$emit('asyncWatcherCompleted');
             complete(response.data.output);
           }).catch(err => {
             exception(err);
           });
         }
       }).then((response) => {
-        if (watcher.output_variable) {
+        // If watcher has an output variable and is a script
+        if (watcher.output_variable && (watcher.script_key || '').length === 0) {
           this.setValue(watcher.output_variable, response);
         }
 


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3182](https://processmaker.atlassian.net/browse/FOUR-3182)

-Removed the clearing of variable to watch when changing between setting on/off the run on load option
-Fix bug associated with filling the output variable with all response data when a data source was used