### PR TITLE
For sameAs, validate against entire vdata, not just subset

### DIFF
--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -157,8 +157,8 @@ export const requiredUnless = (variable, expected) => (value, data) => {
   return value instanceof Array ? value.length > 0 : !!value;
 };
   
-export const sameAs = (field) => helpers.withParams({field}, (value, data) => {
-  const valueSameAs = get(data, field);
+export const sameAs = (field) => helpers.withParams({field}, function(value) {
+  const valueSameAs = get(this.vdata, field);
   return value == valueSameAs;
 });
 


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3409

Change to an old style function so we have access to `this`, which vuelidate binds to the current $vm.

Tech note: I think there's a bug in vuelidate since the old format should have worked with the 2nd param being the $vm, but instead, its a subset of the data. Strange.