### PR TITLE
Fix: Page Navigation does not work if the data does not provided FOUR-3488

### DIFF
--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -49,6 +49,10 @@ export default {
     };
   },
   methods: {
+    // Convert foo.0.bar to foo[0].bar
+    dot2bracket(str) {
+      return str.replace(/\.\d/g, match => `[${match.substr(1)}]`);
+    },
     submit() {
       this.$emit('submit', this.value);
     },

--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -20,15 +20,15 @@ export default {
         }
         // Update vdata
         this.addMounted(screen, `
-          this.setValue(${JSON.stringify(name)}, this.${name}, this.vdata, this);
+          this.setValue(${JSON.stringify(name)}, this.getValue(${JSON.stringify(name)}), this.vdata, this);
         `);
       });
     },
     setupDefaultValue(screen, name, value) {
       const defaultComputedName = `default_${name}__`;
-      this.addData(screen, `${name}_was_filled__`, `!!this.getValue(${JSON.stringify(name)}, this.vdata)`);
+      this.addData(screen, `${name}_was_filled__`, `!!this.getValue(${JSON.stringify(name)}, this.vdata) || !!this.getValue(${JSON.stringify(name)}, data)`);
       this.addMounted(screen, `if (!this.${name}) {
-        this.tryFormField(${JSON.stringify(name)}, () => {this.${name} = ${value};});
+        this.tryFormField(${JSON.stringify(name)}, () => {this.${this.dot2bracket(name)} = ${value};});
       }`);
       screen.computed[defaultComputedName] = {
         get: new Function(`return this.tryFormField(${JSON.stringify(name)}, () => ${value});`),
@@ -46,7 +46,7 @@ export default {
         const name = element.config.name;
         if (this.isComputedVariable(name, definition)) return;
         if (element.config.defaultValue || element.config.initiallyChecked) {
-          const event = `${name}_was_filled__ |= !!$event; !${name}_was_filled__ && (vdata.${name} = default_${name}__)`;
+          const event = `${name}_was_filled__ |= !!$event; !${name}_was_filled__ && (vdata.${this.dot2bracket(name)} = default_${name}__)`;
           this.addEvent(properties, 'input', event);
         }
       },

--- a/tests/e2e/fixtures/FPP_PFP_CHAIRS_SCREEN.json
+++ b/tests/e2e/fixtures/FPP_PFP_CHAIRS_SCREEN.json
@@ -1,0 +1,19257 @@
+{
+  "type": "screen_package",
+  "version": "2",
+  "screens": [
+    {
+      "id": 1559,
+      "screen_category_id": "53",
+      "title": "FPP_PFP_CHAIRS_SCREEN",
+      "description": "Chairs Form",
+      "type": "FORM",
+      "config": [
+        {
+          "name": "FPP_PREPARE_FACULTY_PLANTILLA_FULL_TIME",
+          "items": [
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_COLLEGE",
+                      "type": "text",
+                      "label": "College:",
+                      "helper": null,
+                      "readonly": true,
+                      "dataFormat": "string",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_COLLEGE}}"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_DEPARTMENT",
+                      "type": "text",
+                      "label": "Department:",
+                      "helper": null,
+                      "readonly": true,
+                      "dataFormat": "string",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_DEPARTMENT}}"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Page Navigation",
+                    "config": {
+                      "icon": "far fa-compass",
+                      "event": "pageNavigate",
+                      "label": "Full Time",
+                      "variant": "link",
+                      "eventData": null
+                    },
+                    "component": "FormButton",
+                    "inspector": [
+                      {
+                        "type": "PageSelect",
+                        "field": "eventData",
+                        "config": {
+                          "label": "Destination Screen",
+                          "helper": "The destination page to navigate to"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Button Label",
+                          "helper": "The label describes the button's text"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                          "label": "Button Variant Style",
+                          "helper": "The variant determines the appearance of the button",
+                          "options": [
+                            { "value": "primary", "content": "Primary" },
+                            { "value": "secondary", "content": "Secondary" },
+                            { "value": "success", "content": "Success" },
+                            { "value": "danger", "content": "Danger" },
+                            { "value": "warning", "content": "Warning" },
+                            { "value": "info", "content": "Info" },
+                            { "value": "light", "content": "Light" },
+                            { "value": "dark", "content": "Dark" },
+                            { "value": "link", "content": "Link" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "PageNavigation",
+                    "editor-component": "FormButton"
+                  }
+                ],
+                [
+                  {
+                    "label": "Page Navigation",
+                    "config": {
+                      "icon": "far fa-compass",
+                      "event": "pageNavigate",
+                      "label": "Part Time",
+                      "variant": "link",
+                      "eventData": "1",
+                      "customCssSelector": "buttonPartTime"
+                    },
+                    "component": "FormButton",
+                    "inspector": [
+                      {
+                        "type": "PageSelect",
+                        "field": "eventData",
+                        "config": {
+                          "label": "Destination Screen",
+                          "helper": "The destination page to navigate to"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Button Label",
+                          "helper": "The label describes the button's text"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                          "label": "Button Variant Style",
+                          "helper": "The variant determines the appearance of the button",
+                          "options": [
+                            { "value": "primary", "content": "Primary" },
+                            { "value": "secondary", "content": "Secondary" },
+                            { "value": "success", "content": "Success" },
+                            { "value": "danger", "content": "Danger" },
+                            { "value": "warning", "content": "Warning" },
+                            { "value": "info", "content": "Info" },
+                            { "value": "light", "content": "Light" },
+                            { "value": "dark", "content": "Dark" },
+                            { "value": "link", "content": "Link" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "PageNavigation",
+                    "editor-component": "FormButton"
+                  }
+                ],
+                []
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "color": null,
+                "label": null,
+                "bgcolor": null,
+                "options": [
+                  { "value": "1", "content": "2" },
+                  { "value": "2", "content": "2" },
+                  { "value": "3", "content": "8" }
+                ],
+                "customCssSelector": "tabsFullTime"
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "label": "Rich Text",
+              "config": {
+                "icon": "fas fa-pencil-ruler",
+                "label": null,
+                "content": "<p style=\"text-align: center;\"><span style=\"font-weight: bolder; color: #ba372a; text-align: center;\">1. FULL TIME PAGE</span></p>",
+                "interactive": true,
+                "renderVarHtml": false
+              },
+              "component": "FormHtmlViewer",
+              "inspector": [
+                {
+                  "type": "FormTextArea",
+                  "field": "content",
+                  "config": {
+                    "rows": 5,
+                    "label": "Content",
+                    "value": null,
+                    "helper": "The HTML text to display"
+                  }
+                },
+                {
+                  "type": "FormCheckbox",
+                  "field": "renderVarHtml",
+                  "config": {
+                    "label": "Render HTML from a Variable",
+                    "value": null,
+                    "helper": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormHtmlEditor",
+              "editor-component": "FormHtmlEditor"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Select List",
+                    "config": {
+                      "icon": "fas fa-angle-double-down",
+                      "name": "FPP_USER_FULL_TIME",
+                      "label": null,
+                      "helper": null,
+                      "options": {
+                        "key": "ID",
+                        "value": "FPP_NAME",
+                        "dataName": "FPP_FULL_TIME.FPP_LIST_USERS_FULL_TIME",
+                        "jsonData": null,
+                        "renderAs": "checkbox",
+                        "editIndex": null,
+                        "dataSource": "dataObject",
+                        "optionsList": [],
+                        "removeIndex": null,
+                        "showRenderAs": true,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "selectedOptions": [],
+                        "allowMultiSelect": false,
+                        "showRemoveWarning": false,
+                        "valueTypeReturned": "object",
+                        "selectedDataSource": null
+                      },
+                      "dataFormat": "array",
+                      "validation": [],
+                      "placeholder": null,
+                      "rootElement": "response",
+                      "defaultValue": { "mode": "js", "value": null },
+                      "dataSourceUrl": null,
+                      "dataSourceEndpoint": null
+                    },
+                    "component": "FormSelectList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "OptionsList",
+                        "field": "options",
+                        "config": { "label": null, "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormSelectList",
+                    "editor-component": "FormSelectList"
+                  }
+                ],
+                [
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_NAME_FULL_TIME",
+                            "type": "text",
+                            "label": "Name:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_FULL_TIME.FPP_NAME_FULL_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_RANK_FULL_TIME",
+                            "type": "text",
+                            "label": "Rank:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_FULL_TIME.FPP_RANK_FULL_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_EMPLOYEE_FULL_TIME",
+                            "type": "text",
+                            "label": "Employee ID:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_FULL_TIME.FPP_EMPLOYEE_FULL_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_GRAND_TOTAL_FULL_TIME",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Grand Total:",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": { "mode": "basic", "value": null }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "props": ["value"],
+                                "watch": { "value": { "immediate": true } },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": "1", "content": "3" },
+                        { "value": "2", "content": "3" },
+                        { "value": "3", "content": "3" },
+                        { "value": "4", "content": "3" }
+                      ],
+                      "customCssSelector": null
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_FULL_TIME_FRONTLOAD_UNDERLOAD",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Frontload / Underload",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "readonly": false,
+                            "dataFormat": "float",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": { "mode": "basic", "value": null }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Select List",
+                          "config": {
+                            "icon": "fas fa-angle-double-down",
+                            "name": "FPP_FULL_TIME_REGULAR_LOAD",
+                            "color": "text-success",
+                            "label": "Regular Load",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "options": {
+                              "key": "value",
+                              "value": "content",
+                              "dataName": "response",
+                              "jsonData": "[{\"value\":null,\"content\":\"- Select -\"},{\"value\":\"12\",\"content\":\"12\"},{\"value\":\"14\",\"content\":\"14\"}]",
+                              "renderAs": "dropdown",
+                              "editIndex": null,
+                              "pmqlQuery": null,
+                              "dataSource": "provideData",
+                              "optionsList": [
+                                { "value": null, "content": "- Select -" },
+                                { "value": "12", "content": "12" },
+                                { "value": "14", "content": "14" }
+                              ],
+                              "removeIndex": null,
+                              "showRenderAs": true,
+                              "showJsonEditor": false,
+                              "showOptionCard": false,
+                              "selectedOptions": [],
+                              "allowMultiSelect": false,
+                              "showRemoveWarning": false,
+                              "valueTypeReturned": "single"
+                            },
+                            "validation": [],
+                            "placeholder": null,
+                            "rootElement": "response",
+                            "defaultValue": { "mode": "basic", "value": null },
+                            "dataSourceUrl": null,
+                            "dataSourceEndpoint": null
+                          },
+                          "component": "FormSelectList",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "OptionsList",
+                              "field": "options",
+                              "config": { "label": null, "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormSelectList",
+                          "editor-component": "FormSelectList"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_FULL_TIME_OVERLOAD",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Overload",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": { "mode": "basic", "value": null }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_FULL_TIME_PREMIUM_TOTAL",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Premium",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": 1, "content": "3" },
+                        { "value": 2, "content": "3" },
+                        { "value": 3, "content": "3" },
+                        { "value": 4, "content": "3" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "label": "Record List",
+                    "config": {
+                      "form": null,
+                      "icon": "fas fa-th-list",
+                      "name": "FPP_USER_FULL_TIME.FPP_TL_FULL_TIME",
+                      "label": "Teaching Load",
+                      "fields": {
+                        "jsonData": "[{\"value\":\"FPP_TL_FULL_TIME_COURSE\",\"content\":\"Course\"},{\"value\":\"FPP_TL_FULL_TIME_SECTION\",\"content\":\"Section\"},{\"value\":\"FPP_TL_FULL_TIME_DAY\",\"content\":\"Day\"},{\"value\":\"FPP_TL_FULL_TIME_TIME\",\"content\":\"Time\"},{\"value\":\"FPP_TL_FULL_TIME_ROOM\",\"content\":\"Room\"},{\"value\":\"FPP_TL_FULL_TIME_FACULTY_UNITS\",\"content\":\"Faculty Units\"},{\"value\":\"FPP_TL_FULL_TIME_TEACHING\",\"content\":\"Teaching\"},{\"value\":\"FPP_TL_FULL_TIME_PREMIUM\",\"content\":\"Premium\"},{\"value\":\"FPP_TL_FULL_TIME_REMARKS\",\"content\":\"Remarks\"}]",
+                        "editIndex": null,
+                        "dataSource": "provideData",
+                        "optionsList": [
+                          {
+                            "value": "FPP_TL_FULL_TIME_COURSE",
+                            "content": "Course"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_SECTION",
+                            "content": "Section"
+                          },
+                          { "value": "FPP_TL_FULL_TIME_DAY", "content": "Day" },
+                          {
+                            "value": "FPP_TL_FULL_TIME_TIME",
+                            "content": "Time"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_ROOM",
+                            "content": "Room"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_FACULTY_UNITS",
+                            "content": "Faculty Units"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_TEACHING",
+                            "content": "Teaching"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_PREMIUM",
+                            "content": "Premium"
+                          },
+                          {
+                            "value": "FPP_TL_FULL_TIME_REMARKS",
+                            "content": "Remarks"
+                          }
+                        ],
+                        "removeIndex": null,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "defaultOptionKey": "FPP_TL_FULL_TIME_COURSE",
+                        "showRemoveWarning": false
+                      },
+                      "editable": false,
+                      "customCssSelector": "recordListTLFullTime"
+                    },
+                    "component": "FormRecordList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "List Label",
+                          "helper": "The label describes this record list"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "editable",
+                        "config": {
+                          "label": "Editable?",
+                          "helper": "Should records be editable/removable and can new records be added"
+                        }
+                      },
+                      {
+                        "type": "ColumnSetup",
+                        "field": "fields",
+                        "config": {
+                          "label": "Columns",
+                          "helper": "List of columns to display in the record list"
+                        }
+                      },
+                      {
+                        "type": "PageSelect",
+                        "field": "form",
+                        "config": {
+                          "label": "Record Form",
+                          "helper": "The form to use for adding/editing records"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormText",
+                    "editor-component": "FormText"
+                  },
+                  {
+                    "label": "Rich Text",
+                    "config": {
+                      "icon": "fas fa-pencil-ruler",
+                      "label": null,
+                      "content": "<br>",
+                      "interactive": true,
+                      "renderVarHtml": false
+                    },
+                    "component": "FormHtmlViewer",
+                    "inspector": [
+                      {
+                        "type": "FormTextArea",
+                        "field": "content",
+                        "config": {
+                          "rows": 5,
+                          "label": "Content",
+                          "value": null,
+                          "helper": "The HTML text to display"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "renderVarHtml",
+                        "config": {
+                          "label": "Render HTML from a Variable",
+                          "value": null,
+                          "helper": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormHtmlEditor",
+                    "editor-component": "FormHtmlEditor"
+                  },
+                  {
+                    "label": "Record List",
+                    "config": {
+                      "form": "2",
+                      "icon": "fas fa-th-list",
+                      "name": "FPP_USER_FULL_TIME.FPP_NTL_FULL_TIME",
+                      "label": "Non-Teaching Load",
+                      "fields": {
+                        "jsonData": "[{\"value\":\"FPP_NTL_FULL_TIME_ACTIVITY\",\"content\":\"Activity\"},{\"value\":\"FPP_NTL_FULL_TIME_ADMIN\",\"content\":\"Admin\"},{\"value\":\"FPP_NTL_FULL_TIME_RESEARCH\",\"content\":\"Research\"},{\"value\":\"FPP_NTL_FULL_TIME_LEAVE_FRONTLOAD\",\"content\":\"Leave/Frontload\"},{\"value\":\"FPP_NTL_FULL_TIME_UNDERLOAD_PAYBACK\",\"content\":\"Underload Payback\"},{\"value\":\"FPP_NTL_FULL_TIME_UNITS\",\"content\":\"Total Unit(s)\"},{\"value\":\"FPP_NTL_FULL_TIME_REMARKS\",\"content\":\"Remarks\"}]",
+                        "editIndex": null,
+                        "dataSource": "provideData",
+                        "optionsList": [
+                          {
+                            "value": "FPP_NTL_FULL_TIME_ACTIVITY",
+                            "content": "Activity"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_ADMIN",
+                            "content": "Admin"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_RESEARCH",
+                            "content": "Research"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_LEAVE_FRONTLOAD",
+                            "content": "Leave/Frontload"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_UNDERLOAD_PAYBACK",
+                            "content": "Underload Payback"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_UNITS",
+                            "content": "Total Unit(s)"
+                          },
+                          {
+                            "value": "FPP_NTL_FULL_TIME_REMARKS",
+                            "content": "Remarks"
+                          }
+                        ],
+                        "removeIndex": null,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "defaultOptionKey": "FPP_NTL_UNITS",
+                        "showRemoveWarning": false
+                      },
+                      "editable": true,
+                      "customCssSelector": "recordListNTLFullTime"
+                    },
+                    "component": "FormRecordList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "List Label",
+                          "helper": "The label describes this record list"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "editable",
+                        "config": {
+                          "label": "Editable?",
+                          "helper": "Should records be editable/removable and can new records be added"
+                        }
+                      },
+                      {
+                        "type": "ColumnSetup",
+                        "field": "fields",
+                        "config": {
+                          "label": "Columns",
+                          "helper": "List of columns to display in the record list"
+                        }
+                      },
+                      {
+                        "type": "PageSelect",
+                        "field": "form",
+                        "config": {
+                          "label": "Record Form",
+                          "helper": "The form to use for adding/editing records"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormText",
+                    "editor-component": "FormText"
+                  },
+                  {
+                    "label": "Textarea",
+                    "config": {
+                      "icon": "fas fa-paragraph",
+                      "name": "FPP_USER_FULL_TIME.FPP_NTL_FULL_TIME",
+                      "rows": 2,
+                      "label": "Remarks",
+                      "helper": null,
+                      "currency": {
+                        "code": "USD",
+                        "name": "US Dollar",
+                        "format": "#,###.##",
+                        "symbol": "$"
+                      },
+                      "readonly": false,
+                      "richtext": false,
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_USER_FULL_TIME.FPP_REMARKS_FULL_TIME}}"
+                      }
+                    },
+                    "component": "FormTextArea",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "richtext",
+                        "config": { "label": "Rich Text", "helper": null }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "rows",
+                        "config": {
+                          "label": "Rows",
+                          "helper": "The number of rows to provide for input",
+                          "validation": "integer"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormTextArea",
+                    "editor-component": "FormTextArea"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Submit Button",
+                          "config": {
+                            "icon": "fas fa-share-square",
+                            "name": "buttonSaveFullTime",
+                            "event": "script",
+                            "label": "Save",
+                            "variant": "secondary",
+                            "fieldValue": null,
+                            "defaultSubmit": true
+                          },
+                          "component": "FormButton",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the button's text"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information."
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "event",
+                              "config": {
+                                "label": "Type",
+                                "helper": "Choose whether the button should submit the form",
+                                "options": [
+                                  {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                  },
+                                  {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "fieldValue",
+                              "config": {
+                                "label": "Value",
+                                "helper": "The value being submitted"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "variant",
+                              "config": {
+                                "label": "Button Variant Style",
+                                "helper": "The variant determines the appearance of the button",
+                                "options": [
+                                  { "value": "primary", "content": "Primary" },
+                                  {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                  },
+                                  { "value": "success", "content": "Success" },
+                                  { "value": "danger", "content": "Danger" },
+                                  { "value": "warning", "content": "Warning" },
+                                  { "value": "info", "content": "Info" },
+                                  { "value": "light", "content": "Light" },
+                                  { "value": "dark", "content": "Dark" },
+                                  { "value": "link", "content": "Link" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormButton",
+                          "editor-component": "FormButton"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Submit Button",
+                          "config": {
+                            "icon": "fas fa-share-square",
+                            "name": "buttonSubmit",
+                            "event": "submit",
+                            "label": "Submit",
+                            "variant": "primary",
+                            "fieldValue": null,
+                            "defaultSubmit": true
+                          },
+                          "component": "FormButton",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the button's text"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information."
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "event",
+                              "config": {
+                                "label": "Type",
+                                "helper": "Choose whether the button should submit the form",
+                                "options": [
+                                  {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                  },
+                                  {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "fieldValue",
+                              "config": {
+                                "label": "Value",
+                                "helper": "The value being submitted"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "variant",
+                              "config": {
+                                "label": "Button Variant Style",
+                                "helper": "The variant determines the appearance of the button",
+                                "options": [
+                                  { "value": "primary", "content": "Primary" },
+                                  {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                  },
+                                  { "value": "success", "content": "Success" },
+                                  { "value": "danger", "content": "Danger" },
+                                  { "value": "warning", "content": "Warning" },
+                                  { "value": "info", "content": "Info" },
+                                  { "value": "light", "content": "Light" },
+                                  { "value": "dark", "content": "Dark" },
+                                  { "value": "link", "content": "Link" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormSubmit",
+                          "editor-component": "FormButton"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": 1, "content": "6" },
+                        { "value": 1, "content": "6" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalUnitsNTLFullTime}}"
+                            },
+                            "conditionalHide": "false"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalTeachingTLFullTime}}"
+                            },
+                            "conditionalHide": "false"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_PREMIUM_TL_FULL_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalPremiumTLFullTime}}"
+                            },
+                            "conditionalHide": "false"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_REQUEST_ID",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{_request.id}}"
+                            },
+                            "conditionalHide": "false"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "props": ["value"],
+                                "watch": { "value": { "immediate": true } },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": "1", "content": "3" },
+                        { "value": "2", "content": "3" },
+                        { "value": "3", "content": "3" },
+                        { "value": "4", "content": "3" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "2" },
+                  { "value": "2", "content": "10" }
+                ],
+                "customCssSelector": "divTeachingLoad"
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            }
+          ]
+        },
+        {
+          "name": "FPP_PREPARE_FACULTY_PLANTILLA_PART_TIME",
+          "items": [
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_COLLEGE",
+                      "type": "text",
+                      "label": "College:",
+                      "helper": null,
+                      "readonly": true,
+                      "dataFormat": "string",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_COLLEGE}}"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "extends": {
+                            "props": [
+                              "label",
+                              "error",
+                              "options",
+                              "helper",
+                              "name",
+                              "value",
+                              "selectedControl"
+                            ],
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "props": ["value"],
+                          "watch": { "value": { "immediate": true } },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_DEPARTMENT",
+                      "type": "text",
+                      "label": "Department:",
+                      "helper": null,
+                      "readonly": true,
+                      "dataFormat": "string",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_DEPARTMENT}}"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "extends": {
+                            "props": [
+                              "label",
+                              "error",
+                              "options",
+                              "helper",
+                              "name",
+                              "value",
+                              "selectedControl"
+                            ],
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "props": ["value"],
+                          "watch": { "value": { "immediate": true } },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Page Navigation",
+                    "config": {
+                      "icon": "far fa-compass",
+                      "event": "pageNavigate",
+                      "label": "Full Time",
+                      "variant": "link",
+                      "eventData": "0",
+                      "customCssSelector": "buttonFullTime"
+                    },
+                    "component": "FormButton",
+                    "inspector": [
+                      {
+                        "type": "PageSelect",
+                        "field": "eventData",
+                        "config": {
+                          "label": "Destination Screen",
+                          "helper": "The destination page to navigate to"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Button Label",
+                          "helper": "The label describes the button's text"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                          "label": "Button Variant Style",
+                          "helper": "The variant determines the appearance of the button",
+                          "options": [
+                            { "value": "primary", "content": "Primary" },
+                            { "value": "secondary", "content": "Secondary" },
+                            { "value": "success", "content": "Success" },
+                            { "value": "danger", "content": "Danger" },
+                            { "value": "warning", "content": "Warning" },
+                            { "value": "info", "content": "Info" },
+                            { "value": "light", "content": "Light" },
+                            { "value": "dark", "content": "Dark" },
+                            { "value": "link", "content": "Link" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "PageNavigation",
+                    "editor-component": "FormButton"
+                  }
+                ],
+                [
+                  {
+                    "label": "Page Navigation",
+                    "config": {
+                      "icon": "far fa-compass",
+                      "event": "pageNavigate",
+                      "label": "Part Time",
+                      "variant": "link",
+                      "eventData": null
+                    },
+                    "component": "FormButton",
+                    "inspector": [
+                      {
+                        "type": "PageSelect",
+                        "field": "eventData",
+                        "config": {
+                          "label": "Destination Screen",
+                          "helper": "The destination page to navigate to"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Button Label",
+                          "helper": "The label describes the button's text"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "variant",
+                        "config": {
+                          "label": "Button Variant Style",
+                          "helper": "The variant determines the appearance of the button",
+                          "options": [
+                            { "value": "primary", "content": "Primary" },
+                            { "value": "secondary", "content": "Secondary" },
+                            { "value": "success", "content": "Success" },
+                            { "value": "danger", "content": "Danger" },
+                            { "value": "warning", "content": "Warning" },
+                            { "value": "info", "content": "Info" },
+                            { "value": "light", "content": "Light" },
+                            { "value": "dark", "content": "Dark" },
+                            { "value": "link", "content": "Link" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "PageNavigation",
+                    "editor-component": "FormButton"
+                  }
+                ],
+                []
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "2" },
+                  { "value": "2", "content": "2" },
+                  { "value": "3", "content": "8" }
+                ],
+                "customCssSelector": "tabsPartTime"
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "label": "Rich Text",
+              "config": {
+                "icon": "fas fa-pencil-ruler",
+                "label": null,
+                "content": "<p style=\"text-align: center;\"><span style=\"font-weight: bolder; color: #ba372a; text-align: center;\">2. PART TIME PAGE</span></p>",
+                "interactive": true,
+                "renderVarHtml": false
+              },
+              "component": "FormHtmlViewer",
+              "inspector": [
+                {
+                  "type": "FormTextArea",
+                  "field": "content",
+                  "config": {
+                    "rows": 5,
+                    "label": "Content",
+                    "value": null,
+                    "helper": "The HTML text to display"
+                  }
+                },
+                {
+                  "type": "FormCheckbox",
+                  "field": "renderVarHtml",
+                  "config": {
+                    "label": "Render HTML from a Variable",
+                    "value": null,
+                    "helper": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormHtmlEditor",
+              "editor-component": "FormHtmlEditor"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Select List",
+                    "config": {
+                      "icon": "fas fa-angle-double-down",
+                      "name": "FPP_USER_PART_TIME",
+                      "label": null,
+                      "helper": null,
+                      "options": {
+                        "key": "value",
+                        "value": "FPP_NAME",
+                        "dataName": "FPP_PART_TIME.FPP_LIST_USERS_PART_TIME",
+                        "jsonData": null,
+                        "renderAs": "checkbox",
+                        "editIndex": null,
+                        "dataSource": "dataObject",
+                        "optionsList": [],
+                        "removeIndex": null,
+                        "showRenderAs": true,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "selectedOptions": [],
+                        "allowMultiSelect": false,
+                        "showRemoveWarning": false,
+                        "valueTypeReturned": "object",
+                        "selectedDataSource": null
+                      },
+                      "dataFormat": "array",
+                      "validation": [],
+                      "placeholder": null,
+                      "rootElement": "response",
+                      "defaultValue": { "mode": "basic", "value": null },
+                      "dataSourceUrl": null,
+                      "dataSourceEndpoint": null
+                    },
+                    "component": "FormSelectList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "OptionsList",
+                        "field": "options",
+                        "config": { "label": null, "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormSelectList",
+                    "editor-component": "FormSelectList"
+                  }
+                ],
+                [
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_NAME_PART_TIME",
+                            "type": "text",
+                            "label": "Name:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_PART_TIME.FPP_NAME_PART_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_RANK_PART_TIME",
+                            "type": "text",
+                            "label": "Rank:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_PART_TIME.FPP_RANK_PART_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_EMPLOYEE_PART_TIME",
+                            "type": "text",
+                            "label": "Employee ID:",
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{FPP_USER_PART_TIME.FPP_EMPLOYEE_PART_TIME}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_GRAND_TOTAL_PART_TIME",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Grand Total:",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{grandTotalPartTime}}"
+                            }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "amdRequire": []
+                                    },
+                                    "watch": { "options": { "deep": true } },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": "1", "content": "3" },
+                        { "value": "2", "content": "3" },
+                        { "value": "3", "content": "3" },
+                        { "value": "4", "content": "3" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_PART_TIME_FRONTLOAD_UNDERLOAD",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Frontload / Underload",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "readonly": false,
+                            "dataFormat": "float",
+                            "validation": [],
+                            "placeholder": null
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Select List",
+                          "config": {
+                            "icon": "fas fa-angle-double-down",
+                            "name": "FPP_PART_TIME_REGULAR_LOAD",
+                            "color": "text-success",
+                            "label": "Regular Load",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "options": {
+                              "key": "value",
+                              "value": "content",
+                              "dataName": "response",
+                              "jsonData": "[{\"value\":\"12\",\"content\":\"12\"},{\"value\":\"14\",\"content\":\"14\"}]",
+                              "renderAs": "dropdown",
+                              "editIndex": null,
+                              "pmqlQuery": null,
+                              "dataSource": "provideData",
+                              "optionsList": [
+                                { "value": "12", "content": "12" },
+                                { "value": "14", "content": "14" }
+                              ],
+                              "removeIndex": null,
+                              "showRenderAs": true,
+                              "showJsonEditor": false,
+                              "showOptionCard": false,
+                              "selectedOptions": [],
+                              "allowMultiSelect": false,
+                              "showRemoveWarning": false,
+                              "valueTypeReturned": "single"
+                            },
+                            "validation": [],
+                            "placeholder": null,
+                            "rootElement": "response",
+                            "dataSourceUrl": null,
+                            "dataSourceEndpoint": null
+                          },
+                          "component": "FormSelectList",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "OptionsList",
+                              "field": "options",
+                              "config": { "label": null, "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormSelectList",
+                          "editor-component": "FormSelectList"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_PART_TIME_OVERLOAD",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Overload",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": { "mode": "basic", "value": null }
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_PART_TIME_PREMIUM_TOTAL",
+                            "type": "text",
+                            "color": "text-success",
+                            "label": "Premium",
+                            "helper": null,
+                            "bgcolor": "alert alert-success",
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-5d32d6af",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "monaco-editor",
+                                    "_Ctor": [],
+                                    "props": { "amdRequire": [] },
+                                    "extends": {
+                                      "name": "MonacoEditor",
+                                      "model": { "event": "change" },
+                                      "props": {
+                                        "theme": { "default": "vs" },
+                                        "value": { "required": true },
+                                        "options": [],
+                                        "language": [],
+                                        "original": [],
+                                        "amdRequire": [],
+                                        "diffEditor": { "default": false }
+                                      },
+                                      "watch": {
+                                        "options": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customFormatter",
+                              "config": {
+                                "label": "Custom Format String",
+                                "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                "validation": null
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": 1, "content": "3" },
+                        { "value": 2, "content": "3" },
+                        { "value": 3, "content": "3" },
+                        { "value": 4, "content": "3" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "label": "Record List",
+                    "config": {
+                      "form": "5",
+                      "icon": "fas fa-th-list",
+                      "name": "FPP_USER_PART_TIME.FPP_TL_PART_TIME",
+                      "label": "Teaching Load",
+                      "fields": {
+                        "jsonData": "[{\"value\":\"FPP_TL_PART_TIME_COURSE\",\"content\":\"Course\"},{\"value\":\"FPP_TL_PART_TIME_SECTION\",\"content\":\"Section\"},{\"value\":\"FPP_TL_PART_TIME_DAY\",\"content\":\"Day\"},{\"value\":\"FPP_TL_PART_TIME_TIME\",\"content\":\"Time\"},{\"value\":\"FPP_TL_PART_TIME_ROOM\",\"content\":\"Room\"},{\"value\":\"FPP_TL_PART_TIME_FACULTY_UNITS\",\"content\":\"Faculty Units\"},{\"value\":\"FPP_TL_PART_TIME_TEACHING\",\"content\":\"Teaching\"},{\"value\":\"FPP_TL_PART_TIME_PREMIUM\",\"content\":\"Premium\"},{\"value\":\"FPP_TL_PART_TIME_REMARKS\",\"content\":\"Remarks\"}]",
+                        "editIndex": null,
+                        "dataSource": "provideData",
+                        "optionsList": [
+                          {
+                            "value": "FPP_TL_PART_TIME_COURSE",
+                            "content": "Course"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_SECTION",
+                            "content": "Section"
+                          },
+                          { "value": "FPP_TL_PART_TIME_DAY", "content": "Day" },
+                          {
+                            "value": "FPP_TL_PART_TIME_TIME",
+                            "content": "Time"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_ROOM",
+                            "content": "Room"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_FACULTY_UNITS",
+                            "content": "Faculty Units"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_TEACHING",
+                            "content": "Teaching"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_PREMIUM",
+                            "content": "Premium"
+                          },
+                          {
+                            "value": "FPP_TL_PART_TIME_REMARKS",
+                            "content": "Remarks"
+                          }
+                        ],
+                        "removeIndex": null,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "showRemoveWarning": false
+                      },
+                      "editable": false,
+                      "customCssSelector": "recordListTLPartTime"
+                    },
+                    "component": "FormRecordList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "List Label",
+                          "helper": "The label describes this record list"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "editable",
+                        "config": {
+                          "label": "Editable?",
+                          "helper": "Should records be editable/removable and can new records be added"
+                        }
+                      },
+                      {
+                        "type": "ColumnSetup",
+                        "field": "fields",
+                        "config": {
+                          "label": "Columns",
+                          "helper": "List of columns to display in the record list"
+                        }
+                      },
+                      {
+                        "type": "PageSelect",
+                        "field": "form",
+                        "config": {
+                          "label": "Record Form",
+                          "helper": "The form to use for adding/editing records"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormText",
+                    "editor-component": "FormText"
+                  },
+                  {
+                    "label": "Rich Text",
+                    "config": {
+                      "icon": "fas fa-pencil-ruler",
+                      "label": null,
+                      "content": "<br>",
+                      "interactive": true,
+                      "renderVarHtml": false
+                    },
+                    "component": "FormHtmlViewer",
+                    "inspector": [
+                      {
+                        "type": "FormTextArea",
+                        "field": "content",
+                        "config": {
+                          "rows": 5,
+                          "label": "Content",
+                          "value": null,
+                          "helper": "The HTML text to display"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "renderVarHtml",
+                        "config": {
+                          "label": "Render HTML from a Variable",
+                          "value": null,
+                          "helper": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormHtmlEditor",
+                    "editor-component": "FormHtmlEditor"
+                  },
+                  {
+                    "label": "Record List",
+                    "config": {
+                      "form": "3",
+                      "icon": "fas fa-th-list",
+                      "name": "FPP_USER_PART_TIME.FPP_NTL_PART_TIME",
+                      "label": "Non-Teaching Load",
+                      "fields": {
+                        "jsonData": "[{\"value\":\"FPP_NTL_PART_TIME_ACTIVITY\",\"content\":\"Activity\"},{\"value\":\"FPP_NTL_PART_TIME_ADMIN\",\"content\":\"Admin\"},{\"value\":\"FPP_NTL_PART_TIME_RESEARCH\",\"content\":\"Research\"},{\"value\":\"FPP_NTL_PART_TIME_LEAVE_FRONTLOAD\",\"content\":\"Leave/Frontload\"},{\"value\":\"FPP_NTL_PART_TIME_UNDERLOAD_PAYBACK\",\"content\":\"Underload Payback\"},{\"value\":\"FPP_NTL_PART_TIME_UNITS\",\"content\":\"Total Unit(s)\"},{\"value\":\"FPP_NTL_PART_TIME_REMARKS\",\"content\":\"Remarks\"}]",
+                        "editIndex": null,
+                        "dataSource": "provideData",
+                        "optionsList": [
+                          {
+                            "value": "FPP_NTL_PART_TIME_ACTIVITY",
+                            "content": "Activity"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_ADMIN",
+                            "content": "Admin"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_RESEARCH",
+                            "content": "Research"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_LEAVE_FRONTLOAD",
+                            "content": "Leave/Frontload"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_UNDERLOAD_PAYBACK",
+                            "content": "Underload Payback"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_UNITS",
+                            "content": "Total Unit(s)"
+                          },
+                          {
+                            "value": "FPP_NTL_PART_TIME_REMARKS",
+                            "content": "Remarks"
+                          }
+                        ],
+                        "removeIndex": null,
+                        "showJsonEditor": false,
+                        "showOptionCard": false,
+                        "showRemoveWarning": false
+                      },
+                      "editable": true,
+                      "customCssSelector": "recordListNTLPartTime"
+                    },
+                    "component": "FormRecordList",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "List Label",
+                          "helper": "The label describes this record list"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "editable",
+                        "config": {
+                          "label": "Editable?",
+                          "helper": "Should records be editable/removable and can new records be added"
+                        }
+                      },
+                      {
+                        "type": "ColumnSetup",
+                        "field": "fields",
+                        "config": {
+                          "label": "Columns",
+                          "helper": "List of columns to display in the record list"
+                        }
+                      },
+                      {
+                        "type": "PageSelect",
+                        "field": "form",
+                        "config": {
+                          "label": "Record Form",
+                          "helper": "The form to use for adding/editing records"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormText",
+                    "editor-component": "FormText"
+                  },
+                  {
+                    "label": "Textarea",
+                    "config": {
+                      "icon": "fas fa-paragraph",
+                      "name": "FPP_REMARKS_PART_TIME",
+                      "rows": 2,
+                      "label": "Remarks:",
+                      "helper": null,
+                      "currency": {
+                        "code": "USD",
+                        "name": "US Dollar",
+                        "format": "#,###.##",
+                        "symbol": "$"
+                      },
+                      "readonly": false,
+                      "richtext": false,
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "basic",
+                        "value": "{{FPP_USER_PART_TIME.FPP_REMARKS_PART_TIME}}"
+                      }
+                    },
+                    "component": "FormTextArea",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "richtext",
+                        "config": { "label": "Rich Text", "helper": null }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "rows",
+                        "config": {
+                          "label": "Rows",
+                          "helper": "The number of rows to provide for input",
+                          "validation": "integer"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "_Ctor": [],
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "value": [],
+                                "options": [],
+                                "language": [],
+                                "amdRequire": []
+                              },
+                              "watch": {
+                                "options": { "deep": true, "user": true }
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormTextArea",
+                    "editor-component": "FormTextArea"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Submit Button",
+                          "config": {
+                            "icon": "fas fa-share-square",
+                            "name": "buttonSavePartTime",
+                            "event": "script",
+                            "label": "Save",
+                            "variant": "secondary",
+                            "fieldValue": null,
+                            "defaultSubmit": true
+                          },
+                          "component": "FormButton",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the button's text"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information."
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "event",
+                              "config": {
+                                "label": "Type",
+                                "helper": "Choose whether the button should submit the form",
+                                "options": [
+                                  {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                  },
+                                  {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "fieldValue",
+                              "config": {
+                                "label": "Value",
+                                "helper": "The value being submitted"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "variant",
+                              "config": {
+                                "label": "Button Variant Style",
+                                "helper": "The variant determines the appearance of the button",
+                                "options": [
+                                  { "value": "primary", "content": "Primary" },
+                                  {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                  },
+                                  { "value": "success", "content": "Success" },
+                                  { "value": "danger", "content": "Danger" },
+                                  { "value": "warning", "content": "Warning" },
+                                  { "value": "info", "content": "Info" },
+                                  { "value": "light", "content": "Light" },
+                                  { "value": "dark", "content": "Dark" },
+                                  { "value": "link", "content": "Link" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormButton",
+                          "editor-component": "FormButton"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Submit Button",
+                          "config": {
+                            "icon": "fas fa-share-square",
+                            "name": "buttonSubmit",
+                            "event": "submit",
+                            "label": "Submit",
+                            "variant": "primary",
+                            "fieldValue": null,
+                            "defaultSubmit": true
+                          },
+                          "component": "FormButton",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the button's text"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information."
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "event",
+                              "config": {
+                                "label": "Type",
+                                "helper": "Choose whether the button should submit the form",
+                                "options": [
+                                  {
+                                    "value": "submit",
+                                    "content": "Submit Button"
+                                  },
+                                  {
+                                    "value": "script",
+                                    "content": "Regular Button"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "fieldValue",
+                              "config": {
+                                "label": "Value",
+                                "helper": "The value being submitted"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "variant",
+                              "config": {
+                                "label": "Button Variant Style",
+                                "helper": "The variant determines the appearance of the button",
+                                "options": [
+                                  { "value": "primary", "content": "Primary" },
+                                  {
+                                    "value": "secondary",
+                                    "content": "Secondary"
+                                  },
+                                  { "value": "success", "content": "Success" },
+                                  { "value": "danger", "content": "Danger" },
+                                  { "value": "warning", "content": "Warning" },
+                                  { "value": "info", "content": "Info" },
+                                  { "value": "light", "content": "Light" },
+                                  { "value": "dark", "content": "Dark" },
+                                  { "value": "link", "content": "Link" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormSubmit",
+                          "editor-component": "FormButton"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": "1", "content": "6" },
+                        { "value": "2", "content": "6" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  },
+                  {
+                    "items": [
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_UNITS_NTL_PART_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalUnitsNTLPartTime}}"
+                            },
+                            "conditionalHide": "true = true"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_FACULTY_TL_PART_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalFacultyTLPartTime}}"
+                            },
+                            "conditionalHide": "true = true"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_SUB_TOTAL_PREMIUM_TL_PART_TIME",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "dataMask": {
+                              "code": "PHP",
+                              "name": "Philippine Peso",
+                              "format": "#,###.##",
+                              "symbol": null
+                            },
+                            "readonly": true,
+                            "dataFormat": "currency",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{subTotalPremiumTLPartTime}}"
+                            },
+                            "conditionalHide": "true = true"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ],
+                      [
+                        {
+                          "label": "Line Input",
+                          "config": {
+                            "icon": "far fa-square",
+                            "name": "FPP_REQUEST_ID",
+                            "type": "text",
+                            "label": null,
+                            "helper": null,
+                            "readonly": true,
+                            "dataFormat": "string",
+                            "validation": [],
+                            "placeholder": null,
+                            "defaultValue": {
+                              "mode": "basic",
+                              "value": "{{_request.id}}"
+                            },
+                            "conditionalHide": "true = true"
+                          },
+                          "component": "FormInput",
+                          "inspector": [
+                            {
+                              "type": "FormInput",
+                              "field": "name",
+                              "config": {
+                                "name": "Variable Name",
+                                "label": "Variable Name",
+                                "helper": "A variable name is a symbolic name to reference information.",
+                                "validation": "regex:/^(?:[A-Z_.a-z])(?:[0-9A-Z_.a-z])*$/|required"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "label",
+                              "config": {
+                                "label": "Label",
+                                "helper": "The label describes the field's name"
+                              }
+                            },
+                            {
+                              "type": "FormMultiselect",
+                              "field": "dataFormat",
+                              "config": {
+                                "name": "Data Type",
+                                "label": "Data Type",
+                                "helper": "The data type specifies what kind of data is stored in the variable.",
+                                "options": [
+                                  { "value": "string", "content": "Text" },
+                                  { "value": "int", "content": "Integer" },
+                                  {
+                                    "value": "currency",
+                                    "content": "Currency"
+                                  },
+                                  {
+                                    "value": "percentage",
+                                    "content": "Percentage"
+                                  },
+                                  { "value": "float", "content": "Decimal" },
+                                  {
+                                    "value": "datetime",
+                                    "content": "Datetime"
+                                  },
+                                  { "value": "date", "content": "Date" },
+                                  { "value": "password", "content": "Password" }
+                                ],
+                                "validation": "required"
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "extends": {
+                                  "_Ctor": [],
+                                  "props": {
+                                    "name": { "type": null },
+                                    "error": { "type": null },
+                                    "label": { "type": null },
+                                    "value": { "type": null },
+                                    "helper": { "type": null },
+                                    "options": { "type": null },
+                                    "selectedControl": { "type": null }
+                                  },
+                                  "mixins": [
+                                    {
+                                      "props": {
+                                        "validation": { "type": null },
+                                        "validationData": { "type": null },
+                                        "validationField": { "type": null },
+                                        "validationMessages": { "type": null }
+                                      },
+                                      "watch": {
+                                        "validationData": {
+                                          "deep": true,
+                                          "user": true
+                                        }
+                                      },
+                                      "methods": []
+                                    }
+                                  ],
+                                  "methods": [],
+                                  "computed": [],
+                                  "_compiled": true,
+                                  "components": {
+                                    "Multiselect": {
+                                      "name": "vue-multiselect",
+                                      "_Ctor": [],
+                                      "props": {
+                                        "name": { "default": null },
+                                        "limit": { "default": 99999 },
+                                        "loading": { "default": false },
+                                        "disabled": { "default": false },
+                                        "tabindex": { "default": 0 },
+                                        "limitText": [],
+                                        "maxHeight": { "default": 300 },
+                                        "showLabels": { "default": true },
+                                        "selectLabel": {
+                                          "default": "Press enter to select"
+                                        },
+                                        "deselectLabel": {
+                                          "default": "Press enter to remove"
+                                        },
+                                        "openDirection": { "default": null },
+                                        "selectedLabel": {
+                                          "default": "Selected"
+                                        },
+                                        "showNoOptions": { "default": true },
+                                        "showNoResults": { "default": true },
+                                        "selectGroupLabel": {
+                                          "default": "Press enter to select group"
+                                        },
+                                        "deselectGroupLabel": {
+                                          "default": "Press enter to deselect group"
+                                        }
+                                      },
+                                      "mixins": [
+                                        {
+                                          "props": {
+                                            "id": { "default": null },
+                                            "max": {
+                                              "type": [null, null],
+                                              "default": false
+                                            },
+                                            "label": [],
+                                            "value": { "type": null },
+                                            "options": { "required": true },
+                                            "trackBy": [],
+                                            "multiple": { "default": false },
+                                            "taggable": { "default": false },
+                                            "blockKeys": [],
+                                            "allowEmpty": { "default": true },
+                                            "groupLabel": [],
+                                            "resetAfter": { "default": false },
+                                            "searchable": { "default": true },
+                                            "customLabel": [],
+                                            "groupSelect": { "default": false },
+                                            "groupValues": [],
+                                            "placeholder": {
+                                              "default": "Select option"
+                                            },
+                                            "tagPosition": { "default": "top" },
+                                            "hideSelected": {
+                                              "default": false
+                                            },
+                                            "optionsLimit": { "default": 1000 },
+                                            "clearOnSelect": {
+                                              "default": true
+                                            },
+                                            "closeOnSelect": {
+                                              "default": true
+                                            },
+                                            "internalSearch": {
+                                              "default": true
+                                            },
+                                            "preselectFirst": {
+                                              "default": false
+                                            },
+                                            "preserveSearch": {
+                                              "default": false
+                                            },
+                                            "tagPlaceholder": {
+                                              "default": "Press enter to create a tag"
+                                            }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        },
+                                        {
+                                          "props": {
+                                            "showPointer": { "default": true },
+                                            "optionHeight": { "default": 40 }
+                                          },
+                                          "watch": [],
+                                          "methods": [],
+                                          "computed": []
+                                        }
+                                      ],
+                                      "computed": [],
+                                      "_compiled": true,
+                                      "beforeCreate": [null],
+                                      "staticRenderFns": []
+                                    }
+                                  },
+                                  "inheritAttrs": false,
+                                  "staticRenderFns": []
+                                },
+                                "computed": [],
+                                "_compiled": true,
+                                "staticRenderFns": []
+                              },
+                              "field": "dataMask",
+                              "config": {
+                                "name": "Data Format",
+                                "label": "Data Format",
+                                "helper": "The data format for the selected type."
+                              }
+                            },
+                            {
+                              "type": "ValidationSelect",
+                              "field": "validation",
+                              "config": {
+                                "label": "Validation Rules",
+                                "helper": "The validation rules needed for this field"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "placeholder",
+                              "config": {
+                                "label": "Placeholder Text",
+                                "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "helper",
+                              "config": {
+                                "label": "Helper Text",
+                                "helper": "Help text is meant to provide additional guidance on the field's value"
+                              }
+                            },
+                            {
+                              "type": "FormCheckbox",
+                              "field": "readonly",
+                              "config": { "label": "Read Only", "helper": null }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "color",
+                              "config": {
+                                "label": "Text Color",
+                                "helper": "Set the element's text color",
+                                "options": [
+                                  {
+                                    "value": "text-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "text-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "text-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "text-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "text-warning",
+                                    "content": "warning"
+                                  },
+                                  { "value": "text-info", "content": "info" },
+                                  { "value": "text-light", "content": "light" },
+                                  { "value": "text-dark", "content": "dark" }
+                                ]
+                              }
+                            },
+                            {
+                              "type": "ColorSelect",
+                              "field": "bgcolor",
+                              "config": {
+                                "label": "Background Color",
+                                "helper": "Set the element's background color",
+                                "options": [
+                                  {
+                                    "value": "alert alert-primary",
+                                    "content": "primary"
+                                  },
+                                  {
+                                    "value": "alert alert-secondary",
+                                    "content": "secondary"
+                                  },
+                                  {
+                                    "value": "alert alert-success",
+                                    "content": "success"
+                                  },
+                                  {
+                                    "value": "alert alert-danger",
+                                    "content": "danger"
+                                  },
+                                  {
+                                    "value": "alert alert-warning",
+                                    "content": "warning"
+                                  },
+                                  {
+                                    "value": "alert alert-info",
+                                    "content": "info"
+                                  },
+                                  {
+                                    "value": "alert alert-light",
+                                    "content": "light"
+                                  },
+                                  {
+                                    "value": "alert alert-dark",
+                                    "content": "dark"
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "type": {
+                                "_Ctor": [],
+                                "props": { "value": { "type": null } },
+                                "watch": {
+                                  "value": { "user": true, "immediate": true }
+                                },
+                                "methods": [],
+                                "_scopeId": "data-v-67152bf8",
+                                "computed": { "effectiveValue": [] },
+                                "_compiled": true,
+                                "components": {
+                                  "MonacoEditor": {
+                                    "name": "MonacoEditor",
+                                    "_Ctor": [],
+                                    "model": { "event": "change" },
+                                    "props": {
+                                      "theme": { "default": "vs" },
+                                      "value": [],
+                                      "options": [],
+                                      "language": [],
+                                      "amdRequire": []
+                                    },
+                                    "watch": {
+                                      "options": { "deep": true, "user": true }
+                                    },
+                                    "methods": []
+                                  }
+                                },
+                                "staticRenderFns": []
+                              },
+                              "field": "defaultValue",
+                              "config": {
+                                "label": "Default Value",
+                                "helper": "Takes precedence over value set in data."
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "conditionalHide",
+                              "config": {
+                                "label": "Visibility Rule",
+                                "helper": "This control is hidden until this expression is true"
+                              }
+                            },
+                            {
+                              "type": "FormInput",
+                              "field": "customCssSelector",
+                              "config": {
+                                "label": "CSS Selector Name",
+                                "helper": "Use this in your custom css rules",
+                                "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                              }
+                            }
+                          ],
+                          "editor-control": "FormInput",
+                          "editor-component": "FormInput"
+                        }
+                      ]
+                    ],
+                    "label": "Multicolumn / Table",
+                    "config": {
+                      "icon": "fas fa-table",
+                      "label": null,
+                      "options": [
+                        { "value": "1", "content": "3" },
+                        { "value": "2", "content": "3" },
+                        { "value": "3", "content": "3" },
+                        { "value": "4", "content": "3" }
+                      ]
+                    },
+                    "component": "FormMultiColumn",
+                    "container": true,
+                    "inspector": [
+                      {
+                        "type": "ContainerColumns",
+                        "field": "options",
+                        "config": {
+                          "label": "Column Width",
+                          "helper": null,
+                          "validation": "columns-adds-to-12"
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormMultiColumn",
+                    "editor-component": "MultiColumn"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "2" },
+                  { "value": "2", "content": "10" }
+                ],
+                "customCssSelector": "divTeachingLoad"
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            }
+          ]
+        },
+        {
+          "name": "FPP_RECORD_LIST_NTL_FULL_TIME",
+          "items": [
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_ACTIVITY",
+                      "type": "text",
+                      "label": "Activity:",
+                      "helper": null,
+                      "readonly": false,
+                      "dataFormat": "string",
+                      "validation": [
+                        {
+                          "value": "required",
+                          "helper": "Checks if the length of the String representation of the value is >",
+                          "content": "Required"
+                        }
+                      ],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_ADMIN",
+                      "type": "text",
+                      "label": "Admin:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_RESEARCH",
+                      "type": "text",
+                      "label": "Research:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "js", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_LEAVE_FRONTLOAD",
+                      "type": "text",
+                      "label": "Leave/Frontload",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-5d32d6af",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "monaco-editor",
+                              "_Ctor": [],
+                              "props": { "amdRequire": [] },
+                              "extends": {
+                                "name": "MonacoEditor",
+                                "model": { "event": "change" },
+                                "props": {
+                                  "theme": { "default": "vs" },
+                                  "value": { "required": true },
+                                  "options": [],
+                                  "language": [],
+                                  "original": [],
+                                  "amdRequire": [],
+                                  "diffEditor": { "default": false }
+                                },
+                                "watch": {
+                                  "options": { "deep": true, "user": true }
+                                },
+                                "methods": []
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_UNDERLOAD_PAYBACK",
+                      "type": "text",
+                      "label": "Underload Payback",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-5d32d6af",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "monaco-editor",
+                              "_Ctor": [],
+                              "props": { "amdRequire": [] },
+                              "extends": {
+                                "name": "MonacoEditor",
+                                "model": { "event": "change" },
+                                "props": {
+                                  "theme": { "default": "vs" },
+                                  "value": { "required": true },
+                                  "options": [],
+                                  "language": [],
+                                  "original": [],
+                                  "amdRequire": [],
+                                  "diffEditor": { "default": false }
+                                },
+                                "watch": {
+                                  "options": { "deep": true, "user": true }
+                                },
+                                "methods": []
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_FULL_TIME_UNITS",
+                      "type": "text",
+                      "label": "Total Units:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": true,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "js",
+                        "value": "let sumUnits = 0;\nif(!isNaN(parseFloat(this.FPP_NTL_FULL_TIME_ADMIN))){\n    sumUnits = parseFloat(sumUnits) + parseFloat(this.FPP_NTL_FULL_TIME_ADMIN);\n}\nif(!isNaN(parseFloat(this.FPP_NTL_FULL_TIME_RESEARCH))){\n    sumUnits = parseFloat(sumUnits) + parseFloat(this.FPP_NTL_FULL_TIME_RESEARCH);\n}\nreturn parseFloat(sumUnits);"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "extends": {
+                            "props": [
+                              "label",
+                              "error",
+                              "options",
+                              "helper",
+                              "name",
+                              "value",
+                              "selectedControl"
+                            ],
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "props": ["value"],
+                          "watch": { "value": { "immediate": true } },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "amdRequire": []
+                              },
+                              "watch": { "options": { "deep": true } },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "label": "Line Input",
+              "config": {
+                "icon": "far fa-square",
+                "name": "FPP_NTL_FULL_TIME_REMARKS",
+                "type": "text",
+                "label": "Remarks:",
+                "helper": null,
+                "readonly": false,
+                "dataFormat": "string",
+                "validation": [],
+                "placeholder": null,
+                "defaultValue": { "mode": "basic", "value": null }
+              },
+              "component": "FormInput",
+              "inspector": [
+                {
+                  "type": "FormInput",
+                  "field": "name",
+                  "config": {
+                    "name": "Variable Name",
+                    "label": "Variable Name",
+                    "helper": "A variable name is a symbolic name to reference information.",
+                    "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "label",
+                  "config": {
+                    "label": "Label",
+                    "helper": "The label describes the field's name"
+                  }
+                },
+                {
+                  "type": "FormMultiselect",
+                  "field": "dataFormat",
+                  "config": {
+                    "name": "Data Type",
+                    "label": "Data Type",
+                    "helper": "The data type specifies what kind of data is stored in the variable.",
+                    "options": [
+                      { "value": "string", "content": "Text" },
+                      { "value": "int", "content": "Integer" },
+                      { "value": "currency", "content": "Currency" },
+                      { "value": "percentage", "content": "Percentage" },
+                      { "value": "float", "content": "Decimal" },
+                      { "value": "datetime", "content": "Datetime" },
+                      { "value": "date", "content": "Date" },
+                      { "value": "password", "content": "Password" }
+                    ],
+                    "validation": "required"
+                  }
+                },
+                {
+                  "type": {
+                    "_Ctor": [],
+                    "extends": {
+                      "_Ctor": [],
+                      "props": {
+                        "name": { "type": null },
+                        "error": { "type": null },
+                        "label": { "type": null },
+                        "value": { "type": null },
+                        "helper": { "type": null },
+                        "options": { "type": null },
+                        "selectedControl": { "type": null }
+                      },
+                      "mixins": [
+                        {
+                          "props": {
+                            "validation": { "type": null },
+                            "validationData": { "type": null },
+                            "validationField": { "type": null },
+                            "validationMessages": { "type": null }
+                          },
+                          "watch": {
+                            "validationData": { "deep": true, "user": true }
+                          },
+                          "methods": []
+                        }
+                      ],
+                      "methods": [],
+                      "computed": [],
+                      "_compiled": true,
+                      "components": {
+                        "Multiselect": {
+                          "name": "vue-multiselect",
+                          "_Ctor": [],
+                          "props": {
+                            "name": { "default": null },
+                            "limit": { "default": 99999 },
+                            "loading": { "default": false },
+                            "disabled": { "default": false },
+                            "tabindex": { "default": 0 },
+                            "limitText": [],
+                            "maxHeight": { "default": 300 },
+                            "showLabels": { "default": true },
+                            "selectLabel": {
+                              "default": "Press enter to select"
+                            },
+                            "deselectLabel": {
+                              "default": "Press enter to remove"
+                            },
+                            "openDirection": { "default": null },
+                            "selectedLabel": { "default": "Selected" },
+                            "showNoOptions": { "default": true },
+                            "showNoResults": { "default": true },
+                            "selectGroupLabel": {
+                              "default": "Press enter to select group"
+                            },
+                            "deselectGroupLabel": {
+                              "default": "Press enter to deselect group"
+                            }
+                          },
+                          "mixins": [
+                            {
+                              "props": {
+                                "id": { "default": null },
+                                "max": {
+                                  "type": [null, null],
+                                  "default": false
+                                },
+                                "label": [],
+                                "value": { "type": null },
+                                "options": { "required": true },
+                                "trackBy": [],
+                                "multiple": { "default": false },
+                                "taggable": { "default": false },
+                                "blockKeys": [],
+                                "allowEmpty": { "default": true },
+                                "groupLabel": [],
+                                "resetAfter": { "default": false },
+                                "searchable": { "default": true },
+                                "customLabel": [],
+                                "groupSelect": { "default": false },
+                                "groupValues": [],
+                                "placeholder": { "default": "Select option" },
+                                "tagPosition": { "default": "top" },
+                                "hideSelected": { "default": false },
+                                "optionsLimit": { "default": 1000 },
+                                "clearOnSelect": { "default": true },
+                                "closeOnSelect": { "default": true },
+                                "internalSearch": { "default": true },
+                                "preselectFirst": { "default": false },
+                                "preserveSearch": { "default": false },
+                                "tagPlaceholder": {
+                                  "default": "Press enter to create a tag"
+                                }
+                              },
+                              "watch": [],
+                              "methods": [],
+                              "computed": []
+                            },
+                            {
+                              "props": {
+                                "showPointer": { "default": true },
+                                "optionHeight": { "default": 40 }
+                              },
+                              "watch": [],
+                              "methods": [],
+                              "computed": []
+                            }
+                          ],
+                          "computed": [],
+                          "_compiled": true,
+                          "beforeCreate": [null],
+                          "staticRenderFns": []
+                        }
+                      },
+                      "inheritAttrs": false,
+                      "staticRenderFns": []
+                    },
+                    "computed": [],
+                    "_compiled": true,
+                    "staticRenderFns": []
+                  },
+                  "field": "dataMask",
+                  "config": {
+                    "name": "Data Format",
+                    "label": "Data Format",
+                    "helper": "The data format for the selected type."
+                  }
+                },
+                {
+                  "type": "ValidationSelect",
+                  "field": "validation",
+                  "config": {
+                    "label": "Validation Rules",
+                    "helper": "The validation rules needed for this field"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "placeholder",
+                  "config": {
+                    "label": "Placeholder Text",
+                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "helper",
+                  "config": {
+                    "label": "Helper Text",
+                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                  }
+                },
+                {
+                  "type": "FormCheckbox",
+                  "field": "readonly",
+                  "config": { "label": "Read Only", "helper": null }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": {
+                    "_Ctor": [],
+                    "props": { "value": { "type": null } },
+                    "watch": { "value": { "user": true, "immediate": true } },
+                    "methods": [],
+                    "_scopeId": "data-v-67152bf8",
+                    "computed": { "effectiveValue": [] },
+                    "_compiled": true,
+                    "components": {
+                      "MonacoEditor": {
+                        "name": "MonacoEditor",
+                        "model": { "event": "change" },
+                        "props": {
+                          "theme": { "default": "vs" },
+                          "amdRequire": []
+                        },
+                        "watch": { "options": { "deep": true } },
+                        "methods": []
+                      }
+                    },
+                    "staticRenderFns": []
+                  },
+                  "field": "defaultValue",
+                  "config": {
+                    "label": "Default Value",
+                    "helper": "Takes precedence over value set in data."
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormInput",
+              "editor-component": "FormInput"
+            }
+          ]
+        },
+        {
+          "name": "FPP_RECORD_LIST_NTL_PART_TIME",
+          "items": [
+            {
+              "items": [
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_ACTIVITY",
+                      "type": "text",
+                      "label": "Activity:",
+                      "helper": null,
+                      "readonly": false,
+                      "dataFormat": "string",
+                      "validation": [
+                        {
+                          "value": "required",
+                          "helper": "Checks if the length of the String representation of the value is >",
+                          "content": "Required"
+                        }
+                      ],
+                      "placeholder": null
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "_Ctor": [],
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "value": [],
+                                "options": [],
+                                "language": [],
+                                "amdRequire": []
+                              },
+                              "watch": {
+                                "options": { "deep": true, "user": true }
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  },
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_RESEARCH",
+                      "type": "text",
+                      "label": "Research:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "_Ctor": [],
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "value": [],
+                                "options": [],
+                                "language": [],
+                                "amdRequire": []
+                              },
+                              "watch": {
+                                "options": { "deep": true, "user": true }
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  },
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_UNDERLOAD_PAYBACK",
+                      "type": "text",
+                      "label": "Underload Payback",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-5d32d6af",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "monaco-editor",
+                              "_Ctor": [],
+                              "props": { "amdRequire": [] },
+                              "extends": {
+                                "name": "MonacoEditor",
+                                "model": { "event": "change" },
+                                "props": {
+                                  "theme": { "default": "vs" },
+                                  "value": { "required": true },
+                                  "options": [],
+                                  "language": [],
+                                  "original": [],
+                                  "amdRequire": [],
+                                  "diffEditor": { "default": false }
+                                },
+                                "watch": {
+                                  "options": { "deep": true, "user": true }
+                                },
+                                "methods": []
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ],
+                [
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_ADMIN",
+                      "type": "text",
+                      "label": "Admin:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "_Ctor": [],
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "value": [],
+                                "options": [],
+                                "language": [],
+                                "amdRequire": []
+                              },
+                              "watch": {
+                                "options": { "deep": true, "user": true }
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  },
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_LEAVE_FRONTLOAD",
+                      "type": "text",
+                      "label": "Leave/Frontload",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": false,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": { "mode": "basic", "value": null }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-5d32d6af",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "monaco-editor",
+                              "_Ctor": [],
+                              "props": { "amdRequire": [] },
+                              "extends": {
+                                "name": "MonacoEditor",
+                                "model": { "event": "change" },
+                                "props": {
+                                  "theme": { "default": "vs" },
+                                  "value": { "required": true },
+                                  "options": [],
+                                  "language": [],
+                                  "original": [],
+                                  "amdRequire": [],
+                                  "diffEditor": { "default": false }
+                                },
+                                "watch": {
+                                  "options": { "deep": true, "user": true }
+                                },
+                                "methods": []
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customFormatter",
+                        "config": {
+                          "label": "Custom Format String",
+                          "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                          "validation": null
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  },
+                  {
+                    "label": "Line Input",
+                    "config": {
+                      "icon": "far fa-square",
+                      "name": "FPP_NTL_PART_TIME_UNITS",
+                      "type": "text",
+                      "label": "Total Units:",
+                      "helper": null,
+                      "dataMask": {
+                        "code": "PHP",
+                        "name": "Philippine Peso",
+                        "format": "#,###.##",
+                        "symbol": null
+                      },
+                      "readonly": true,
+                      "dataFormat": "currency",
+                      "validation": [],
+                      "placeholder": null,
+                      "defaultValue": {
+                        "mode": "js",
+                        "value": "let sumUnits = 0;\nif(!isNaN(parseFloat(this.FPP_NTL_PART_TIME_ADMIN))){\n    sumUnits = parseFloat(sumUnits) + parseFloat(this.FPP_NTL_PART_TIME_ADMIN);\n}\nif(!isNaN(parseFloat(this.FPP_NTL_PART_TIME_RESEARCH))){\n    sumUnits = parseFloat(sumUnits) + parseFloat(this.FPP_NTL_PART_TIME_RESEARCH);\n}\nreturn parseFloat(sumUnits);"
+                      }
+                    },
+                    "component": "FormInput",
+                    "inspector": [
+                      {
+                        "type": "FormInput",
+                        "field": "name",
+                        "config": {
+                          "name": "Variable Name",
+                          "label": "Variable Name",
+                          "helper": "A variable name is a symbolic name to reference information.",
+                          "validation": "regex:/^(?:[A-Z_a-z])(?:[0-9A-Z_a-z])*(?:[A-Z.a-z])*(?<!\\.)$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "label",
+                        "config": {
+                          "label": "Label",
+                          "helper": "The label describes the field's name"
+                        }
+                      },
+                      {
+                        "type": "FormMultiselect",
+                        "field": "dataFormat",
+                        "config": {
+                          "name": "Data Type",
+                          "label": "Data Type",
+                          "helper": "The data type specifies what kind of data is stored in the variable.",
+                          "options": [
+                            { "value": "string", "content": "Text" },
+                            { "value": "int", "content": "Integer" },
+                            { "value": "currency", "content": "Currency" },
+                            { "value": "percentage", "content": "Percentage" },
+                            { "value": "float", "content": "Decimal" },
+                            { "value": "datetime", "content": "Datetime" },
+                            { "value": "date", "content": "Date" },
+                            { "value": "password", "content": "Password" }
+                          ],
+                          "validation": "required"
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "extends": {
+                            "_Ctor": [],
+                            "props": {
+                              "name": { "type": null },
+                              "error": { "type": null },
+                              "label": { "type": null },
+                              "value": { "type": null },
+                              "helper": { "type": null },
+                              "options": { "type": null },
+                              "selectedControl": { "type": null }
+                            },
+                            "mixins": [
+                              {
+                                "props": {
+                                  "validation": { "type": null },
+                                  "validationData": { "type": null },
+                                  "validationField": { "type": null },
+                                  "validationMessages": { "type": null }
+                                },
+                                "watch": {
+                                  "validationData": {
+                                    "deep": true,
+                                    "user": true
+                                  }
+                                },
+                                "methods": []
+                              }
+                            ],
+                            "methods": [],
+                            "computed": [],
+                            "_compiled": true,
+                            "components": {
+                              "Multiselect": {
+                                "name": "vue-multiselect",
+                                "_Ctor": [],
+                                "props": {
+                                  "name": { "default": null },
+                                  "limit": { "default": 99999 },
+                                  "loading": { "default": false },
+                                  "disabled": { "default": false },
+                                  "tabindex": { "default": 0 },
+                                  "limitText": [],
+                                  "maxHeight": { "default": 300 },
+                                  "showLabels": { "default": true },
+                                  "selectLabel": {
+                                    "default": "Press enter to select"
+                                  },
+                                  "deselectLabel": {
+                                    "default": "Press enter to remove"
+                                  },
+                                  "openDirection": { "default": null },
+                                  "selectedLabel": { "default": "Selected" },
+                                  "showNoOptions": { "default": true },
+                                  "showNoResults": { "default": true },
+                                  "selectGroupLabel": {
+                                    "default": "Press enter to select group"
+                                  },
+                                  "deselectGroupLabel": {
+                                    "default": "Press enter to deselect group"
+                                  }
+                                },
+                                "mixins": [
+                                  {
+                                    "props": {
+                                      "id": { "default": null },
+                                      "max": {
+                                        "type": [null, null],
+                                        "default": false
+                                      },
+                                      "label": [],
+                                      "value": { "type": null },
+                                      "options": { "required": true },
+                                      "trackBy": [],
+                                      "multiple": { "default": false },
+                                      "taggable": { "default": false },
+                                      "blockKeys": [],
+                                      "allowEmpty": { "default": true },
+                                      "groupLabel": [],
+                                      "resetAfter": { "default": false },
+                                      "searchable": { "default": true },
+                                      "customLabel": [],
+                                      "groupSelect": { "default": false },
+                                      "groupValues": [],
+                                      "placeholder": {
+                                        "default": "Select option"
+                                      },
+                                      "tagPosition": { "default": "top" },
+                                      "hideSelected": { "default": false },
+                                      "optionsLimit": { "default": 1000 },
+                                      "clearOnSelect": { "default": true },
+                                      "closeOnSelect": { "default": true },
+                                      "internalSearch": { "default": true },
+                                      "preselectFirst": { "default": false },
+                                      "preserveSearch": { "default": false },
+                                      "tagPlaceholder": {
+                                        "default": "Press enter to create a tag"
+                                      }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  },
+                                  {
+                                    "props": {
+                                      "showPointer": { "default": true },
+                                      "optionHeight": { "default": 40 }
+                                    },
+                                    "watch": [],
+                                    "methods": [],
+                                    "computed": []
+                                  }
+                                ],
+                                "computed": [],
+                                "_compiled": true,
+                                "beforeCreate": [null],
+                                "staticRenderFns": []
+                              }
+                            },
+                            "inheritAttrs": false,
+                            "staticRenderFns": []
+                          },
+                          "computed": [],
+                          "_compiled": true,
+                          "staticRenderFns": []
+                        },
+                        "field": "dataMask",
+                        "config": {
+                          "name": "Data Format",
+                          "label": "Data Format",
+                          "helper": "The data format for the selected type."
+                        }
+                      },
+                      {
+                        "type": "ValidationSelect",
+                        "field": "validation",
+                        "config": {
+                          "label": "Validation Rules",
+                          "helper": "The validation rules needed for this field"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "placeholder",
+                        "config": {
+                          "label": "Placeholder Text",
+                          "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "helper",
+                        "config": {
+                          "label": "Helper Text",
+                          "helper": "Help text is meant to provide additional guidance on the field's value"
+                        }
+                      },
+                      {
+                        "type": "FormCheckbox",
+                        "field": "readonly",
+                        "config": { "label": "Read Only", "helper": null }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "color",
+                        "config": {
+                          "label": "Text Color",
+                          "helper": "Set the element's text color",
+                          "options": [
+                            { "value": "text-primary", "content": "primary" },
+                            {
+                              "value": "text-secondary",
+                              "content": "secondary"
+                            },
+                            { "value": "text-success", "content": "success" },
+                            { "value": "text-danger", "content": "danger" },
+                            { "value": "text-warning", "content": "warning" },
+                            { "value": "text-info", "content": "info" },
+                            { "value": "text-light", "content": "light" },
+                            { "value": "text-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": "ColorSelect",
+                        "field": "bgcolor",
+                        "config": {
+                          "label": "Background Color",
+                          "helper": "Set the element's background color",
+                          "options": [
+                            {
+                              "value": "alert alert-primary",
+                              "content": "primary"
+                            },
+                            {
+                              "value": "alert alert-secondary",
+                              "content": "secondary"
+                            },
+                            {
+                              "value": "alert alert-success",
+                              "content": "success"
+                            },
+                            {
+                              "value": "alert alert-danger",
+                              "content": "danger"
+                            },
+                            {
+                              "value": "alert alert-warning",
+                              "content": "warning"
+                            },
+                            { "value": "alert alert-info", "content": "info" },
+                            {
+                              "value": "alert alert-light",
+                              "content": "light"
+                            },
+                            { "value": "alert alert-dark", "content": "dark" }
+                          ]
+                        }
+                      },
+                      {
+                        "type": {
+                          "_Ctor": [],
+                          "props": { "value": { "type": null } },
+                          "watch": {
+                            "value": { "user": true, "immediate": true }
+                          },
+                          "methods": [],
+                          "_scopeId": "data-v-67152bf8",
+                          "computed": { "effectiveValue": [] },
+                          "_compiled": true,
+                          "components": {
+                            "MonacoEditor": {
+                              "name": "MonacoEditor",
+                              "_Ctor": [],
+                              "model": { "event": "change" },
+                              "props": {
+                                "theme": { "default": "vs" },
+                                "value": [],
+                                "options": [],
+                                "language": [],
+                                "amdRequire": []
+                              },
+                              "watch": {
+                                "options": { "deep": true, "user": true }
+                              },
+                              "methods": []
+                            }
+                          },
+                          "staticRenderFns": []
+                        },
+                        "field": "defaultValue",
+                        "config": {
+                          "label": "Default Value",
+                          "helper": "Takes precedence over value set in data."
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "conditionalHide",
+                        "config": {
+                          "label": "Visibility Rule",
+                          "helper": "This control is hidden until this expression is true"
+                        }
+                      },
+                      {
+                        "type": "FormInput",
+                        "field": "customCssSelector",
+                        "config": {
+                          "label": "CSS Selector Name",
+                          "helper": "Use this in your custom css rules",
+                          "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                        }
+                      }
+                    ],
+                    "editor-control": "FormInput",
+                    "editor-component": "FormInput"
+                  }
+                ]
+              ],
+              "label": "Multicolumn / Table",
+              "config": {
+                "icon": "fas fa-table",
+                "label": null,
+                "options": [
+                  { "value": "1", "content": "6" },
+                  { "value": "2", "content": "6" }
+                ]
+              },
+              "component": "FormMultiColumn",
+              "container": true,
+              "inspector": [
+                {
+                  "type": "ContainerColumns",
+                  "field": "options",
+                  "config": {
+                    "label": "Column Width",
+                    "helper": null,
+                    "validation": "columns-adds-to-12"
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customFormatter",
+                  "config": {
+                    "label": "Custom Format String",
+                    "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                    "validation": null
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormMultiColumn",
+              "editor-component": "MultiColumn"
+            },
+            {
+              "label": "Line Input",
+              "config": {
+                "icon": "far fa-square",
+                "name": "FPP_NTL_PART_TIME_REMARKS",
+                "type": "text",
+                "label": "Remarks:",
+                "helper": null,
+                "readonly": false,
+                "dataFormat": "string",
+                "validation": [],
+                "placeholder": null,
+                "defaultValue": { "mode": "basic", "value": null }
+              },
+              "component": "FormInput",
+              "inspector": [
+                {
+                  "type": "FormInput",
+                  "field": "name",
+                  "config": {
+                    "name": "Variable Name",
+                    "label": "Variable Name",
+                    "helper": "A variable name is a symbolic name to reference information.",
+                    "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "label",
+                  "config": {
+                    "label": "Label",
+                    "helper": "The label describes the field's name"
+                  }
+                },
+                {
+                  "type": "FormMultiselect",
+                  "field": "dataFormat",
+                  "config": {
+                    "name": "Data Type",
+                    "label": "Data Type",
+                    "helper": "The data type specifies what kind of data is stored in the variable.",
+                    "options": [
+                      { "value": "string", "content": "Text" },
+                      { "value": "int", "content": "Integer" },
+                      { "value": "currency", "content": "Currency" },
+                      { "value": "percentage", "content": "Percentage" },
+                      { "value": "float", "content": "Decimal" },
+                      { "value": "datetime", "content": "Datetime" },
+                      { "value": "date", "content": "Date" },
+                      { "value": "password", "content": "Password" }
+                    ],
+                    "validation": "required"
+                  }
+                },
+                {
+                  "type": {
+                    "extends": {
+                      "props": [
+                        "label",
+                        "error",
+                        "options",
+                        "helper",
+                        "name",
+                        "value",
+                        "selectedControl"
+                      ],
+                      "mixins": [
+                        {
+                          "props": {
+                            "validation": { "type": null },
+                            "validationData": { "type": null },
+                            "validationField": { "type": null },
+                            "validationMessages": { "type": null }
+                          },
+                          "watch": {
+                            "validationData": { "deep": true, "user": true }
+                          },
+                          "methods": []
+                        }
+                      ],
+                      "methods": [],
+                      "computed": [],
+                      "_compiled": true,
+                      "components": {
+                        "Multiselect": {
+                          "name": "vue-multiselect",
+                          "props": {
+                            "name": { "default": null },
+                            "limit": { "default": 99999 },
+                            "loading": { "default": false },
+                            "disabled": { "default": false },
+                            "tabindex": { "default": 0 },
+                            "limitText": [],
+                            "maxHeight": { "default": 300 },
+                            "showLabels": { "default": true },
+                            "selectLabel": {
+                              "default": "Press enter to select"
+                            },
+                            "deselectLabel": {
+                              "default": "Press enter to remove"
+                            },
+                            "openDirection": { "default": null },
+                            "selectedLabel": { "default": "Selected" },
+                            "showNoOptions": { "default": true },
+                            "showNoResults": { "default": true },
+                            "selectGroupLabel": {
+                              "default": "Press enter to select group"
+                            },
+                            "deselectGroupLabel": {
+                              "default": "Press enter to deselect group"
+                            }
+                          },
+                          "mixins": [
+                            {
+                              "props": {
+                                "id": { "default": null },
+                                "max": {
+                                  "type": [null, null],
+                                  "default": false
+                                },
+                                "label": [],
+                                "value": { "type": null },
+                                "options": { "required": true },
+                                "trackBy": [],
+                                "multiple": { "default": false },
+                                "taggable": { "default": false },
+                                "blockKeys": [],
+                                "allowEmpty": { "default": true },
+                                "groupLabel": [],
+                                "resetAfter": { "default": false },
+                                "searchable": { "default": true },
+                                "customLabel": [],
+                                "groupSelect": { "default": false },
+                                "groupValues": [],
+                                "placeholder": { "default": "Select option" },
+                                "tagPosition": { "default": "top" },
+                                "hideSelected": { "default": false },
+                                "optionsLimit": { "default": 1000 },
+                                "clearOnSelect": { "default": true },
+                                "closeOnSelect": { "default": true },
+                                "internalSearch": { "default": true },
+                                "preselectFirst": { "default": false },
+                                "preserveSearch": { "default": false },
+                                "tagPlaceholder": {
+                                  "default": "Press enter to create a tag"
+                                }
+                              },
+                              "watch": [],
+                              "methods": [],
+                              "computed": []
+                            },
+                            {
+                              "props": {
+                                "showPointer": { "default": true },
+                                "optionHeight": { "default": 40 }
+                              },
+                              "watch": [],
+                              "methods": [],
+                              "computed": []
+                            }
+                          ],
+                          "computed": [],
+                          "_compiled": true,
+                          "beforeCreate": [null],
+                          "staticRenderFns": []
+                        }
+                      },
+                      "inheritAttrs": false,
+                      "staticRenderFns": []
+                    },
+                    "computed": [],
+                    "_compiled": true,
+                    "staticRenderFns": []
+                  },
+                  "field": "dataMask",
+                  "config": {
+                    "name": "Data Format",
+                    "label": "Data Format",
+                    "helper": "The data format for the selected type."
+                  }
+                },
+                {
+                  "type": "ValidationSelect",
+                  "field": "validation",
+                  "config": {
+                    "label": "Validation Rules",
+                    "helper": "The validation rules needed for this field"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "placeholder",
+                  "config": {
+                    "label": "Placeholder Text",
+                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "helper",
+                  "config": {
+                    "label": "Helper Text",
+                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                  }
+                },
+                {
+                  "type": "FormCheckbox",
+                  "field": "readonly",
+                  "config": { "label": "Read Only", "helper": null }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "color",
+                  "config": {
+                    "label": "Text Color",
+                    "helper": "Set the element's text color",
+                    "options": [
+                      { "value": "text-primary", "content": "primary" },
+                      { "value": "text-secondary", "content": "secondary" },
+                      { "value": "text-success", "content": "success" },
+                      { "value": "text-danger", "content": "danger" },
+                      { "value": "text-warning", "content": "warning" },
+                      { "value": "text-info", "content": "info" },
+                      { "value": "text-light", "content": "light" },
+                      { "value": "text-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": "ColorSelect",
+                  "field": "bgcolor",
+                  "config": {
+                    "label": "Background Color",
+                    "helper": "Set the element's background color",
+                    "options": [
+                      { "value": "alert alert-primary", "content": "primary" },
+                      {
+                        "value": "alert alert-secondary",
+                        "content": "secondary"
+                      },
+                      { "value": "alert alert-success", "content": "success" },
+                      { "value": "alert alert-danger", "content": "danger" },
+                      { "value": "alert alert-warning", "content": "warning" },
+                      { "value": "alert alert-info", "content": "info" },
+                      { "value": "alert alert-light", "content": "light" },
+                      { "value": "alert alert-dark", "content": "dark" }
+                    ]
+                  }
+                },
+                {
+                  "type": {
+                    "props": ["value"],
+                    "watch": { "value": { "immediate": true } },
+                    "methods": [],
+                    "_scopeId": "data-v-67152bf8",
+                    "computed": { "effectiveValue": [] },
+                    "_compiled": true,
+                    "components": {
+                      "MonacoEditor": {
+                        "name": "MonacoEditor",
+                        "model": { "event": "change" },
+                        "props": {
+                          "theme": { "default": "vs" },
+                          "amdRequire": []
+                        },
+                        "watch": { "options": { "deep": true } },
+                        "methods": []
+                      }
+                    },
+                    "staticRenderFns": []
+                  },
+                  "field": "defaultValue",
+                  "config": {
+                    "label": "Default Value",
+                    "helper": "Takes precedence over value set in data."
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "conditionalHide",
+                  "config": {
+                    "label": "Visibility Rule",
+                    "helper": "This control is hidden until this expression is true"
+                  }
+                },
+                {
+                  "type": "FormInput",
+                  "field": "customCssSelector",
+                  "config": {
+                    "label": "CSS Selector Name",
+                    "helper": "Use this in your custom css rules",
+                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                  }
+                }
+              ],
+              "editor-control": "FormInput",
+              "editor-component": "FormInput"
+            }
+          ]
+        }
+      ],
+      "computed": [
+        {
+          "id": 1,
+          "name": "subTotalPremiumTLFullTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalPremiumTLFullTime"
+        },
+        {
+          "id": 2,
+          "name": "subTotalFacultyTLFullTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalFacultyTLFullTime"
+        },
+        {
+          "id": 3,
+          "name": "FPP_GRAND_TOTAL_FULL_TIME",
+          "type": "javascript",
+          "formula": "let sumGrandTotal = 0;\nif(!isNaN(parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME);\n}\nif(!isNaN(parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME);\n}\nreturn parseFloat(sumGrandTotal);",
+          "property": "FPP_GRAND_TOTAL_FULL_TIME"
+        },
+        {
+          "id": 4,
+          "name": "subTotalUnitsNTLPartTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalUnitsNTLPartTime"
+        },
+        {
+          "id": 5,
+          "name": "subTotalPremiumTLPartTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalPremiumTLPartTime"
+        },
+        {
+          "id": 6,
+          "name": "subTotalFacultyTLPartTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalFacultyTLPartTime"
+        },
+        {
+          "id": 7,
+          "name": "grandTotalPartTime",
+          "type": "javascript",
+          "formula": "let sumGrandTotal = 0;\nif(!isNaN(parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_PART_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_PART_TIME);\n}\nif(!isNaN(parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_PART_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_PART_TIME);\n}\nif(!isNaN(parseFloat(this.FPP_SUB_TOTAL_PREMIUM_TL_PART_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_SUB_TOTAL_PREMIUM_TL_PART_TIME);\n}\nreturn parseFloat(sumGrandTotal);",
+          "property": "grandTotalPartTime"
+        },
+        {
+          "id": 8,
+          "name": "buttonSavePartTime",
+          "type": "javascript",
+          "formula": "",
+          "property": "buttonSavePartTime"
+        },
+        {
+          "id": 9,
+          "name": "subTotalTeachingTLFullTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalTeachingTLFullTime"
+        },
+        {
+          "id": 10,
+          "name": "formatRecordListFunction",
+          "type": "javascript",
+          "formula": "if(this.FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME){\n    if($(\"div[selector='recordListTLFullTime'] tfoot\").length == 0) {\n        $(\"div[selector='recordListTLFullTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalTLFullTime\"><td colspan=\"6\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalTeachingFacultyFullTime\" class=\"text-right\">0.00</td><td id=\"sumSubTotalPremiumFullTime\" class=\"text-right\">0.00 PHP</td><td></td></tr></tfoot');\n    } else {\n        $(\"div[selector='recordListTLFullTime'] tfoot\").remove();\n        $(\"div[selector='recordListTLFullTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalTLFullTime\"><td colspan=\"6\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalTeachingFacultyFullTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td id=\"sumSubTotalPremiumFullTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_PREMIUM_TL_FULL_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td ></td></tr></tfoot>');\n    }\n}\n\n$(\"div[selector='recordListTLFullTime'] tbody\").find(\"tr\").each(function () {\n    $(this).find(\"td\").eq(5).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(6).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(7).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(8).css(\"text-align\", \"right\");\n});\n\nif(this.FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME){\n    if($(\"div[selector='recordListNTLFullTime'] tfoot\").length == 0) {\n        $(\"div[selector='recordListNTLFullTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalNTLFllTime\"><td colspan=\"5\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalNTLFullTime\" class=\"text-right\">0.00 PHP</td><td colspan=\"2\"></td></tr></tfoot');\n    } else {\n        $(\"div[selector='recordListNTLFullTime'] tfoot\").remove();\n        $(\"div[selector='recordListNTLFullTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalNTLFllTime\"><td colspan=\"5\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalNTLFullTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td colspan=\"2\"></td></tr></tfoot>');\n    }\n}\n\n$(\"div[selector='recordListNTLFullTime'] tbody\").find(\"tr\").each(function () {\n    $(this).find(\"td\").eq(1).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(2).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(3).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(4).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(5).css(\"text-align\", \"right\");\n});\n\n////---- Part Time\nif(this.FPP_SUB_TOTAL_FACULTY_TL_PART_TIME){\n    if($(\"div[selector='recordListTLPartTime'] tfoot\").length == 0) {\n        $(\"div[selector='recordListTLPartTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalTLPartTime\"><td colspan=\"6\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalTeachingFacultyPartTime\" class=\"text-right\">0.00</td><td id=\"sumSubTotalPremiumPartTime\" class=\"text-right\">0.00 PHP</td><td></td></tr></tfoot');\n    } else {\n        $(\"div[selector='recordListTLPartTime'] tfoot\").remove();\n        $(\"div[selector='recordListTLPartTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalTLPartTime\"><td colspan=\"6\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalTeachingFacultyPartTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_FACULTY_TL_PART_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td id=\"sumSubTotalPremiumPartTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_PREMIUM_TL_PART_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td ></td></tr></tfoot>');\n    }\n}\n\n$(\"div[selector='recordListTLPartTime'] tbody\").find(\"tr\").each(function () {\n    $(this).find(\"td\").eq(5).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(6).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(7).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(8).css(\"text-align\", \"right\");\n});\n\nif(this.FPP_SUB_TOTAL_UNITS_NTL_PART_TIME){\n    if($(\"div[selector='recordListNTLPartTime'] tfoot\").length == 0) {\n        $(\"div[selector='recordListNTLPartTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalNTLPartTime\"><td colspan=\"5\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalNTLPartTime\" class=\"text-right\">0.00 PHP</td><td colspan=\"2\"></td></tr></tfoot');\n    } else {\n        $(\"div[selector='recordListNTLPartTime'] tfoot\").remove();\n        $(\"div[selector='recordListNTLPartTime'] table\").append('<tfoot><tr class=\"subTotal\" id=\"trTotalNTLPartTime\"><td colspan=\"5\" class=\"text-right\">Sub Total: </td><td id=\"sumSubTotalNTLPartTime\" class=\"text-right\">' + parseFloat(this.FPP_SUB_TOTAL_UNITS_NTL_PART_TIME).toFixed(2).replace(/\\d(?=(\\d{3})+\\.)/g, '$&,') + ' PHP</td><td colspan=\"2\"></td></tr></tfoot>');\n    }\n}\n\n$(\"div[selector='recordListNTLPartTime'] tbody\").find(\"tr\").each(function () {\n    $(this).find(\"td\").eq(1).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(2).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(3).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(4).css(\"text-align\", \"right\");\n    $(this).find(\"td\").eq(5).css(\"text-align\", \"right\");\n});",
+          "property": "formatRecordListFunction"
+        },
+        {
+          "id": 11,
+          "name": "subTotalUnitsNTLFullTime",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "subTotalUnitsNTLFullTime"
+        },
+        {
+          "id": 12,
+          "name": "FPP_FULL_TIME_OVERLOAD",
+          "type": "javascript",
+          "formula": "////---- Overload = Grand Total  - Frontload - Regular Load\nlet sumGrandTotal = 0;\nif(!isNaN(parseFloat(this.FPP_GRAND_TOTAL_FULL_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_GRAND_TOTAL_FULL_TIME);\n}\nif(!isNaN(parseFloat(this.FPP_FULL_TIME_FRONTLOAD_UNDERLOAD))){\n    sumGrandTotal = parseFloat(sumGrandTotal) - parseFloat(this.FPP_FULL_TIME_FRONTLOAD_UNDERLOAD);\n}\nif(!isNaN(parseFloat(this.FPP_FULL_TIME_REGULAR_LOAD))){\n    sumGrandTotal = parseFloat(sumGrandTotal) - parseFloat(this.FPP_FULL_TIME_REGULAR_LOAD);\n}\nreturn parseFloat(sumGrandTotal);",
+          "property": "FPP_FULL_TIME_OVERLOAD"
+        },
+        {
+          "id": 13,
+          "name": "FPP_FULL_TIME_PREMIUM_TOTAL",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "FPP_FULL_TIME_PREMIUM_TOTAL"
+        },
+        {
+          "id": 14,
+          "name": "FPP_PART_TIME_OVERLOAD",
+          "type": "javascript",
+          "formula": "////---- Overload = Grand Total  - Frontload - Regular Load\nlet sumGrandTotal = 0;\nif(!isNaN(parseFloat(this.FPP_GRAND_TOTAL_PART_TIME))){\n    sumGrandTotal = parseFloat(sumGrandTotal) + parseFloat(this.FPP_GRAND_TOTAL_PART_TIME);\n}\nif(!isNaN(parseFloat(this.FPP_PART_TIME_FRONTLOAD_UNDERLOAD))){\n    sumGrandTotal = parseFloat(sumGrandTotal) - parseFloat(this.FPP_PART_TIME_FRONTLOAD_UNDERLOAD);\n}\nif(!isNaN(parseFloat(this.FPP_PART_TIME_REGULAR_LOAD))){\n    sumGrandTotal = parseFloat(sumGrandTotal) - parseFloat(this.FPP_PART_TIME_REGULAR_LOAD);\n}\nreturn parseFloat(sumGrandTotal);",
+          "property": "FPP_PART_TIME_OVERLOAD"
+        },
+        {
+          "id": 15,
+          "name": "FPP_PART_TIME_PREMIUM_TOTAL",
+          "type": "javascript",
+          "formula": "return 0;",
+          "property": "FPP_PART_TIME_PREMIUM_TOTAL"
+        }
+      ],
+      "custom_css": "[selector='tabsFullTime'] .row {\n    margin-right: 0px !important;\n    margin-left: 0px !important;\n}\n\n[selector='tabsPartTime'] .row {\n    margin-right: 0px !important;\n    margin-left: 0px !important;\n}\n\n[selector='tabsFullTime'] .col-sm-2:nth-child(1) {\n    border-top-left-radius: 9px;\n    border-top-right-radius: 9px;\n    border-top: 1px solid lightgrey;\n    border-left: 1px solid lightgrey;\n    border-right: 1px solid lightgrey;\n    padding-right:5px;\n    padding-left:5px;\n}\n[selector='tabsFullTime'] .col-sm-2:nth-child(2) {\n    border-top-left-radius: 9px;\n    border-top-right-radius: 9px;\n    border-top: 1px solid lightgrey;\n    border-left: 1px solid lightgrey;\n    border-right: 1px solid lightgrey;\n    border-bottom: 1px solid lightgrey;\n    padding-right:5px;\n    padding-left:5px;\n}\n[selector='tabsPartTime'] .col-sm-2:nth-child(2) {\n    border-top-left-radius: 9px;\n    border-top-right-radius: 9px;\n    border-top: 1px solid lightgrey;\n    border-left: 1px solid lightgrey;\n    border-right: 1px solid lightgrey;\n    padding-right:5px;\n    padding-left:5px;\n}\n[selector='tabsPartTime'] .col-sm-2:nth-child(1) {\n    border-top-left-radius: 9px;\n    border-top-right-radius: 9px;\n    border-top: 1px solid lightgrey;\n    border-left: 1px solid lightgrey;\n    border-right: 1px solid lightgrey;\n    border-bottom: 1px solid lightgrey;\n    padding-right:5px;\n    padding-left:5px;\n}\n\n[selector='tabsFullTime'] .col-sm-8:nth-child(3),\n[selector='tabsPartTime'] .col-sm-8:nth-child(3) {\n    border-bottom: 1px solid  lightgrey;\n}\n\n[selector='navColor'] .btn.btn-link {\n    color: black;\n    font-size: smaller;\n}\n[selector='navActive'] .btn.btn-link {\n    font-size: smaller;\n}\n[selector='navActive'],\n[selector='navColor'] {\n    text-align: center;\n}\n\n[selector='recordListTLFullTime'], [selector='recordListNTLFullTime'], [selector='recordListNTLPartTime'], [selector='recordListTLPartTime'] {\n    border: 1px solid lightgray;\n    border-radius: 5px;\n    padding: 15px;\n    max-width: 1200px !important;\n    overflow: auto;\n}\n.subTotal {\n    background-color: #ffff9e;\n    font-weight: bold;\n}",
+      "created_at": "2020-09-04T18:33:11+00:00",
+      "updated_at": "2021-06-01T19:38:12+00:00",
+      "status": "ACTIVE",
+      "key": null,
+      "watchers": [],
+      "categories": [
+        {
+          "id": 53,
+          "name": "De La Salle University Forms",
+          "status": "ACTIVE",
+          "is_system": 0,
+          "created_at": "2020-04-20T19:37:13+00:00",
+          "updated_at": "2021-05-31T14:21:22+00:00",
+          "pivot": {
+            "assignable_id": 1559,
+            "category_id": 53,
+            "category_type": "ProcessMaker\\Models\\ScreenCategory"
+          }
+        }
+      ]
+    }
+  ],
+  "screen_categories": [],
+  "scripts": []
+}

--- a/tests/e2e/specs/LoadComplexData.spec.js
+++ b/tests/e2e/specs/LoadComplexData.spec.js
@@ -1,0 +1,63 @@
+describe('Validation Rules (Advanced test)', () => {
+  beforeEach(() => {
+    cy.server();
+    cy.visit('/');
+  });
+
+  it('Verify all validation rules within loops', () => {
+    cy.loadFromJson('FPP_PFP_CHAIRS_SCREEN.json', 0);
+    cy.get('[data-cy=mode-preview]').click();
+    // Open Tab 2
+    cy.get('[aria-label="Part Time"]:visible:first').click();
+    // Tab 2 contains the title '2. PART TIME PAGE'
+    cy.get('#preview').should('contain.html', '2. PART TIME PAGE');
+
+    // Check the data is properly loaded
+    cy.assertPreviewData({
+      'FPP_COLLEGE': '',
+      'FPP_DEPARTMENT': '',
+      'FPP_USER_FULL_TIME': {
+        'FPP_TL_FULL_TIME': null,
+        'FPP_NTL_FULL_TIME': null,
+      },
+      'FPP_NAME_FULL_TIME': '',
+      'FPP_RANK_FULL_TIME': '',
+      'FPP_EMPLOYEE_FULL_TIME': '',
+      'FPP_FULL_TIME_FRONTLOAD_UNDERLOAD': null,
+      'FPP_FULL_TIME_REGULAR_LOAD': null,
+      'buttonSaveFullTime': null,
+      'buttonSubmit': null,
+      'FPP_SUB_TOTAL_UNITS_NTL_FULL_TIME': '0',
+      'FPP_SUB_TOTAL_FACULTY_TL_FULL_TIME': '0',
+      'FPP_SUB_TOTAL_PREMIUM_TL_FULL_TIME': '0',
+      'FPP_REQUEST_ID': '',
+      'FPP_USER_PART_TIME': {
+        'FPP_TL_PART_TIME': null,
+        'FPP_NTL_PART_TIME': null,
+      },
+      'FPP_NAME_PART_TIME': '',
+      'FPP_RANK_PART_TIME': '',
+      'FPP_EMPLOYEE_PART_TIME': '',
+      'FPP_GRAND_TOTAL_PART_TIME': '0',
+      'FPP_PART_TIME_FRONTLOAD_UNDERLOAD': null,
+      'FPP_PART_TIME_REGULAR_LOAD': null,
+      'FPP_REMARKS_PART_TIME': '',
+      'FPP_SUB_TOTAL_UNITS_NTL_PART_TIME': '0',
+      'FPP_SUB_TOTAL_FACULTY_TL_PART_TIME': '0',
+      'FPP_SUB_TOTAL_PREMIUM_TL_PART_TIME': '0',
+      'subTotalPremiumTLFullTime': 0,
+      'subTotalFacultyTLFullTime': 0,
+      'FPP_GRAND_TOTAL_FULL_TIME': 0,
+      'subTotalUnitsNTLPartTime': 0,
+      'subTotalPremiumTLPartTime': 0,
+      'subTotalFacultyTLPartTime': 0,
+      'grandTotalPartTime': 0,
+      'subTotalTeachingTLFullTime': 0,
+      'subTotalUnitsNTLFullTime': 0,
+      'FPP_FULL_TIME_OVERLOAD': 0,
+      'FPP_FULL_TIME_PREMIUM_TOTAL': 0,
+      'FPP_PART_TIME_OVERLOAD': 0,
+      'FPP_PART_TIME_PREMIUM_TOTAL': 0,
+    });
+  });
+});


### PR DESCRIPTION
Ticket: http://tickets.pm4overflow.com/tickets/1206
Ticket: http://tickets.pm4overflow.com/tickets/1198
https://processmaker.atlassian.net/browse/FOUR-3488

Problem: A default value (null) is overwriting the object of another one:
Select List Control: FPP_USER_PART_TIME   Default: null
Input Text Control: FPP_USER_PART_TIME.FPP_NAME_PART_TIME Default null

The `Select List Control` was overwriting FPP_USER_PART_TIME to `null`, causing the Input Text Control to fail.

This PR includes:

- Test to replicate the issue. Now the user could open the second tab
- Fix: Default value does not overwrite a declared variable (e.g. FPP_USER_PART_TIME.FPP_NAME_PART_TIME)

Screen:
[FPP_PFP_CHAIRS_SCREEN .json.txt](https://github.com/ProcessMaker/screen-builder/files/7476979/FPP_PFP_CHAIRS_SCREEN.json.txt)


