### PR TITLE
FOUR-3575:  returned data is mixed when the watcher runs at the same time in two different sessions

### DIFF
--- a/src/mixins/watchers.js
+++ b/src/mixins/watchers.js
@@ -12,6 +12,9 @@ export default {
   },
   methods: {
     queueWatcherSync(watcher) {
+      //add a random sufix to uniquely identify this watcher call
+      watcher.uid = watcher.uid + (Math.random().toString(36)+'00000000000000000').slice(2, 16) + Date.now();
+
       if (watcher.synchronous) {
         // lock screen with watcher's popup
         if (this.$el.offsetParent) {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3575](https://processmaker.atlassian.net/browse/FOUR-3575)