### PR TITLE
Bugfix Attribute name same as the Variable name

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -117,6 +117,7 @@ export default {
             setValue
           );
           object = get(object, attr);
+          defaults = get(defaults, attr);
         });
       }
     },

--- a/tests/e2e/specs/VariableNames.js
+++ b/tests/e2e/specs/VariableNames.js
@@ -1,0 +1,44 @@
+describe('Default values', () => {
+  it('Variable names with dots 2 levels', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]').clear().type('user.address');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.assertPreviewData({
+      user: {
+        address: '',
+      },
+    });
+  });
+  it('Variable names with dots 3 levels', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]').clear().type('user.address.city');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name="user.address.city"]').type('La Paz');
+    cy.assertPreviewData({
+      user: {
+        address: {
+          city: 'La Paz',
+        },
+      },
+    });
+  });
+  it('Variable names with dots and one attribute same as the name', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]').clear().type('address.address.city');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name="address.address.city"]').type('La Paz');
+    cy.assertPreviewData({
+      address: {
+        address: {
+          city: 'La Paz',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Issue: When a field name is set as for example: `address.address.city` it breaks the screen builder.

https://user-images.githubusercontent.com/8028650/136061824-14866710-c145-4c93-9685-cebe5254886e.mp4


This PR includes:

- Test to replicate the issue
- Fix to solve the problem

https://user-images.githubusercontent.com/8028650/136061905-762922eb-57ae-4f1a-bd13-a9993d988fe4.mp4



