### PR TITLE
Missing uploaded public file data in modal

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -498,6 +498,8 @@ export default {
        
         this.$set(this.nativeFiles, id, rootFile);
         this.addToFiles(fileInfo);
+      } else {
+        this.$emit('input', name);
       }
     },
     removed() {


### PR DESCRIPTION
Ticket: [FOUR-4125](https://processmaker.atlassian.net/browse/FOUR-4125)

<h2>Issue</h2>

When uploading a public file the modal does not display the file data in the Upload Tray.  This was caused by not emitting the file name in the `fileUploaded` method when the `message` variable is not set. 

<h2>Solution</h2>

- Add `else` condition when the `message` variable is not set and emit the uploaded file name.

<h2>To Replicate</h2>

1. Under the file manager add a new public file
2. Upload a file.

**Current Behavior**

The uploaded file information does not display in the Uploaded Files tray

see video
https://user-images.githubusercontent.com/52755494/145288720-de279fbb-60f6-454f-add8-61c51279b40c.mov


<h2>Related PR's</h2>

https://github.com/ProcessMaker/package-files/pull/66

<h2> To Test</h2>

1. Under the file manager add a new public file
2. Upload a file.

**Expected Behavior**

The uploaded file information is displayed in the Uploaded Files tray.




