### PR TITLE
Fix Vocabulary Array Max Items Validation

### DIFF
--- a/src/components/renderer/add-loop-row.vue
+++ b/src/components/renderer/add-loop-row.vue
@@ -1,14 +1,22 @@
 <template>
-  <b-row class="justify-content-md-center" v-if="value && config.settings.add">
-    <b-col md="auto">
-      <b-button size="sm" variant="secondary" class="ml-1 mr-1" @click="add" :title="$t('Add Item')" :data-cy="`loop-${config.name}-add`">
-        <i class="fas fa-plus"/>
-      </b-button>
-      <b-button v-if="value.length > 0" size="sm" variant="outline-danger" class="ml-1 mr-1" @click="removeConfirm" :title="$t('Delete Item')" :data-cy="`loop-${config.name}-remove`">
-        <i class="fas fa-minus"/>
-      </b-button>
-    </b-col>
-  </b-row>
+  <div>
+    <b-row class="justify-content-start" v-if="error">
+      <b-col md="auto">
+        <div class="invalid-feedback d-block">{{ error }}</div>
+      </b-col>
+    </b-row>
+
+    <b-row class="justify-content-md-center"  v-if="value && config.settings.add">
+      <b-col md="auto">
+        <b-button size="sm" variant="secondary" class="ml-1 mr-1" @click="add" :title="$t('Add Item')" :data-cy="`loop-${config.name}-add`">
+          <i class="fas fa-plus"/>
+        </b-button>
+        <b-button v-if="value.length > 0" size="sm" variant="outline-danger" class="ml-1 mr-1" @click="removeConfirm" :title="$t('Delete Item')" :data-cy="`loop-${config.name}-remove`">
+          <i class="fas fa-minus"/>
+        </b-button>
+      </b-col>
+    </b-row>
+  </div>
 </template>
 
 <script>
@@ -16,6 +24,7 @@ export default {
   props: {
     value: Array,
     config: Object,
+    error: String,
   },
   methods: {
     add() {

--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -22,6 +22,7 @@ import {
   or,
   and,
   maxItems,
+  minItems,
 } from 'vuelidate/lib/validators';
 
 export const ValidationMsg = {
@@ -57,6 +58,7 @@ export const ValidationMsg = {
   customDate: 'Must be a valid Date',
   regex: 'Invalid value',
   maxItems: 'Should NOT have more than {max} items',
+  minItems: 'Must have at least {min}',
 };
 
 export const custom_date = (date) => {
@@ -228,4 +230,5 @@ export const validators = {
   regex,
   afterOrEqual: after_or_equal,
   maxItems,
+  minItems,
 };

--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -21,6 +21,7 @@ import {
   not,
   or,
   and,
+  maxItems,
 } from 'vuelidate/lib/validators';
 
 export const ValidationMsg = {
@@ -55,6 +56,7 @@ export const ValidationMsg = {
   invalid_default_value: 'Invalid default value',
   customDate: 'Must be a valid Date',
   regex: 'Invalid value',
+  maxItems: 'Should NOT have more than {max} items',
 };
 
 export const custom_date = (date) => {
@@ -225,4 +227,5 @@ export const validators = {
   notIn,
   regex,
   afterOrEqual: after_or_equal,
+  maxItems,
 };

--- a/src/mixins/extensions/LoopContainer.js
+++ b/src/mixins/extensions/LoopContainer.js
@@ -47,6 +47,7 @@ export default {
       const addLoopRow = this.createComponent('AddLoopRow', {
         ':value': element.config.settings.varname,
         ':config': this.byValue(element.config),
+        ':error': `${this.checkVariableExists('$v.vdata.' + element.config.name)} && validationMessage($v.vdata.${element.config.name}) || ${this.checkVariableExists('$v.schema.' + element.config.name)} && validationMessage($v.schema.${element.config.name})`,
       });
       loop.appendChild(child);
       node.appendChild(loop);


### PR DESCRIPTION
## Editing and playback steps
the scenario to replicate is with json schema (package-vocabulary)

## Solution
- add message and section for display error in component loop.

## How to test
- Create a Vocabulary to validate the maximum Item of a loop_1
- Create a Screen with a Loop (loop_1)
- Create a process with that screen assigned to a Task
- Assign the created vocabularyto to the Task
- Run the process,  the loop passes with any number of items


** Video of work **


https://user-images.githubusercontent.com/1747025/145604066-339c2166-17c4-46f3-9f05-d973756053f7.mp4


## Related tickets and packages
- [FOUR-4785] (https://processmaker.atlassian.net/browse/FOUR-4785)


## Code Review Checklist
- [] I have extracted this code locally and tested it on my instance, along with the associated packages.
- [] This code adheres to the [ProcessMaker Coding Guidelines] (https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [] This solution fixes the error reported in the original ticket.
- [] This solution does not alter the expected output of a component in a way that breaks existing Processes.
- [] This solution does not implement any major changes that would invalidate the documentation or cause existing processes to fail.
- [] This solution has been tested with business packages that depend on its functionality and do not introduce errors in those packages.
- [] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-4785]: https://processmaker.atlassian.net/browse/FOUR-4785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ