### PR TITLE
Disable file upload for unclaimed self service tasks (4.2)

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -20,7 +20,16 @@
 
       <uploader-drop class="form-control-file">
         <p>{{ $t('Drop a file here to upload or') }}</p>
-        <uploader-btn tabindex="0" v-on:keyup.native="browse" :aria-label="$attrs['aria-label']" class="btn btn-secondary text-white">{{ $t('select file') }}</uploader-btn>
+        <uploader-btn
+          :attrs="nativeButtonAttrs"
+          :class="{disabled: disabled}"
+          tabindex="0"
+          v-on:keyup.native="browse"
+          :aria-label="$attrs['aria-label']"
+          class="btn btn-secondary text-white"
+        >
+          {{ $t('select file') }}
+        </uploader-btn>
         <span v-if="validation === 'required' && !value" class="required">{{ $t('Required') }}</span>
       </uploader-drop>
       <uploader-list>
@@ -92,6 +101,8 @@ export default {
     if (this.$refs['uploader']) {
       this.$refs['uploader'].$forceUpdate();
     }
+
+    this.disabled = _.get(window, 'ProcessMaker.isSelfService', false);
   },
   errorCaptured(err) {
     if (ignoreErrors.includes(err.message)) {
@@ -99,6 +110,13 @@ export default {
     }
   },
   computed: {
+    nativeButtonAttrs() {
+      const attrs = { 'data-cy':'file-upload-button' };
+      if (this.disabled) {
+        attrs.disabled = true;
+      }
+      return attrs;
+    },
     required() {
       if (this.config && this.config.validation) {
         return this.config.validation === 'required';
@@ -205,6 +223,7 @@ export default {
       attrs: {
         accept: this.accept,
       },
+      disabled: false,
     };
   },
   methods: {
@@ -286,6 +305,11 @@ export default {
       });
     },
     addFile(file) {
+      if (this.disabled) {
+        file.ignored = true;
+        return false;
+      }
+
       if (this.filesAccept) {
         file.ignored = true;
         if (this.filesAccept.indexOf(file.fileType) !== -1) {

--- a/tests/e2e/specs/FileUpload.spec.js
+++ b/tests/e2e/specs/FileUpload.spec.js
@@ -8,5 +8,19 @@ describe('File Upload', () => {
       const data = div[0].__vue__.name;
       expect(data).to.eql('file_upload_1');
     });
+    
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=file-upload-button]').should('not.have.attr', 'disabled');
+  });
+  
+  it('Disables when task is self service', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      win.ProcessMaker.isSelfService = true;
+    });
+
+    cy.get('[data-cy=controls-FileUpload]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=file-upload-button]').should('have.attr', 'disabled');
   });
 });


### PR DESCRIPTION
Fixes http://tickets.pm4overflow.com/tickets/142

Disables the select file button and drag/drop when the task is self service

Requires: https://github.com/ProcessMaker/processmaker/pull/4030

4.1 Equivalent: https://github.com/ProcessMaker/screen-builder/pull/1056