### PR TITLE
Bugfix/FOUR-4329: Fixed watcher triggering on a second page with checkbox (FOR 4.2)

### DIFF
--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -15,8 +15,8 @@ export default {
             this.setupDefaultValue(screen, name, `(function() {${config.defaultValue.value}}).bind(this.vdata)()`);
           }
         }
-        if (config.initiallyChecked) {
-          this.setupDefaultValue(screen, name, 'true');
+        if ('initiallyChecked' in config) {
+          this.setupDefaultValue(screen, name, config.initiallyChecked ? 'true' : 'false');
         }
         // Update vdata
         this.addMounted(screen, `

--- a/tests/e2e/specs/ComplexScreen.spec.js
+++ b/tests/e2e/specs/ComplexScreen.spec.js
@@ -115,14 +115,14 @@ describe('Complex screen', () => {
         'form_record_list_3': null,
         'page2': null,
         'form_text_area_4': '',
-        'form_checkbox_4': null,
+        'form_checkbox_4': false,
         'form_date_picker_8': null,
         'form_input_4': '',
         'form_date_picker_5': null,
         'form_text_area_3': '',
         'form_date_picker_6': null,
         'form_select_list_3': null,
-        'form_checkbox_3': null,
+        'form_checkbox_3': false,
       });
     });
 


### PR DESCRIPTION
Ticket [FOUR-4329](https://processmaker.atlassian.net/browse/FOUR-4329)

Default checkbox value in second page was setted to null instead false, so when moving to second page, the value of the checkbox that initially was null changed to false and watcher was detecting that reactivity. Now checkbox is setted as false instead null.

**Working video**

https://user-images.githubusercontent.com/90727999/141355450-733395d1-9728-4c74-940c-a4373696c025.mov



