### PR TITLE
Replace Regex Negative Lookbehind for Safari support

### DIFF
--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -95,7 +95,7 @@ export const keyNameProperty = {
   config: {
     label: 'Variable Name',
     name: 'Variable Name',
-    validation: 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*$/|required|not_in:' + javascriptReservedKeywords,
+    validation: 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/|required|not_in:' + javascriptReservedKeywords,
     helper: 'A variable name is a symbolic name to reference information.',
   },
 };


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-3263

<h2>Changes</h2>

- Replaces the 'Variable Name' regex validation to prevent variable names ending in a dot.

**Video**

https://www.loom.com/share/afb35ca1998c45a0a628f8aff89edb15
