### PR TITLE
Fix multi-file uploads

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -45,6 +45,9 @@ export default {
   post(...args) {
     return this.apiInstance().post(...args);
   },
+  delete(...args) {
+    return this.apiInstance().delete(...args);
+  },
   token() {
     return localStorage.getItem('token');
   },
@@ -135,5 +138,10 @@ export default {
     }
 
     return query;
+  },
+
+  deleteFile(id) {
+    const url = _.get(window, 'PM4ConfigOverrides.deleteFileEndpoint', 'files');
+    return this.delete(`${url}/${id}`);
   },
 };

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -144,4 +144,8 @@ export default {
     const url = _.get(window, 'PM4ConfigOverrides.deleteFileEndpoint', 'files');
     return this.delete(`${url}/${id}`);
   },
+
+  download(url) {
+    return this.apiInstance().get(url, {responseType: 'blob'});
+  },
 };

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -140,9 +140,12 @@ export default {
     return query;
   },
 
-  deleteFile(id) {
-    const url = _.get(window, 'PM4ConfigOverrides.deleteFileEndpoint', 'files');
-    return this.delete(`${url}/${id}`);
+  deleteFile(id, token = null) {
+    let url = `files/${id}`;
+    if (token) {
+      url += `?token=${token}`;
+    }
+    return this.delete(url);
   },
 
   download(url) {

--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -9,7 +9,7 @@
     </b-card>
     <div v-else>
       <template v-if="filesInfo.length > 0">
-        <div v-for="file in filesInfo" :key="file.id" :data-cy="file.id + '-' + file.name.replace(/[^0-9a-zA-Z\-]/g, '-')">
+        <div v-for="(file, idx) in filesInfo" :key="idx" :data-cy="file.id + '-' + file.name.replace(/[^0-9a-zA-Z\-]/g, '-')">
           <b-btn v-show="!isReadOnly"
             class="mb-2 d-print-none" variant="primary" :aria-label="$attrs['aria-label']"
             @click="downloadFile(file)"
@@ -189,11 +189,25 @@ export default {
       }
     },
     setFilesInfoFromRequest() {
+      if (!this.value) {
+        return;
+      }
+
       let requestFiles = _.get(
         window,
         `PM4ConfigOverrides.requestFiles["${this.fileDataName}"]`,
         []
       );
+
+      requestFiles = requestFiles.filter(file => {
+        // Filter any requestFiles that don't exist in this component's value. This can happen if
+        // a file is uploaded but the task is not saved.
+        if (Array.isArray(this.value)) {
+          return this.value.some(valueFile => valueFile.file === file.id);
+        } else {
+          return file.id === this.value;
+        }
+      });
 
       // Might be accessing individual files from inside a loop
       if (requestFiles.length === 0 && this.fileDataName.endsWith('.file')) {

--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -5,25 +5,19 @@
       {{ messageForPreview }}
     </b-card>
     <div v-else>
-      <div v-if="loading">
-        <i class="fas fa-cog fa-spin text-muted"/>
-        {{ $t('Loading...') }}
-      </div>
-      <div v-else>
-        <template v-if="!loading && filesInfo">
-          <div  v-for="file in asArray(filesInfo)" :key="file.id" :nada="JSON.stringify(file)" :data-cy="file.id + '-' + (file.name ? file.name : file.file_name).replace(/[^0-9a-zA-Z\-]/g, '-')">
-            <b-btn v-show="!isReadOnly"
-              class="mb-2 d-print-none" variant="primary" :aria-label="$attrs['aria-label']"
-              @click="downloadFile(file)"
-            >
-              <i class="fas fa-file-download"/> {{ $t('Download') }}
-            </b-btn>
-            {{ file.name ? file.name : file.file_name }}
-          </div>
-        </template>
-        <div v-else>
-          {{ $t('No files available for download') }}
+      <template v-if="filesInfo.length > 0">
+        <div v-for="file in filesInfo" :key="file.id" :data-cy="file.id + '-' + file.name.replace(/[^0-9a-zA-Z\-]/g, '-')">
+          <b-btn v-show="!isReadOnly"
+            class="mb-2 d-print-none" variant="primary" :aria-label="$attrs['aria-label']"
+            @click="downloadFile(file)"
+          >
+            <i class="fas fa-file-download"/> {{ $t('Download') }}
+          </b-btn>
+          {{ file.name }}
         </div>
+      </template>
+      <div v-else>
+        {{ $t('No files available for download') }}
       </div>
     </div>
   </div>
@@ -37,59 +31,43 @@ export default {
   inheritAttrs: false,
   data() {
     return {
-      fileType: null,
-      loading: true,
-      filesInfo: null,
+      filesInfo: [],
       fileName: null,
       requestId: null,
       collectionId: null,
       recordId: null,
       prefix: '',
-      recordListVarName: null,
+      rowId: null,
     };
   },
   props: ['name', 'value', 'endpoint', 'requestFiles', 'label'],
   beforeMount() {
-    this.fileType = this.getFileType();
-
-    if (this.fileType == 'request') {
+    if (!this.collection) {
       this.requestId = this.getRequestId();
-    }
-
-    if (this.fileType == 'collection') {
-      // Fill this.recordId and collectionId
-      this.getCollectionInfo();
     }
   },
   mounted() {
     this.$root.$on('set-upload-data-name',
       (recordList, index, id) => this.listenRecordList(recordList, index, id));
 
-    if (!this.fileType) {
+    if (!this.collection && !this.requestId) {
       // Not somewhere we can download anything (like web entry start event)
-      this.loading = false;
       return;
     }
 
+    this.checkIfInRecordList();
     this.setPrefix();
-
-    if (this.fileType == 'request') {
-      this.getFilesInfo();
-    }
-
-    if (this.fileType == 'collection') {
-      this.getCollectionFiles();
-    }
+    this.setFilesInfo();
   },
   watch: {
-    value(value) {
-      this.fileName = value;
-      if (this.parentRecordList((this)) === null) {
-        this.getFilesInfo();
-      }
-      else {
-        this.getFilesInfo(this.recordListVarName);
-      }
+    value: {
+      handler() {
+        this.setFilesInfo();
+      },
+      deep: true,
+    },
+    fileDataName() {
+      this.setFilesInfo();
     },
   },
   computed: {
@@ -108,6 +86,16 @@ export default {
     isReadOnly() {
       return this.$attrs.readonly ? this.$attrs.readonly : false;
     },
+    fileDataName() {
+      return this.prefix + this.name + (this.rowId ? '.' + this.rowId : '');
+    },
+    collection() {
+      const collectionIdNode = document.head.querySelector('meta[name="collection-id"]');
+      if (collectionIdNode) {
+        return collectionIdNode.content;
+      }
+      return false;
+    },
   },
   methods: {
     parentRecordList(node) {
@@ -121,19 +109,16 @@ export default {
     },
     listenRecordList(recordList, index, id) {
       const parent = this.parentRecordList(this);
-      if (parent === recordList) {
-        const prefix = (this.parentRecordList(this) === null) ? '' : recordList.name + '.';
-        this.recordListVarName = prefix + this.name + (id ? '.' + id : '');
-        this.getFilesInfo(this.recordListVarName);
+      if (parent !== recordList) {
+        return;
       }
+      this.rowId = (parent !== null) ? id : null;
     },
     downloadFile(file) {
-      if (this.fileType == 'request') {
-        this.downloadRequestFile(file);
-      }
-
-      if (this.fileType == 'collection') {
+      if (this.collection) {
         this.downloadCollectionFile(file);
+      } else {
+        this.downloadRequestFile(file);
       }
     },
     requestEndpoint(file) {
@@ -148,7 +133,7 @@ export default {
         return endpoint + query;
       }
 
-      return '/request/' + this.requestId + '/files/' + file.id;
+      return `/files/${file.id}/contents`;
     },
     setPrefix() {
       let parent = this.$parent;
@@ -172,188 +157,76 @@ export default {
       }
     },
     downloadRequestFile(file) {
-      window.ProcessMaker.apiClient({
-        baseURL: '/',
-        url: this.requestEndpoint(file),
-        method: 'GET',
-        responseType: 'blob', // important
-      }).then(response => {
-        //axios needs to be told to open the file
-        const url = window.URL.createObjectURL(new Blob([response.data]));
-        const link = document.createElement('a');
-        link.href = url;
-        link.setAttribute('download', (file.name ? file.name : file.file_name));
-        document.body.appendChild(link);
-        link.click();
+      this.$dataProvider.download(this.requestEndpoint(file)).then(response => {
+        this.sendToBrowser(response, file);
       });
     },
     downloadCollectionFile(file) {
-      window.ProcessMaker.apiClient({
-        url: '/files/' + file.id + '/contents',
-        method: 'GET',
-        responseType: 'blob', // important
-      }).then(response => {
-        //axios needs to be told to open the file
-        const url = window.URL.createObjectURL(new Blob([response.data]));
-        const link = document.createElement('a');
-        link.href = url;
-        link.setAttribute('download', file.name);
-        document.body.appendChild(link);
-        link.click();
+      this.$dataProvider.download('/files/' + file.id + '/contents').then(response => {
+        this.sendToBrowser(response, file);
       });
     },
-    getFileType() {
-      let result = null;
-      const requestIdNode = document.head.querySelector('meta[name="request-id"]');
-      if (requestIdNode && requestIdNode.content) {
-        result = 'request';
-      }
-
-      if (document.head.querySelector('meta[name="collection-id"]')) {
-        result = 'collection';
-      }
-      return result;
+    sendToBrowser(response, file) {
+      //axios needs to be told to open the file
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement('a');
+      link.href = url;
+      link.setAttribute('download', file.name);
+      document.body.appendChild(link);
+      link.click();
     },
     getRequestId() {
       let node = document.head.querySelector('meta[name="request-id"]');
       if (node === null) {
-        this.loading = false;
-        return;
+        return null;
       }
       return node.content;
     },
-    getCollectionInfo() {
-      let collectionId, recordId = null;
-      let collectionNode = document.head.querySelector('meta[name="collection-id"]');
-      if (collectionNode === null) {
-        this.loading = false;
-        return;
-      }
-      this.collectionId = collectionNode.content;
-
-      let recordNode = document.head.querySelector('meta[name="record-id"]');
-      if (recordNode === null) {
-        this.loading = false;
-        return;
-      }
-      this.recordId = recordNode.content;
-      return {collectionId, recordId};
-    },
-    getFilesInfo(variableName = null) {
-      if (this.getFileType() === 'collection') {
-        this.filesInfo = this.value;
-        return;
-      }
-
-      if (this.value === null) {
-        this.loading=false;
-        return;
-      }
-      const name = variableName ? variableName : this.prefix + this.name;
-      const fileIds = this.asArray(this.value);
-      let requestFilesForVarExist = _.has(window, ['PM4ConfigOverrides', 'requestFiles', name]);
-
-      const allFilesInValueHaveData =
-        requestFilesForVarExist &&
-        fileIds.every(fileId => {
-          let fieldIsFoundinRequestData = false;
-          for (const variable in window.PM4ConfigOverrides.requestFiles) {
-            const varData = this.asArray(window.PM4ConfigOverrides.requestFiles[variable]);
-            fieldIsFoundinRequestData = fieldIsFoundinRequestData || varData.some(requestFile => requestFile.id === fileId);
-          }
-          return fieldIsFoundinRequestData;
-        });
-
-      if (allFilesInValueHaveData) {
-        this.setFileInfo(name);
-      }
-      else {
-        window.ProcessMaker.apiClient
-          .get(`requests/${this.requestId}/files`)
-          .then(response => {
-            const data = response.data.data;
-            let filesData = {};
-            data.forEach(fileData => {
-              const varName = _.get(fileData, 'custom_properties.data_name', null);
-              if (varName) {
-                const item = {
-                  id: fileData.id,
-                  file_name: fileData.file_name,
-                };
-                if (filesData[varName]) {
-                  if (!Array.isArray(filesData[varName])) {
-                    filesData[varName] = [filesData[varName]];
-                  }
-                  filesData[varName].push(item);
-                }
-                else {
-                  filesData[varName] = item;
-                }
-              }
-              _.set(window, 'PM4ConfigOverrides.requestFiles', filesData);
-              this.setFileInfo(name);
-            });
-            this.loading = false;
-          });
+    setFilesInfo() {
+      if (this.collection) {
+        this.setFilesInfoFromCollectionValue();
+      } else {
+        this.setFilesInfoFromRequest();
       }
     },
-    setFileInfo(name) {
-      let requestFiles = this.requestFiles;
-      if (_.has(window, 'PM4ConfigOverrides.requestFiles')) {
-        requestFiles = window.PM4ConfigOverrides.requestFiles;
-      }
-
-      if (requestFiles[name]) {
-        this.loading = false;
-        //return always an array
-        const filesData = Array.isArray(requestFiles[name]) ? requestFiles[name] :  [requestFiles[name]];
-        const valueIds = Array.isArray(this.value) ? this.value : [this.value];
-        let result = [];
-        valueIds.forEach(valueId => {
-          const fileData = filesData.find(item => item.id === valueId);
-          if (fileData) {
-            result.push(fileData);
-          }
-        });
-        this.filesInfo = result;
-      }
-    },
-    asArray(value) {
-      if (value === null || value === undefined) {
-        return null;
-      }
-      return Array.isArray(value) ? value : [value];
-    },
-    setFileInfoFromCache() {
-      const info = this.asArray(_.get(window.ProcessMaker.CollectionData, this.prefix + this.name, null));
-      if (info) {
-        this.filesInfo = info.map(item => {
-          return {...item, file_name: item.name};
-        });
-      }
-    },
-    getCollectionFiles() {
-      if (this.collectionId === null || this.recordId === null) {
-        this.loading = false;
-        return;
-      }
-
-      window.ProcessMaker.EventBus.$on('got-collection-data', () => {
-        this.setFileInfoFromCache();
-        this.loading = false;
+    setFilesInfoFromRequest() {
+      this.filesInfo = _.get(
+        window,
+        `PM4ConfigOverrides.requestFiles["${this.fileDataName}"]`,
+        []
+      ).map(file => {
+        return { id: file.id, name: file.file_name };
       });
-
-      if (!window.ProcessMaker.CollectionData) {
-        window.ProcessMaker.CollectionData = {};
-        window.ProcessMaker.apiClient
-          .get('collections/' + this.collectionId + '/records/' + this.recordId)
-          .then(response => {
-            window.ProcessMaker.CollectionData = response.data.data;
-            this.filesInfo = this.value;
-            window.ProcessMaker.EventBus.$emit('got-collection-data');
-          });
+    },
+    setFilesInfoFromCollectionValue() {
+      if (!this.value) {
+        this.filesInfo = [];
+        return;
       }
-      this.filesInfo = this.value;
+      if (Array.isArray(this.value)) {
+        // multi file upload
+        this.filesInfo = this.value.map(value => value.file);
+      } else {
+        this.filesInfo = [this.value];
+      }
+
+    },
+    checkIfInRecordList() {
+      const parent = this.parentRecordList(this);
+      if (parent !== null) {
+        const recordList = parent;
+        const prefix = recordList.name + '.';
+        this.setFileUploadNameForChildren(recordList.$children, prefix);
+      }
+    },
+    setFileUploadNameForChildren(children, prefix) {
+      children.forEach(child => {
+        if (_.get(child, '$options.name') === 'FileDownload') {
+          child.prefix = prefix;
+        } else if (_.get(child, '$children', []).length > 0) {
+          this.setFileUploadNameForChildren(child.$children, prefix);
+        }
+      });
     },
   },
 };

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -119,7 +119,18 @@ export default {
   },
   computed: {
     filesFromGlobalRequestFiles() {
-      return _.get(window, `PM4ConfigOverrides.requestFiles["${this.fileDataName}"]`, []);
+      if (!this.value) {
+        return [];
+      }
+      return _.get(window, `PM4ConfigOverrides.requestFiles["${this.fileDataName}"]`, []).filter(file => {
+        // Filter any requestFiles that don't exist in this component's value. This can happen if
+        // a file is uploaded but the task is not saved.
+        if (this.multipleUpload) {
+          return this.value.some(valueFile => valueFile.file === file.id);
+        } else {
+          return file.id === this.value;
+        }
+      });
     },
     filesFromCollection() {
       if (!this.value) {
@@ -477,6 +488,7 @@ export default {
         const fileInfo = {
           id,
           file_name: name,
+          mime_type: rootFile.fileType,
         };
        
         this.$set(this.nativeFiles, id, rootFile);

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -36,15 +36,15 @@
         <template>
           <ul>
             <li v-for="(file, i) in files " :key="i" :data-cy="file.id">
-              <div class="container-fluid pl-3 pr-3">
-                <div class="row" style="background:rgb(226 238 255)">
-                  <div v-if="nativeFiles[file.id]" class="col-11 pr-0 pl-0" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
+              <div class="">
+                <div class="" style="display:flex; background:rgb(226 238 255)">
+                  <div v-if="nativeFiles[file.id]" style="flex: 1" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
                     <uploader-file :file="nativeFiles[file.id]" :list="true" />
                   </div>
-                  <div v-else class="col-11 pr-0 pl-0 my-auto">
+                  <div v-else style="flex: 1">
                     <i class="fas fa-paperclip"/> {{ file.file_name }}
                   </div>
-                  <div class="col-1 my-auto uploader-file">
+                  <div class="pt-1">
                     <b-btn variant="outline" @click="removeFile(file)" v-b-tooltip.hover :title="$t('Delete')">
                       <i class="fas fa-trash-alt"/>
                     </b-btn>

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -382,7 +382,12 @@ export default {
     },
     async removeFile(file) { 
       const id = file.id;
-      await this.$dataProvider.deleteFile(id);
+      const token = file.token ? file.token : null;
+
+      // If it's not a web entry start event
+      if (!isNaN(id)) {
+        await this.$dataProvider.deleteFile(id, token);
+      }
       
       this.removeFromFiles(id);
     },

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -38,7 +38,7 @@
             <li v-for="(file, i) in files " :key="i" :data-cy="file.id">
               <div class="container-fluid pl-3 pr-3">
                 <div class="row" style="background:rgb(226 238 255)">
-                  <div v-if="nativeFiles[file.id]" class="col-11 pr-0 pl-0">
+                  <div v-if="nativeFiles[file.id]" class="col-11 pr-0 pl-0" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
                     <uploader-file :file="nativeFiles[file.id]" :list="true" />
                   </div>
                   <div v-else class="col-11 pr-0 pl-0 my-auto">
@@ -348,6 +348,9 @@ export default {
 
           for (const id of idsInRemoved) {
             if (this.hasFileId(id)) {
+              // In record lists, delete can be called twice on the same file.
+              // Catch and igore the error.
+              // eslint-disable-next-line no-unused-vars
               await this.$dataProvider.deleteFile(id).catch(e => {});
               this.removeFromFiles(id);
             }

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -36,12 +36,6 @@
         <template>
           <ul>
             <li v-for="(file, i) in files " :key="i" :data-cy="file.id">
-
-
-
-              ID: {{ file.id }}
-
-              
               <div class="container-fluid pl-3 pr-3">
                 <div class="row" style="background:rgb(226 238 255)">
                   <div v-if="nativeFiles[file.id]" class="col-11 pr-0 pl-0">
@@ -527,23 +521,7 @@ export default {
       }
 
       if (this.collection) {
-        return 'http://pmdev41.nossl'
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        
-        + '/api/1.0/files' +
+        return '/api/1.0/files' +
             '?model=' +
             'ProcessMaker\\Plugins\\Collections\\Models\\Collection' +
             '&model_id=' +

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -264,7 +264,6 @@ export default {
         headers: {
           'X-Requested-With': 'XMLHttpRequest',
           'X-CSRF-TOKEN': window.ProcessMaker.apiClient.defaults.headers.common['X-CSRF-TOKEN'],
-          'Authorization': 'Bearer ' + this.$dataProvider.token(),
         },
         singleFile: !this.multipleUpload,
       },

--- a/tests/e2e/specs/MultipleUpload.spec.js
+++ b/tests/e2e/specs/MultipleUpload.spec.js
@@ -28,7 +28,7 @@ describe('Multiple Upload', () => {
     // The global variable should store the uploaded item
     cy.window().its('PM4ConfigOverrides.requestFiles.filesingle')
       .then(fileValue => {
-        expect(fileValue.file_name).to.equal('avatar.jpeg');
+        expect(fileValue[0].file_name).to.equal('avatar.jpeg');
       });
     // The download control should have the file to download
     cy.get('[data-cy=1-avatar-jpeg]').should('contain.text', 'avatar.jpeg');
@@ -41,10 +41,10 @@ describe('Multiple Upload', () => {
     }));
     cy.uploadFile('[data-cy=preview-content] [data-cy=screen-field-filesingle] input[type=file]', 'file1.jpeg', 'image/jpg');
     cy.get('[data-cy=file1-jpeg] .uploader-file-name').should('include.text', 'file1.jpeg');
-    cy.waitUntil(() => cy.window().then(win => win.PM4ConfigOverrides.requestFiles.filesingle.file_name === 'file1.jpeg'));
+    cy.waitUntil(() => cy.window().then(win => win.PM4ConfigOverrides.requestFiles.filesingle[0].file_name === 'file1.jpeg'));
     cy.window().its('PM4ConfigOverrides.requestFiles.filesingle')
       .then(fileValue => {
-        expect(fileValue.file_name).to.equal('file1.jpeg');
+        expect(fileValue[0].file_name).to.equal('file1.jpeg');
       });
     // The download control should have the new file ready to download
     cy.get('[data-cy=2-file1-jpeg]').should('contain.text', 'file1.jpeg');
@@ -129,7 +129,7 @@ describe('Multiple Upload', () => {
       .then(requestFiles => {
         const firstMapFileVar = Object.keys(requestFiles).find(x => x.startsWith('members.map'));
         const rowId = firstMapFileVar.split('members.map.')[1];
-        expect(requestFiles['members.map.' + rowId].file_name).to.equal('avatar.jpeg');
+        expect(requestFiles['members.map.' + rowId][0].file_name).to.equal('avatar.jpeg');
       });
     // The download control should have the file to download
     cy.get('[data-cy=1-avatar-jpeg]').should('contain.text', 'avatar.jpeg');


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-4406

Complete refactor of multi-file uploads to fix issues in ticket.

Requires
- https://github.com/ProcessMaker/processmaker/pull/4169
- https://github.com/ProcessMaker/package-webentry/pull/128
- https://github.com/ProcessMaker/package-files/pull/65

To test, try a variety of single and multi-upload enabled file upload components and download components in a screen in a variety of scenarios

Notes
- file download auto-detects if it was a multi-upload, there is no inspector option to enable mulit-file uploads in the download component.
- To test in a loop, set the loop variable name to the same as the multi-file upload. Inside the loop, the file variable is always named "file"
