### PR TITLE
Prevent errors during validation break the screen builder loading

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -440,7 +440,14 @@ export default {
         }
 
         // Validation will not run until you call passes/fails on it
-        if (!validator.passes()) {
+        let passes;
+        try {
+          passes = validator.passes();
+        } catch (err) {
+          // Prevent errors during validation break the screen builder loading
+          passes = false;
+        }
+        if (!passes) {
           Object.keys(validator.errors.errors).forEach(field => {
             validator.errors.errors[field].forEach(error => {
               validationErrors.push({


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3699

Safari does not support regular expressions with **lookbehind**. This was used previously and some screens still store this expressions in its json definition.
https://caniuse.com/js-regexp-lookbehind

This PR prevents that errors during validation check break the screen builder loading


