### PR TITLE
Fix Screen saving in Safari

### DIFF
--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -95,7 +95,7 @@ export const keyNameProperty = {
   config: {
     label: 'Variable Name',
     name: 'Variable Name',
-    validation: 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$/|required|not_in:' + javascriptReservedKeywords,
+    validation: 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*$/|required|not_in:' + javascriptReservedKeywords,
     helper: 'A variable name is a symbolic name to reference information.',
   },
 };


### PR DESCRIPTION
Jira Ticket
https://processmaker.atlassian.net/browse/FOUR-3214

The issue only occurs when using the Safari browser. When mounting a Form Input control or when saving / previewing a screen with a Form Input control the following error appeared.

`SyntaxError: Invalid regular expression: invalid group specifier name`

This was caused by the `Variable Name` regex including a negative look-behind assertion that Safari does not support.

<h2>Changes</h2>

- Remove the unsupported negative look behind for Safari

**Video**

https://www.loom.com/share/88456a0d626549bfb6254a4c5bc192c5
