### PR TITLE
Include vdata in nested calculated props

### DIFF
--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -1,21 +1,20 @@
+import _ from 'lodash';
 import { Parser } from 'expr-eval';
 
 export default {
   methods: {
     evaluateExpression(expression, type) {
       let value = null;
-      try {
-        const self = this;
 
+      const merged = {};
+      _.merge(merged, this.vdata, this._data);
+
+      try {
         //monitor if variable belongs to data (defined variables) or vdata (external variables)
         //in this way the event is not executed again when the variable is update
-        const data = new Proxy(Object.assign({}, this), {
+        const data = new Proxy(merged, {
           get(data, name) {
-            if (data[name] === undefined) {
-              return self.vdata[name];
-            } else {
-              return data[name];
-            }
+            return data[name];
           },
           set() {
             throw 'You are not allowed to set properties from inside an expression';


### PR DESCRIPTION
To reproduce the problem:

screen: [FOUR-4853.json.txt](https://github.com/ProcessMaker/screen-builder/files/7737838/FOUR-4853.json.txt)
Create a calculated prop called `output` with js `return this.foo.one`;
Create a screen with an input name `foo.two`
Create a rich text that shows the `output` variable
Go to preview and add this example input data
```
{
    "foo": {
        "one": "one",
        "two": "two"
    }
}
```
Expected: output should show `one`
Actual result: no output

The problem is that the calculated props input data is not merged with the vdata.

Proposed solution is to merge those objects

Need to make sure this solution does not break the solution for https://processmaker.atlassian.net/browse/FOUR-2797

