### PR TITLE
FOUR-4901: "Time outs" in collection in screen with several nested screen with select list with variables object 

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export default {
   screensCache: [],
+  cachedScreenPromises: [],
 
   install(Vue) {
     Vue.prototype.$dataProvider = this;
@@ -80,23 +81,28 @@ export default {
       }
     });
   },
-  getScreen(id, query = '') {
-    const endpoint = _.get(window, 'PM4ConfigOverrides.getScreenEndpoint', '/screens');
-    return new Promise((resolve, reject) => {
-      const cache = this.screensCache.find(screen => screen.id == id);
-      if (cache) {
-        resolve({data: cache});
-      }
-      if (!cache && id != undefined) {
-        const request = this.get(endpoint + `/${id}${query}`);
-        request.then(response => {
-          if (response.data.nested) {
-            this.addNestedScreenCache(response.data.nested);
-          }
-          resolve(response);
-        }).catch(response => reject(response));
-      }
-    });
+  getScreen(id, query='') {
+    let cachedPromise = this.cachedScreenPromises.find(item => item.id === id && item.query === query);
+    if (cachedPromise) {
+      return cachedPromise.screenPromise;
+    }
+    else {
+      const endpoint = _.get(window, 'PM4ConfigOverrides.getScreenEndpoint', '/screens');
+      const request = this.get(endpoint + `/${id}${query}`);
+
+      let screenPromise = new Promise((resolve, reject) => {
+        request
+          .then(response => {
+            if (response.data.nested) {
+              this.addNestedScreenCache(response.data.nested);
+            }
+            resolve(response);
+          })
+          .catch(response => reject(response));
+      });
+      this.cachedScreenPromises.push({id, query, screenPromise});
+      return screenPromise;
+    }
   },
 
   postScript(id, params, options = {}) {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-4901](https://processmaker.atlassian.net/browse/FOUR-4901)

The problem was caused because the screen definitions were added when the API call response arrived but at that time, n requests were already dispatched, so "n" API calls were made.  Now we'll catch promises instead of screen definitions.

To test:

- Import the attached screen 
[Screen Many nested.zip](https://github.com/ProcessMaker/screen-builder/files/7737310/Screen.Many.nested.zip)

- Associate the screen to a collection
- Create a new record for the collection
- Verify that just one network call to retrieve the nested screen is made.

Before:
![antes](https://user-images.githubusercontent.com/14875032/146576861-6cfc380d-6a01-4683-95af-290a2228ac65.gif)

After:
![después](https://user-images.githubusercontent.com/14875032/146576918-715b30c0-54bf-420c-b849-270786b9f02a.gif)

