### PR TITLE
Bugfix/FOUR-4903: Date Field validation not working with calc prop (For 4.2)

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -57,9 +57,12 @@
             </div>
           </b-card-header>
           <b-collapse :id="formatRuleContentAsId(rule.content)" :accordion="formatRuleContentAsId(rule.content)" :visible="rule.visible" role="tabpanel">
-            <b-card-body> 
-              <div class="p-2"> 
+            <b-card-body>
+              <div class="p-2">
                 <div v-for="config in rule.configs" :key="config.label" class="mb-2">
+                  <div v-if="rule.showMustacheHelper">
+                    <mustache-helper/>
+                  </div>
                   <div v-if="config.type === 'FormInput'">
                     <form-input :label="config.label" :name="config.name || config.label" v-model="config.value" :validation="config.validation" :helper="config.helper"/>
                   </div>
@@ -92,6 +95,7 @@
 
 <script>
 import { FormInput } from '@processmaker/vue-form-elements';
+import MustacheHelper from './mustache-helper';
 import _ from 'lodash';
 import InputVariable from '../inspector/input-variable';
 
@@ -100,6 +104,7 @@ export default {
   components: {
     FormInput,
     InputVariable,
+    MustacheHelper,
   },
   data() {
     return {
@@ -237,6 +242,7 @@ export default {
           content: this.$t('After Date'),
           helper: this.$t('The field under validation must be after the given date.'),
           visible: true,
+          showMustacheHelper: true,
           configs: [
             {type: 'FormInput', label: this.$t('Date'), helper: '', validation: 'required'},
           ],
@@ -247,6 +253,7 @@ export default {
           content: this.$t('After or Equal to Date'),
           helper: this.$t('The field unter validation must be after or equal to the given field.'),
           visible: true,
+          showMustacheHelper: true,
           configs: [
             {type: 'FormInput', label: this.$t('Date'), helper: '', validation: 'required'},
           ],
@@ -257,6 +264,7 @@ export default {
           content: this.$t('Before Date'),
           helper: this.$t('The field unter validation must be before the given date.'),
           visible: true,
+          showMustacheHelper: true,
           configs: [
             {type: 'FormInput', label: this.$t('Date'), helper: '', validation: 'required'},
           ],
@@ -267,6 +275,7 @@ export default {
           content: this.$t('Before or Equal to Date'),
           helper: this.$t('The field unter validation must be before or equal to the given field.'),
           visible: true,
+          showMustacheHelper: true,
           configs: [
             {type: 'FormInput', label: this.$t('Date'), helper: '', validation: 'required'},
           ],
@@ -292,7 +301,7 @@ export default {
       if (this.rules && this.rules.length) {
         return true;
       }
-      
+
       return false;
     },
   },
@@ -314,7 +323,7 @@ export default {
     value() {
       this.rules = this.value || [];
       this.cloneSetRules();
-      
+
     },
     selectedOption: {
       deep: true,
@@ -378,13 +387,13 @@ export default {
             }
           });
 
-          if (ruleConfigs.length > 1) {  
+          if (ruleConfigs.length > 1) {
             ruleConfigs = ruleConfigs.join(',');
           }
           if (ruleConfigs.length) {
             rule.value = rule.field + ruleConfigs;
           }
-          
+
         }
       });
     },

--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -70,20 +70,18 @@ export const custom_date = (date) => {
   let checkDate = moment(date, [format, moment.ISO_8601], true);
   return checkDate.isValid();
 };
-  
+
 export const after = (after, fieldName) => helpers.withParams({after}, function(date, data) {
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after, after));
+  const checkDate = moment(get(dataWithParent, after.replace(/[{ }]/g, ''), after));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const afterDate = checkDate.toISOString();
-
+  const afterDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
   return inputDate > afterDate;
 });
 
@@ -92,13 +90,12 @@ export const after_or_equal = (after_or_equal, fieldName) => helpers.withParams(
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after_or_equal, after_or_equal));
+  const checkDate = moment(get(dataWithParent, after_or_equal.replace(/[{ }]/g, ''), after_or_equal));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const equalOrAfterDate = checkDate.toISOString();
+  const equalOrAfterDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
   return inputDate >= equalOrAfterDate;
 });
 
@@ -107,13 +104,12 @@ export const before = (before, fieldName) => helpers.withParams({before}, functi
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before, before));
+  const checkDate = moment(get(dataWithParent, before.replace(/[{ }]/g, ''), before));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const beforeDate = checkDate.toISOString();
+  const beforeDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
   return inputDate < beforeDate;
 });
 
@@ -122,14 +118,12 @@ export const before_or_equal = (before_or_equal, fieldName) => helpers.withParam
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before_or_equal, before_or_equal));
+  const checkDate = moment(get(dataWithParent, before_or_equal.replace(/[{ }]/g, ''), before_or_equal));
   if (!checkDate.isValid()) {
     return false;
   }
-    
   const inputDate = moment(date).toISOString();
-  const beforeDate = checkDate.toISOString();
-    
+  const beforeDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
   return inputDate <= beforeDate;
 });
 
@@ -187,7 +181,7 @@ export const requiredUnless = (variable, expected, fieldName) => helpers.withPar
   if (variableValue == expectedValue) return true;
   return value instanceof Array ? value.length > 0 : !!value;
 });
-  
+
 export const sameAs = (field, fieldName) => helpers.withParams({field}, function(value, data) {
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);

--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -1,6 +1,7 @@
 import { helpers } from 'vuelidate/lib/validators';
 import moment from 'moment';
 import { get } from 'lodash';
+import Mustache from 'mustache';
 
 import {
   minLength,
@@ -75,13 +76,14 @@ export const after = (after, fieldName) => helpers.withParams({after}, function(
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
+  const afterReplaced = Mustache.render(after, dataWithParent);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after.replace(/[{ }]/g, ''), after));
+  const checkDate = moment(get(dataWithParent, after, afterReplaced));
   if (!checkDate.isValid()) {
     return false;
   }
   const inputDate = moment(date).toISOString();
-  const afterDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
+  const afterDate = checkDate.toISOString();
   return inputDate > afterDate;
 });
 
@@ -89,13 +91,14 @@ export const after_or_equal = (after_or_equal, fieldName) => helpers.withParams(
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
+  const afterOrEqualReplaced = Mustache.render(after_or_equal, dataWithParent);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after_or_equal.replace(/[{ }]/g, ''), after_or_equal));
+  const checkDate = moment(get(dataWithParent, after_or_equal, afterOrEqualReplaced));
   if (!checkDate.isValid()) {
     return false;
   }
   const inputDate = moment(date).toISOString();
-  const equalOrAfterDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
+  const equalOrAfterDate = checkDate.toISOString();
   return inputDate >= equalOrAfterDate;
 });
 
@@ -103,13 +106,14 @@ export const before = (before, fieldName) => helpers.withParams({before}, functi
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
+  const beforeReplaced = Mustache.render(before, dataWithParent);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before.replace(/[{ }]/g, ''), before));
+  const checkDate = moment(get(dataWithParent, before, beforeReplaced));
   if (!checkDate.isValid()) {
     return false;
   }
   const inputDate = moment(date).toISOString();
-  const beforeDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
+  const beforeDate = checkDate.toISOString();
   return inputDate < beforeDate;
 });
 
@@ -117,13 +121,14 @@ export const before_or_equal = (before_or_equal, fieldName) => helpers.withParam
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
+  const beforeOrEqualReplaced = Mustache.render(before_or_equal, dataWithParent);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before_or_equal.replace(/[{ }]/g, ''), before_or_equal));
+  const checkDate = moment(get(dataWithParent, before_or_equal, beforeOrEqualReplaced));
   if (!checkDate.isValid()) {
     return false;
   }
   const inputDate = moment(date).toISOString();
-  const beforeDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
+  const beforeDate = checkDate.toISOString();
   return inputDate <= beforeDate;
 });
 

--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -49,4 +49,236 @@ describe('Date Picker', () => {
       form_date_picker_1: today.toISOString(),
     });
   });
+
+  it('Mustache in Date validation After Date with a before input date should show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'After Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/08/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('contain.html', '<div>Must be after {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation After Date with an after input date should not show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'After Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/21/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert not see validation error
+    cy.get('.page').should('not.contain.html', '<div>Must be after {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation After or Equal Date with a before input date should show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'After or Equal to Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/08/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('contain.html', '<div>Must be equal or after {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation After or Equal Date with same input date should not show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'After or Equal to Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/20/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('not.contain.html', '<div>Must be equal or after {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation Before Date with an after input date should show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Before Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/21/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('contain.html', '<div>Must be before {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation Before Date with a before input date should not show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Before Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/19/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert not see validation error
+    cy.get('.page').should('not.contain.html', '<div>Must be before {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation Before or Equal Date with an after input date should show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Before or Equal to Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/21/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('contain.html', '<div>Must be equal or before {{form_input_1}}</div>');
+  });
+
+  it('Mustache in Date validation Before or Equal Date with same input date should not show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Before or Equal to Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}form_input_1{}}{}}');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021-12-20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/20/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('not.contain.html', '<div>Must be equal or before {{form_input_1}}</div>');
+  });
+
+  it('Mustache combination in Date validation After Date with an before input date should show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'After Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}year_input{}}{}}-{{}{{}month_input{}}{}}-{{}{{}day_input{}}{}}');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('year_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021');
+    cy.get(':nth-child(2) > [data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('month_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('12');
+    cy.get(':nth-child(3) > [data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('day_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/18/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('contain.html', '<div>Must be after {{year_input}}-{{month_input}}-{{day_input}}</div>');
+  });
+
+  it('Mustache combination in Date validation Before or Equal Date with same input date should not show validation error', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Before or Equal to Date');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('*[class^="form-control"]').get('[name="Date"]').type('{{}{{}year_input{}}{}}-{{}{{}month_input{}}{}}-{{}{{}day_input{}}{}}');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=update-rule]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('year_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('2021');
+    cy.get(':nth-child(2) > [data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('month_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('12');
+    cy.get(':nth-child(3) > [data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=inspector-name]').clear().type('day_input');
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('20');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').type('12/20/2021');
+    cy.get('[data-cy=preview-content]').click();
+    // Assert see validation error
+    cy.get('.page').should('not.contain.html', '<div>Must be equal or before {{form_input_1}}</div>');
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
**Issue 1**
Validations not working for calculated properties (after date, before date, after or equal date, before or equal date)

**Issue 2**
Client is returning a date with the format DD/MM/YYYY and should be YYYY-MM-DD as described in the [documentation](https://processmaker.gitbook.io/processmaker/designing-processes/design-forms/screens-builder/control-descriptions/validation-rules-for-validation-control-settings#after-date)

**Issue 3**
If you have a datetime input with the value eg. 15/12/2021 11:52 and we want to validate if **after** (not after or equal) than 15/12/2021 the output should be false becase is not after, is equal date, but is returning true because the currentDate is 15/12/2021 00:00 and the input date is 15/12/2021 11:52. The same happens with the other cases.

Reproduction steps
- Have a screen with a date field
- Add a validation rule "Before or Equal to Date"
- Add a variable in mustache currentDate
- Have a calc prop to return the current date with JS to the variable currentDate

Sample calc property code (set name of the calc property to currentDate):
```
today = new Date();
var sp = '-';
var dd = today.getDate();
var mm = today.getMonth()+1; //As January is 0.
var yyyy = today.getFullYear();

if(dd<10) dd='0'+dd;
if(mm<10) mm='0'+mm;
// return (dd+sp+mm+sp+yyyy);  First issue detected is that client is returning a date in format DD/MM/YYYY
return (yyyy+sp+mm+sp+dd);
```
- Go to Preview and select a date Before or equal that currentDate calc property. You will note that validation is not working.

## Solution
- When doing moment(get(dataWithParent, before_or_equal, before_or_equal)) searching from before_or_equal index is not finding the key inside dataWithParent because it is passed as {{currentDate}} instead currentDate, so added a regex to remove mustaches {{ }}.
- Added endOf('day') to before_or_equal and after validations to work properly
- Added startOf('day') to after_or_equal and before validations to work properly 

## How to Test
- Have a screen with a date field
- Add a validation rule "Before or Equal to Date"
- Add a variable in mustache currentDate
- Have a calc prop to return the current date with JS to the variable currentDate
Use the previous sample calc property code and set name of the calc property to currentDate
- Go to Preview and select a date Before or equal that currentDate calc property. You will note that validation is working now. **Please test it with After date, After or equal date, before date and Before or equal date.**

**Working video**

https://user-images.githubusercontent.com/90727999/146244650-e4b6a95f-2829-462c-81ca-c9bdfa3c625d.mov


## Related Tickets & Packages
- [FOUR-4903](https://processmaker.atlassian.net/browse/FOUR-4903)