### PR TITLE
[FOUR-4913] Removed defaultValues from Advanced tab and added unselected option (4.2)

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -42,17 +42,17 @@
 
       <div class="row">
         <div class="col">
-					<div data-cy="unselected-container">
-						<div class="row border-top">
-							<div class="col-1"></div>
-							<div class="col-1 d-flex align-items-center">
-								<input type="radio" class="form-check" @click="defaultOptionClick($event)" name="defaultOptionGroup" v-model="defaultOptionKey" :value="''" data-cy="inspector-options-unselected">
-							</div>
-							<div class="col-6" style="cursor:grab">
-								{{ $t('Unselected') }}
-							</div>
-						</div>
-					</div>
+          <div data-cy="unselected-container">
+            <div class="row border-top">
+              <div class="col-1"/>
+              <div class="col-1 d-flex align-items-center">
+                <input type="radio" class="form-check" @click="defaultOptionClick($event)" name="defaultOptionGroup" v-model="defaultOptionKey" :value="''" data-cy="inspector-options-unselected">
+              </div>
+              <div class="col-6" style="cursor:grab">
+                {{ $t('Unselected') }}
+              </div>
+            </div>
+          </div>
           <draggable @update="updateSort" :element="'div'" v-model="optionsList" group="options" @start="drag=true" @end="drag=false" >
             <div v-for="(option, index) in optionsList" :key="option.value">
               <div v-if="removeIndex === index">
@@ -512,35 +512,35 @@ export default {
       this.jsonError = '';
     },
     defaultOptionClick(event) {
-			const {value} = event.target;
-			this.defaultOptionKey = value;
-			this.setDefaultValue();
-		},
-		setDefaultValue() {
-			if (this.valueTypeReturned === 'single') {
-				return this.selectedControl.config.defaultValue = {
-					mode: 'basic',
-					value: this.defaultOptionKey
-				};
-			}
-			// if the Unselected option was selected
-			if (this.valueTypeReturned === 'object' && this.defaultOptionKey === '') {
-				return this.selectedControl.config.defaultValue = {
-					mode: 'basic',
-					value: this.defaultOptionKey
-				}
-			}
-			if (this.valueTypeReturned === 'object' && this.defaultOptionKey !== '') {
-				this.optionsList.find(option => {
-					if (option.value === this.defaultOptionKey) {
-						return this.selectedControl.config.defaultValue = {
-							mode: 'js',
-							value: `return ${JSON.stringify(option)}`
-						}
-					}
-				});
-			}
-		},
+      const {value} = event.target;
+      this.defaultOptionKey = value;
+      this.setDefaultValue();
+    },
+    setDefaultValue() {
+      if (this.valueTypeReturned === 'single') {
+        return this.selectedControl.config.defaultValue = {
+          mode: 'basic',
+          value: this.defaultOptionKey,
+        };
+      }
+      // if the Unselected option was selected
+      if (this.valueTypeReturned === 'object' && this.defaultOptionKey === '') {
+        return this.selectedControl.config.defaultValue = {
+          mode: 'basic',
+          value: this.defaultOptionKey,
+        };
+      }
+      if (this.valueTypeReturned === 'object' && this.defaultOptionKey !== '') {
+        this.optionsList.find(option => {
+          if (option.value === this.defaultOptionKey) {
+            return this.selectedControl.config.defaultValue = {
+              mode: 'js',
+              value: `return ${JSON.stringify(option)}`,
+            };
+          }
+        });
+      }
+    },
     rowCss(index) {
       return index % 2 === 0 ? 'striped' : 'bg-default';
     },

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -42,6 +42,17 @@
 
       <div class="row">
         <div class="col">
+					<div data-cy="unselected-container">
+						<div class="row border-top">
+							<div class="col-1"></div>
+							<div class="col-1 d-flex align-items-center">
+								<input type="radio" class="form-check" @click="defaultOptionClick($event)" name="defaultOptionGroup" v-model="defaultOptionKey" :value="''" data-cy="inspector-options-unselected">
+							</div>
+							<div class="col-6" style="cursor:grab">
+								{{ $t('Unselected') }}
+							</div>
+						</div>
+					</div>
           <draggable @update="updateSort" :element="'div'" v-model="optionsList" group="options" @start="drag=true" @end="drag=false" >
             <div v-for="(option, index) in optionsList" :key="option.value">
               <div v-if="removeIndex === index">
@@ -87,12 +98,12 @@
                 </div>
               </div>
 
-              <div class="row border-top" :class="rowCss(index)">
+              <div class="row border-top" :class="rowCss(index)" :data-cy="'option-' + option[keyField].trim()">
                 <div class="col-1" style="cursor:grab">
                   <span class="fas fa-arrows-alt-v"/>
                 </div>
                 <div class="col-1 d-flex align-items-center">
-                  <input type="radio" class="form-check" @click="defaultOptionClick" name="defaultOptionGroup" v-model="defaultOptionKey" :value="option[keyField]">
+                  <input type="radio" class="form-check" @click="defaultOptionClick($event)" name="defaultOptionGroup" v-model="defaultOptionKey" :value="option[keyField]">
                 </div>
                 <div class="col-5" style="cursor:grab">
                   {{ option[valueField] }}
@@ -182,7 +193,7 @@
     </div>
 
     <label for="value-type-returned">{{ $t('Type of Value Returned') }}</label>
-    <b-form-select id="value-type-returded" v-model="valueTypeReturned" :options="returnValueOptions" data-cy="inspector-value-returned" />
+    <b-form-select id="value-type-returded" @change="setDefaultValue" v-model="valueTypeReturned" :options="returnValueOptions" data-cy="inspector-value-returned" />
     <small class="form-text text-muted mb-3">{{ $t("Select 'Single Value' to use parts of the selected object. Select 'Object' to use the entire selected value.") }}</small>
 
     <div v-if="dataSource === dataSourceValues.dataConnector">
@@ -428,8 +439,8 @@ export default {
     this.dataSource = this.options.dataSource;
     this.jsonData = this.options.jsonData;
     this.dataName = this.options.dataName;
-    this.selectedDataSource = this.options.selectedDataSource,
-    this.selectedEndPoint = this.options.selectedEndPoint,
+    this.selectedDataSource = this.options.selectedDataSource;
+    this.selectedEndPoint = this.options.selectedEndPoint;
     this.key = this.options.key;
     this.value = this.options.value;
     this.pmqlQuery = this.options.pmqlQuery;
@@ -478,7 +489,6 @@ export default {
         text: option['name'],
       };
     },
-
     jsonDataChange() {
       let jsonList = [];
       try {
@@ -501,11 +511,36 @@ export default {
       });
       this.jsonError = '';
     },
-    defaultOptionClick() {
-      if (this.defaultOptionKey === event.target.value) {
-        this.defaultOptionKey = false;
-      }
-    },
+    defaultOptionClick(event) {
+			const {value} = event.target;
+			this.defaultOptionKey = value;
+			this.setDefaultValue();
+		},
+		setDefaultValue() {
+			if (this.valueTypeReturned === 'single') {
+				return this.selectedControl.config.defaultValue = {
+					mode: 'basic',
+					value: this.defaultOptionKey
+				};
+			}
+			// if the Unselected option was selected
+			if (this.valueTypeReturned === 'object' && this.defaultOptionKey === '') {
+				return this.selectedControl.config.defaultValue = {
+					mode: 'basic',
+					value: this.defaultOptionKey
+				}
+			}
+			if (this.valueTypeReturned === 'object' && this.defaultOptionKey !== '') {
+				this.optionsList.find(option => {
+					if (option.value === this.defaultOptionKey) {
+						return this.selectedControl.config.defaultValue = {
+							mode: 'js',
+							value: `return ${JSON.stringify(option)}`
+						}
+					}
+				});
+			}
+		},
     rowCss(index) {
       return index % 2 === 0 ? 'striped' : 'bg-default';
     },

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -215,7 +215,6 @@ export default [
         },
         colorProperty,
         bgcolorProperty,
-        defaultValueProperty,
         readonlyProperty,
       ],
     },

--- a/tests/e2e/specs/SelectListDefaultOption.spec.js
+++ b/tests/e2e/specs/SelectListDefaultOption.spec.js
@@ -1,0 +1,86 @@
+describe('Select List with Default Option selected', () => {
+  before(() => {
+    cy.server();
+    cy.visit('/');
+  });
+  describe('Select List with unselected option', () => {
+    it('should add a select list', () => {
+      cy.get('[data-cy="controls-FormSelectList"]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    });
+    it('should select the recently added select list', () => {
+      cy.get('[data-cy="screen-element-container"]').click();
+    });
+    it('should NOT have the defaultValue input option', () => {
+      cy.get('[data-cy="accordion-Advanced"]').click();
+      cy.get('[data-cy="inspector-defaultValue"]').should('not.be.visible');
+    });
+    it('Select List options should have unselected', () => {
+      cy.get('[data-cy="accordion-DataSource"]').click();
+      cy.get('[data-cy="unselected-container"]').should('be.visible');
+    });
+  });
+  describe('Select List should create 2 options', () => {
+    it('should add 2 options', () => {
+      cy.get('[data-cy="inspector-add-option"]').click();
+      cy.get('[data-cy="inspector-option-value"]').type('true');
+      cy.get('[data-cy="inspector-option-content"]').type('True');
+      cy.get('[data-cy="inspector-option-save"]').click();
+      // Verify that the element was added successfully
+      cy.get('[data-cy="option-true"]').should('be.visible');
+
+      cy.get('[data-cy="inspector-add-option"]').click();
+      cy.get('[data-cy="inspector-option-value"]').type('false');
+      cy.get('[data-cy="inspector-option-content"]').type('False');
+      cy.get('[data-cy="inspector-option-save"]').click();
+      // Verify that the element was added successfully
+      cy.get('[data-cy="option-false"]').should('be.visible');
+    });
+  });
+  describe('Select List should set True as the default value', () => {
+    it('should select true as the default option', () => {
+      cy.get('[data-cy="option-true"] input').click();
+    });
+    it('should set the default value as true in preview mode', () => {
+      cy.get('[data-cy="mode-preview"]').click();
+      cy.get('[data-cy="screen-field-form_select_list_1"] .multiselect__single').contains('True');
+    });
+  });
+
+  describe('Select List should set False as the default value', () => {
+    it('should go back to design mode', () => {
+      cy.get('[data-cy="mode-editor"]').click();
+    });
+    it('should select true as the default option', () => {
+      cy.get('[data-cy="option-false"] input').click();
+    });
+    it('should set the default value as true in preview mode', () => {
+      cy.get('[data-cy="mode-preview"]').click();
+      cy.get('[data-cy="screen-field-form_select_list_1"] .multiselect__single').contains('False');
+    });
+  });
+
+  describe('Should change the data model of the defaultValue if the Type of Value Returned changes', () => {
+    it('should go back to design mode', () => {
+      cy.get('[data-cy="mode-editor"]').click();
+    });
+    it('should change the type of value returned from a single value to object', () => {
+      cy.get('[data-cy="inspector-value-returned"]').select('object');
+    });
+    it('should be defaultValue to be False', () => {
+      cy.get('[data-cy="mode-preview"]').click();
+      cy.get('[data-cy="screen-field-form_select_list_1"] .multiselect__single').contains('False');
+    });
+  });
+  describe('Should defaultValue to be false even if rolledback to single returned value', () => {
+    it('should go back to design mode', () => {
+      cy.get('[data-cy="mode-editor"]').click();
+    });
+    it('should change the type of value returned from a single value to object', () => {
+      cy.get('[data-cy="inspector-value-returned"]').select('single');
+    });
+    it('should be defaultValue to be False', () => {
+      cy.get('[data-cy="mode-preview"]').click();
+      cy.get('[data-cy="screen-field-form_select_list_1"] .multiselect__single').contains('False');
+    });
+  });
+});


### PR DESCRIPTION
Even though we removed the defaultValue from the advance tab, we had some functionality to set the defaultValues using radio buttons next to the options, which wasn't working previously but fixed those and added some e2e

End result:
![Screen Shot 2021-12-22 at 11 20 11 AM](https://user-images.githubusercontent.com/7969479/147125623-abd441ff-7e35-4fbf-9ec6-abe65861bde3.png)


### Things to test

- [ ] defaultValue box in advance tab shouldn't show
- [ ] radio buttons should set the default value
- [ ] Switching between returned value type should set the correct default value since the data model changes between
- [ ] E2E test is passing on my end but make sure that they are passing on your end