### PR TITLE
Remove editable Loop inspector configs for Display screens

### DIFF
--- a/src/components/inspector/loop.vue
+++ b/src/components/inspector/loop.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="form-group border-bottom pb-3">
+    <div v-if="screenType == 'form'" class="form-group border-bottom pb-3">
       <label for="type">{{ $t('Data Source') }}</label>
       <b-form-select id="type" v-model="settings.type" :options="options" data-cy="inspector-source"/>
     </div>
@@ -17,7 +17,7 @@
     </div>
 
 
-    <div v-if="settings.type === 'new'" class="form-group border-bottom">
+    <div v-if="screenType == 'form' && settings.type === 'new'" class="form-group border-bottom">
       <FormInput
         v-model="settings.times"
         :label="$t('Default Loop Count')"
@@ -28,7 +28,7 @@
       />
     </div>
 
-    <form-checkbox name="add"
+    <form-checkbox v-if="screenType == 'form'" name="add"
       :label="$t('Allow additional loops')"
       v-model="settings.add"
       :helper="$t('Check this box to allow task assignee to add additional loops')"
@@ -41,7 +41,7 @@
 import { FormInput, FormCheckbox } from '@processmaker/vue-form-elements';
 
 export default {
-  props: ['value'],
+  props: ['value', 'screenType'],
   inheritAttrs: false,
   components: { FormInput, FormCheckbox },
   data() {


### PR DESCRIPTION
Ticket:

<h2>Changes</h2>

 - Remove the editable Loop inspector configs for Display screens.

![Screen Shot 2021-10-12 at 3 18 09 PM](https://user-images.githubusercontent.com/52755494/137036767-d27caf9e-f195-483f-bdc8-cc764f1b351d.png)
