### PR TITLE
Bugfix/FOUR-4903: Date Field validation not working with calc prop (For 4.1)

### DIFF
--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -66,20 +66,18 @@ export const custom_date = (date) => {
   let checkDate = moment(date, [format, moment.ISO_8601], true);
   return checkDate.isValid();
 };
-  
+
 export const after = (after, fieldName) => helpers.withParams({after}, function(date, data) {
   // Get check date
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after, after));
+  const checkDate = moment(get(dataWithParent, after.replace(/[{ }]/g, ''), after));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const afterDate = checkDate.toISOString();
-
+  const afterDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
   return inputDate > afterDate;
 });
 
@@ -88,13 +86,12 @@ export const after_or_equal = (after_or_equal, fieldName) => helpers.withParams(
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, after_or_equal, after_or_equal));
+  const checkDate = moment(get(dataWithParent, after_or_equal.replace(/[{ }]/g, ''), after_or_equal));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const equalOrAfterDate = checkDate.toISOString();
+  const equalOrAfterDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
   return inputDate >= equalOrAfterDate;
 });
 
@@ -103,13 +100,12 @@ export const before = (before, fieldName) => helpers.withParams({before}, functi
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before, before));
+  const checkDate = moment(get(dataWithParent, before.replace(/[{ }]/g, ''), before));
   if (!checkDate.isValid()) {
     return false;
   }
-
   const inputDate = moment(date).toISOString();
-  const beforeDate = checkDate.toISOString();
+  const beforeDate = moment(checkDate.toISOString()).startOf('day').toDate().toISOString();
   return inputDate < beforeDate;
 });
 
@@ -118,14 +114,12 @@ export const before_or_equal = (before_or_equal, fieldName) => helpers.withParam
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
   dataWithParent.today = moment().format('YYYY-MM-DD');
-  const checkDate = moment(get(dataWithParent, before_or_equal, before_or_equal));
+  const checkDate = moment(get(dataWithParent, before_or_equal.replace(/[{ }]/g, ''), before_or_equal));
   if (!checkDate.isValid()) {
     return false;
   }
-    
   const inputDate = moment(date).toISOString();
-  const beforeDate = checkDate.toISOString();
-    
+  const beforeDate = moment(checkDate.toISOString()).endOf('day').toDate().toISOString();
   return inputDate <= beforeDate;
 });
 
@@ -171,7 +165,7 @@ export const requiredUnless = (variable, expected, fieldName) => helpers.withPar
   if (get(dataWithParent, variable) == expected) return true;
   return value instanceof Array ? value.length > 0 : !!value;
 });
-  
+
 export const sameAs = (field, fieldName) => helpers.withParams({field}, function(value, data) {
   const level = fieldName.split('.').length - 1;
   const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);


### PR DESCRIPTION
## Issue & Reproduction Steps
**Issue 1**
Validations not working for calculated properties (after date, before date, after or equal date, before or equal date)

**Issue 2**
Client is returning a date with the format DD/MM/YYYY and should be YYYY-MM-DD as described in the [documentation](https://processmaker.gitbook.io/processmaker/designing-processes/design-forms/screens-builder/control-descriptions/validation-rules-for-validation-control-settings#after-date)

**Issue 3**
If you have a datetime input with the value eg. 15/12/2021 11:52 and we want to validate if **after** (not after or equal) than 15/12/2021 the output should be false becase is not after, is equal date, but is returning true because the currentDate is 15/12/2021 00:00 and the input date is 15/12/2021 11:52. The same happens with the other cases.

Reproduction steps
- Have a screen with a date field
- Add a validation rule "Before or Equal to Date"
- Add a variable in mustache currentDate
- Have a calc prop to return the current date with JS to the variable currentDate

Sample calc property code (set name of the calc property to currentDate):
```
today = new Date();
var sp = '-';
var dd = today.getDate();
var mm = today.getMonth()+1; //As January is 0.
var yyyy = today.getFullYear();

if(dd<10) dd='0'+dd;
if(mm<10) mm='0'+mm;
// return (dd+sp+mm+sp+yyyy);  First issue detected is that client is returning a date in format DD/MM/YYYY
return (yyyy+sp+mm+sp+dd);
```
- Go to Preview and select a date Before or equal that currentDate calc property. You will note that validation is not working.

## Solution
- When doing moment(get(dataWithParent, before_or_equal, before_or_equal)) searching from before_or_equal index is not finding the key inside dataWithParent because it is passed as {{currentDate}} instead currentDate, so added a regex to remove mustaches {{ }}.
- Added endOf('day') to before_or_equal and after validations to work properly
- Added startOf('day') to after_or_equal and before validations to work properly 

## How to Test
- Have a screen with a date field
- Add a validation rule "Before or Equal to Date"
- Add a variable in mustache currentDate
- Have a calc prop to return the current date with JS to the variable currentDate
Use the previous sample calc property code and set name of the calc property to currentDate
- Go to Preview and select a date Before or equal that currentDate calc property. You will note that validation is working now. **Please test it with After date, After or equal date, before date and Before or equal date.**

**Working video**

https://user-images.githubusercontent.com/90727999/146244650-e4b6a95f-2829-462c-81ca-c9bdfa3c625d.mov


## Related Tickets & Packages
- [FOUR-4903](https://processmaker.atlassian.net/browse/FOUR-4903)