### PR TITLE
Fix Custom CSS Styles rendering on elements in Design mode

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -99,7 +99,7 @@
 
       <draggable
         data-cy="editor-content"
-        class="h-100 custom-css-scope"
+        class="h-100"
         ghost-class="form-control-ghost"
         :value="config[currentPage].items"
         @input="updateConfig"

--- a/tests/e2e/specs/CustomCss.spec.js
+++ b/tests/e2e/specs/CustomCss.spec.js
@@ -53,7 +53,22 @@ describe('Custom CSS', () => {
     cy.assertComponentValue('[data-cy=monaco-editor]', 'div[selector=\'new_input_css\'] {background-color:red;padding:10px;}');
   });
 
-  it('Adds styling to element', () => {
+  it('Does not add styling to element in design mode', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-customCssSelector]').type('new_input_css');
+    cy.get('[data-cy=topbar-css]').click();
+    cy.get('#custom-css').type('div[selector=\'new_input_css\'] {background-color:red;padding:10px;}', {parseSpecialCharSequences: false} );
+    cy.get('[data-cy=save-button]').click();
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('.page').should('contain.html', '<div selector="new_input_css">');
+    cy.get('[data-cy=mode-editor]').click();
+    cy.get('[data-cy=editor-content]').should('not.contain.class', 'custom-css-scope');
+  });
+
+  it('Adds styling to element in preview mode', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();


### PR DESCRIPTION
<h2>Issue</h2>

Ticket: [FOUR-4844](https://processmaker.atlassian.net/browse/FOUR-4844)

Per the documentation for [adding custom CSS styling](https://processmaker.gitbook.io/processmaker/designing-processes/design-forms/screens-builder/add-custom-css-to-a-screen#add-custom-css-to-a-processmaker-screen).  Custom CSS styles should display in Preview mode and NOT Design mode. Currently, custom CSS displays in both modes.

<h2>Solution</h2>

- Remove the `custom-css-scope` class that renders Custom CSS in Design Mode.
- Add a test to ensure CSS styles do not display in Design mode

<h2>To Replicate / Test</h2>

1. Add a Line Input control to the screen
2. For the control, configure a custom CSS selector under the 'Advanced' accordion
3. Add CSS for the selector in the Custom CSS modal

**Correct Behavior**
While in Design mode the Line Input control should NOT render the custom CSS. 
While in Preview mode the Line Input control SHOULD render the custom CSS.

Note: 
For standalone Screen Builder testing, toggling between design -> preview -> design triggers the custom CSS to display in design mode.



