### PR TITLE
ticket 599: Validation Delete Confirmation UI

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -45,13 +45,13 @@
           <draggable @update="updateSort" :element="'div'" v-model="optionsList" group="options" @start="drag=true" @end="drag=false" >
             <div v-for="(option, index) in optionsList" :key="option.value">
               <div v-if="removeIndex === index">
-                <div class="card mb-3 bg-danger text-white text-left" style="border-radius: 0.25em">
-                  <div class="card-body p-3" v-html="currentItemToDelete"/>
+                <div class="card mb-3 bg-danger text-white text-left mt-2">
+                  <div class="card-body p-2" v-html="currentItemToDelete"/>
                   <div class="card-footer text-right p-2">
-                    <button type="button" class="btn btn-sm btn-light mr-2 text-capitalize" @click="removeIndex=null" data-cy="inspector-options-remove-cancel">
+                    <button type="button" class="btn btn-sm btn-light mr-2" @click="removeIndex=null" data-cy="inspector-options-remove-cancel">
                       {{ $t('Cancel') }}
                     </button>
-                    <button type="button" class="btn btn-sm btn-danger text-capitalize" @click="deleteOption()" data-cy="inspector-options-remove-confirm">
+                    <button type="button" class="btn btn-sm btn-danger" @click="deleteOption()" data-cy="inspector-options-remove-confirm">
                       {{ $t('Delete') }}
                     </button>
                   </div>

--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -31,16 +31,16 @@
     <p v-if="!hasRules && !showCard">{{ $t('No validation rule(s)') }}</p>
     <div v-if="hasRules">
       <div role="tablist">
-        <b-card v-for="(rule, index) in rules" class="mb-2" :key="index">
-          <div v-if="showDeleteConfirmCard && removeIndex == index" class="card mb-3 bg-danger text-white text-right"  style="border-radius: 0.25em">
-            <div class="card-body p-3 text-left">
+        <b-card v-for="(rule, index) in rules" class="mb-2 border-1" :class="{'border-0': showDeleteConfirmCard, 'border-top-1': showDeleteConfirmCard, 'border-1': !showDeleteConfirmCard}" :key="index">
+          <div v-if="showDeleteConfirmCard && removeIndex == index" class="card mb-3 bg-danger text-white text-right">
+            <div class="card-body p-2 text-left">
               {{ confirmMessage }}
             </div>
             <div class="card-footer text-right p-2">
-              <button type="button" class="btn btn-sm btn-light mr-2 text-capitalize" @click="hideDeleteConfirmCard" data-cy="cancel-confirm-delete-rule">
+              <button type="button" class="btn btn-sm btn-light mr-2" @click="hideDeleteConfirmCard" data-cy="cancel-confirm-delete-rule">
                 {{ $t('Cancel') }}
               </button>
-              <button type="button" class="btn btn-sm btn-danger text-capitalize" @click="deleteRule(index)" data-cy="confirm-delete-rule">
+              <button type="button" class="btn btn-sm btn-danger" @click="deleteRule(index)" data-cy="confirm-delete-rule">
                 {{ $t('Delete') }}
               </button>
             </div>
@@ -363,7 +363,7 @@ export default {
     },
     hideDeleteConfirmCard() {
       this.removeIndex = null;
-      this.showConfirmationCard = false;
+      this.showDeleteConfirmCard = false;
     },
     deleteRule(index) {
       this.rules.splice(index, 1);


### PR DESCRIPTION
Fixes [http://tickets.pm4overflow.com/tickets/599](http://tickets.pm4overflow.com/tickets/599)

- Border when deleting a validation rule has been removed.
- Padding and border-radius inside .card are configured in our in app.scss file. They were left untouched to avoid a modification that will affect all elements that use this css class accross our application.
Before:
![image](https://user-images.githubusercontent.com/14875032/130287758-dc9a8780-2bed-4389-a617-7efd8b6ade41.png)

After:
 
![image](https://user-images.githubusercontent.com/14875032/130287041-29734187-a78e-4463-8a65-d9177364c556.png)
