### PR TITLE
Fix Settings Page Infinite Loop

### DIFF
--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -13,14 +13,17 @@ export default {
         const isVisible = !!Parser.evaluate(rule, Object.assign({}, this, data));
 
         // Update the array of hidden fields
-        const fieldExists = this.hiddenFields__.indexOf(fieldName) !== -1;
-        if (isVisible && fieldExists) {
-          this.hiddenFields__ = this.hiddenFields__.filter((f) => f !== fieldName);
-          this.$root.$emit('refresh-validation-rules');
-        } else if (!isVisible && !fieldExists) {
-          this.hiddenFields__.push(fieldName);
-          this.$root.$emit('refresh-validation-rules');
+        if (fieldName) {
+          const fieldExists = this.hiddenFields__.indexOf(fieldName) !== -1;
+          if (isVisible && fieldExists) {
+            this.hiddenFields__ = this.hiddenFields__.filter((f) => f !== fieldName);
+            this.$root.$emit('refresh-validation-rules');
+          } else if (!isVisible && !fieldExists) {
+            this.hiddenFields__.push(fieldName);
+            this.$root.$emit('refresh-validation-rules');
+          }
         }
+        
 
         return isVisible;
       } catch (e) {


### PR DESCRIPTION
<h2>Changes</h2>

This PR adds back a fix that was removed for the infinite loop on the settings page.

Original PR
[https://github.com/ProcessMaker/screen-builder/pull/1076](https://github.com/ProcessMaker/screen-builder/pull/1076)

