### PR TITLE
FOUR-3210: Record list updating the wrong record when more than one page of records

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -57,6 +57,7 @@
         :total-rows="tableData.total"
         :per-page="perPage"
         aria-controls="vuetable"
+        @change="onChangePage"
       />
     </template>
 
@@ -331,7 +332,6 @@ export default {
       if (this.paginatorPage > this.lastPage) {
         this.paginatorPage = this.lastPage;
       }
-      this.$refs.vuetable.changePage(page);
     },
     showEditForm(index) {
       let pageIndex = ((this.paginatorPage-1) * this.perPage) + index;


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3210](https://processmaker.atlassian.net/browse/FOUR-3210)

The tracking of the Record List current page has been fixed.