### PR TITLE
Make elements read-only if they use a sub object of a computed property

### DIFF
--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -214,7 +214,12 @@ export default {
       return name && typeof name === 'string' && name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/);
     },
     isComputedVariable(name, definition) {
-      return definition.computed && definition.computed.find(c => c.property === name);
+      return definition.computed && definition.computed.some(computed => {
+        // Check if the first part of an element's name (up to the first `.`)
+        // matches the name of a computed property.
+        const regex = new RegExp(`^${computed.property}(\\.|$)`, 'i');
+        return regex.test(name);
+      });
     },
     registerVariable(name, element = {}) {
       if (!this.validVariableName(name)) {

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -69,7 +69,7 @@ export default {
       properties[':form-computed'] = JSON.stringify(definition.computed);
       properties[':form-watchers'] = JSON.stringify(definition.watchers);
       // Check if control is assigned to a calculated property
-      const isCalcProp = definition.computed && !!definition.computed.find(computed => computed.property == element.config.name);
+      const isCalcProp = this.isComputedVariable(element.config.name, definition);
       properties[':readonly'] = isCalcProp || element.config.readonly;
       properties[':disabled'] = isCalcProp || element.config.disabled;
       // Events

--- a/tests/e2e/specs/ComputedFieldsReadOnly.spec.js
+++ b/tests/e2e/specs/ComputedFieldsReadOnly.spec.js
@@ -201,4 +201,31 @@ describe('Computed fields', () => {
       form_select_list_1: '1',
     });
   });
+
+  it('The user should not be able to change an input assigned to a sub property of a computed property', () => {
+    cy.visit('/');
+
+    // Add an input field
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
+    cy.get('[data-cy=screen-element-container]').eq(0).click();
+    cy.get('[data-cy=inspector-name]').clear().type('object.foo');
+
+    cy.get('[data-cy="topbar-calcs"]').click();
+    cy.get('[data-cy="calcs-add-property"]').click();
+    cy.get('[data-cy="calcs-property-name"]').clear().type('object');
+    cy.get('[data-cy="calcs-property-description"]').clear().type('returns object');
+    cy.get('[data-cy="calcs-switch-javascript"]').click();
+    cy.setVueComponentValue('[data-cy="calcs-property-javascript"]', 'return { foo: "bar" };');
+    cy.get('[data-cy="calcs-button-save"]').click();
+    cy.get('[data-cy="calcs-modal"] .close').click();
+    cy.get('[data-cy=mode-preview]').click();
+
+    // Assertion: Check the input is read only
+    cy.get('[data-cy=preview-content] [name="object.foo"]').should('have.attr', 'readonly');
+    // Assertion: Check the input is the computed object
+    cy.assertPreviewData({
+      object: { foo: 'bar' },
+    });
+
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

We're supposed to prevent elements from modifying calculated properties by making them read-only. This is not working when the element references a sub object.

1. Create a calculated property called `object` and have it run javascript `return { foo: "bar" };`
2. Add a input element and name it `object.foo`
3. Go to preview

Expected behavior: The element is read only

Actual behavior: User can type in the element

## Solution
- Check if the first part of the elements name (up to the first `.` if any) matches the name of a computed property, and if so, make the element read-only;

## How to Test
Test the the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-4938
- Found while testing https://processmaker.atlassian.net/browse/FOUR-4915

## Code Review Checklist
- [X] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [X] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [X] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [X] This solution fixes the bug reported in the original ticket.
- [X] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [X] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [X] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [X] This ticket conforms to the PRD associated with this part of ProcessMaker.
