### PR TITLE
Check if pagesValidated exists

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -139,7 +139,7 @@ class PageNavigateValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    if (!this.screen.pagesValidated.includes(parseInt(this.element.config.eventData))) {
+    if (this.screen.pagesValidated && !this.screen.pagesValidated.includes(parseInt(this.element.config.eventData))) {
       this.screen.pagesValidated.push(parseInt(this.element.config.eventData));
       if (this.screen.config[this.element.config.eventData] && this.screen.config[this.element.config.eventData].items) {
         await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-4228
From: https://github.com/ProcessMaker/screen-builder/pull/1092

Fix error message: "Cannot read properties of undefined (reading 'includes')" message error appears with nested screen and page navigation

----

Ticket: [1183](http://tickets.pm4overflow.com/tickets/1183)

Error is reproducible in screen builder's preview mode.

<h2>Changes</h2>

Fix error `Cannot read properties of undefined (reading includes)` when using the Page Navigation button on a screen that has a Nested Screen configured.

<h2>Replicate the error</h2>

Before testing this branch ensure the error does reproduce in your env. 

1. Import the below screen (remove the .txt extension)
[pageNavigation_test.json.txt](https://github.com/ProcessMaker/screen-builder/files/7401443/pageNavigation_test.json.txt)
2. In the screen's preview mode select the page navigations. 

**Expected Behavior:** 
Page 1 & 3 should produce the error.

<h2>Testing the Fix</h2>

1. Ensure you are on the correct branch
2. Ensure you have the above screen imported
3. In the screen's preview mode select the page navigations

**Expected Behavior**
Pages 1 & 3 should **NOT** produce an error.


