### PR TITLE
Hide Tooltips for Submit buttons

### DIFF
--- a/src/components/inspector/tooltip.vue
+++ b/src/components/inspector/tooltip.vue
@@ -34,6 +34,7 @@
 </template>
 
 <script>
+import _ from 'lodash';
 
 export default {
   inheritAttrs: false,


### PR DESCRIPTION
Ticket [1060](http://tickets.pm4overflow.com/tickets/1060)


<h2>Changes</h2>

- Removes the Tooltip configs in the inspector panel for the Submit type buttons.

**Submit Button**

![Screen Shot 2021-10-14 at 3 13 25 PM](https://user-images.githubusercontent.com/52755494/137402713-29a7bdc7-0ebe-46ac-9a1f-a51a69e043c6.png)

**Regular Button**

![Screen Shot 2021-10-14 at 3 13 47 PM](https://user-images.githubusercontent.com/52755494/137402754-d413ba58-fd6a-4838-9659-bc8593196688.png)

