### PR TITLE
Fix call to Vocabulary API when Vocabulary package not installed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -227,7 +227,7 @@ export default {
     loadTask() {
       const url = `/${this.taskId}?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested`;
       // For Vocabularies
-      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.indexOf('package-vocabularies')) {
+      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
         window.ProcessMaker.VocabulariesSchemaUrl = `vocabularies/task_schema/${this.taskId}`;
       }
 

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -7,7 +7,7 @@ const stringFormats = ['string', 'datetime', 'date', 'password'];
 export default {
   schema: [
     function() {
-      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.indexOf('package-vocabularies')) {
+      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
         if (window.ProcessMaker.VocabulariesSchemaUrl) {
           let response = window.ProcessMaker.apiClient.get(window.ProcessMaker.VocabulariesSchemaUrl);
           return response.then(response => {


### PR DESCRIPTION
<h2>Issue</h2>

https://processmaker.atlassian.net/browse/FOUR-4471

When the Vocabulary Package is **NOT** installed, the endpoint `/api/1.0/vocabularies/task_schema/{task_id}` was still triggered when loading a task, causing a `404` error.

<h2>Reproduce</h2>

1. Install the `packages` package
2. Install the `package-vocabularies` package
3. Create a simple process with a FormTask and run
4.  Uninstall the `package-vocabularies` package
5. Run the same process

** Bug Behavior**

Error alerts appear in the UI. In the Network tab there are Not found `404` requests to the `/api/1.0/vocabularies/task_schema/{task_id}` endpoint

<h2>Cause</h2>
The vocabulary package must have been previously installed on the server then later uninstalled. The logic that checks to see if the vocabulary package is installed was failing. This allowed the `window.ProcessMakerSchemaUrl` variable to be set and triggered. 

<h2>Solution</h2>

Update the logic that checks if the vocabulary package is installed.

<h2>To Test the Fix</h2>

1. Install the `packages` package
2. Install the `package-vocabularies` package
3. Create a simple process with a FormTask and run
4.  Uninstall the `package-vocabularies` package
5. Run the same process

** Current Behavior**

No errors appear in UI or in the Network tab. Vocabulary API is not called.


<h2>Changes</h2>

- Replace `indexOf` with `includes` in the _Task.vue_ and _ScreenBase.js_ files.
