### PR TITLE
# Bugfix FOUR 4892 - Select list shows an error in console with object variables

### DIFF
--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -25,13 +25,14 @@ export default {
       });
     },
     setupDefaultValue(screen, name, value) {
-      const defaultComputedName = `default_${name}__`;
+      const splittedName = name.split('.').join('_DOT_'); 
+      const defaultComputedName = `default_${splittedName}__`;
       this.addData(screen, `${name}_was_filled__`, `!!this.getValue(${JSON.stringify(name)}, this.vdata) || !!this.getValue(${JSON.stringify(name)}, data)`);
-      this.addMounted(screen, `if (!this.${name}) {
-        this.tryFormField(${JSON.stringify(name)}, () => {this.${this.dot2bracket(name)} = ${value};});
+      this.addMounted(screen, `if (!this.${splittedName}) {
+        this.tryFormField(${JSON.stringify(splittedName)}, () => {this.${this.dot2bracket(name)} = ${value};});
       }`);
       screen.computed[defaultComputedName] = {
-        get: new Function(`return this.tryFormField(${JSON.stringify(name)}, () => ${value});`),
+        get: new Function(`return this.tryFormField(${JSON.stringify(splittedName)}, () => ${value});`),
         set() {},
       };
       this.addWatch(screen, defaultComputedName, `!this.${name}_was_filled__ && this.setValue(${JSON.stringify(name)}, this.${defaultComputedName}, this.vdata, this);`);
@@ -44,9 +45,10 @@ export default {
       },
       onloadproperties({ properties, element, definition }) {
         const name = element.config.name;
+        const splittedName = name.split('.').join('_DOT_'); 
         if (this.isComputedVariable(name, definition)) return;
         if (element.config.defaultValue || element.config.initiallyChecked) {
-          const event = `${name}_was_filled__ |= !!$event; !${name}_was_filled__ && (vdata.${this.dot2bracket(name)} = default_${name}__)`;
+          const event = `${name}_was_filled__ |= !!$event; !${name}_was_filled__ && (vdata.${this.dot2bracket(name)} = default_${splittedName}__)`;
           this.addEvent(properties, 'input', event);
         }
       },


### PR DESCRIPTION
## Issue & Reproduction Steps
The console displays an error "ReferenceError: default_fields is not defined". This happens in version 4.2.24, but not in v.4.2.19. From the "collections package" this error is shown several times, and at times the screen crashes.

1. Create or import the screen
2. Add a select list control with a variable of type `object.value`
3. Create some options in data source
4. Preview

## Solution
- The dot was removed from the variable name creating a new name for the variable.

## How to Test
1. Create or import the screen
2. Add a select list control with a variable of type `object.value`
3. Create some options in data source
4. Preview

## Related Tickets & Packages
- [FOUR-4892](https://processmaker.atlassian.net/browse/FOUR-4892)
