### PR TITLE
Improve render screen 4.2

### DIFF
--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -43,8 +43,7 @@ export default {
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
     this.component = this.buildComponent(this.currentDefinition);
-    // debounce rebuildScreen
-    this.rebuildScreen = debounce(this.rebuildScreen, 300);
+    this.rebuildScreen = debounce(this.rebuildScreen, 25);
   },
   watch: {
     definition: {

--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -26,7 +26,7 @@ import Json2Vue from '../mixins/Json2Vue';
 import CurrentPageProperty from '../mixins/CurrentPageProperty';
 import WatchersSynchronous from '@/components/watchers-synchronous';
 import ScreenRendererError from '../components/renderer/screen-renderer-error';
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep, isEqual, debounce } from 'lodash';
 
 export default {
   name: 'screen-renderer',
@@ -43,19 +43,24 @@ export default {
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
     this.component = this.buildComponent(this.currentDefinition);
+    // debounce rebuildScreen
+    this.rebuildScreen = debounce(this.rebuildScreen, 300);
   },
   watch: {
     definition: {
       deep: true,
       handler(definition) {
-        if (!isEqual(definition, this.currentDefinition)) {
-          this.currentDefinition = cloneDeep(definition);
-          this.component = this.buildComponent(this.currentDefinition);
-        }
+        this.rebuildScreen(definition);
       },
     },
   },
   methods: {
+    rebuildScreen(definition) {
+      if (!isEqual(definition, this.currentDefinition)) {
+        this.currentDefinition = cloneDeep(definition);
+        this.component = this.buildComponent(this.currentDefinition);
+      }
+    },
     onAsyncWatcherOn() {
       this.displayAsyncLoading = typeof this._parent === 'undefined';
     },

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -367,7 +367,7 @@ export default {
           }
         });
       };
-      updateValidationRules = debounce(updateValidationRules, 100);
+      updateValidationRules = debounce(updateValidationRules, 25);
       component.methods.loadValidationRules = function() {
         // Asynchronous loading of validations
         const validations = {};

--- a/tests/e2e/specs/NestedCalcRadioFreeze.spec.js
+++ b/tests/e2e/specs/NestedCalcRadioFreeze.spec.js
@@ -10,6 +10,8 @@ describe('nested calc radio freeze', () => {
     cy.get('[data-cy=mode-preview]').click();
 
     cy.get('[data-cy=preview-content] button:contains(Continue)').click();
+    // Wait until you load the screen
+    cy.wait(500);
 
     // Check the data of the screen
     cy.assertPreviewData({


### PR DESCRIPTION
Fix: https://processmaker.atlassian.net/browse/FOUR-4925

## Issue
- Since validation rules object contains Function, isEqual do not check properly if validations have changed
- Visibility rules could trigger multiple times at once the re-render of the screen
- Some nested screens are loaded 

## Fix
- Improve the comparition of validation rules
- Add a debounce to re-render screen function
- Requires https://github.com/ProcessMaker/screen-builder/pull/1130 to cache properly the screens

## How to test

- Import the attached process
- Open the main screen in preview or Run the process
- Navigate through the tabs, some of them take time to render

Attached files:

[Test Performance Process.zip](https://github.com/ProcessMaker/screen-builder/files/7764303/Test.Performance.Process.zip)
