### PR TITLE
Ticket #745 Missing filename in Uploaded Files URL (for 4.1)

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -334,7 +334,7 @@ export default {
     },
     fileUploaded(rootFile, file, message) {
       if (this.fileType == 'request') {
-        let id = '';
+        let id = file.name;
         if (message) {
           const msg = JSON.parse(message);
           if (!_.has(window, 'PM4ConfigOverrides')) {


### PR DESCRIPTION
**Changes**:
The `package-files` package uses ScreenBuilder's file-upload component.

- In the `package-files@AddPublicFile.vue` modal component, the name of the uploaded file is expected, for that reason we now return the file name instead of an empty string.
- Changes only in `ScreenBuilder@file-upload.vue`

**Fixes**:

- http://tickets.pm4overflow.com/tickets/745.