### PR TITLE
Improve render screen 4.1

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -85,10 +85,14 @@ export default {
     }
     else {
       const endpoint = _.get(window, 'PM4ConfigOverrides.getScreenEndpoint', '/screens');
-      const request = this.get(endpoint + `/${id}${query}`);
+      
+      const screensCacheHit = this.screensCache.find(screen => screen.id == id);
+      if (screensCacheHit) {
+        return Promise.resolve({data: screensCacheHit});
+      }
 
       let screenPromise = new Promise((resolve, reject) => {
-        request
+        this.get(endpoint + `/${id}${query}`)
           .then(response => {
             if (response.data.nested) {
               this.addNestedScreenCache(response.data.nested);

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export default {
   screensCache: [],
+  cachedScreenPromises: [],
 
   install(Vue) {
     Vue.prototype.$dataProvider = this;
@@ -77,23 +78,28 @@ export default {
       }
     });
   },
-  getScreen(id, query = '') {
-    const endpoint = _.get(window, 'PM4ConfigOverrides.getScreenEndpoint', '/screens');
-    return new Promise((resolve, reject) => {
-      const cache = this.screensCache.find(screen => screen.id == id);
-      if (cache) {
-        resolve({data: cache});
-      }
-      if (!cache && id != undefined) {
-        const request = this.get(endpoint + `/${id}${query}`);
-        request.then(response => {
-          if (response.data.nested) {
-            this.addNestedScreenCache(response.data.nested);
-          }
-          resolve(response);
-        }).catch(response => reject(response));
-      }
-    });
+  getScreen(id, query='') {
+    let cachedPromise = this.cachedScreenPromises.find(item => item.id === id && item.query === query);
+    if (cachedPromise) {
+      return cachedPromise.screenPromise;
+    }
+    else {
+      const endpoint = _.get(window, 'PM4ConfigOverrides.getScreenEndpoint', '/screens');
+      const request = this.get(endpoint + `/${id}${query}`);
+
+      let screenPromise = new Promise((resolve, reject) => {
+        request
+          .then(response => {
+            if (response.data.nested) {
+              this.addNestedScreenCache(response.data.nested);
+            }
+            resolve(response);
+          })
+          .catch(response => reject(response));
+      });
+      this.cachedScreenPromises.push({id, query, screenPromise});
+      return screenPromise;
+    }
   },
 
   postScript(id, params) {

--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -11,7 +11,7 @@ import Json2Vue from '../mixins/Json2Vue';
 import CurrentPageProperty from '../mixins/CurrentPageProperty';
 import WatchersSynchronous from '@/components/watchers-synchronous';
 import ScreenRendererError from '../components/renderer/screen-renderer-error';
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep, isEqual, debounce } from 'lodash';
 
 export default {
   name: 'screen-renderer',
@@ -27,19 +27,30 @@ export default {
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
     this.component = this.buildComponent(this.currentDefinition);
+    // debounce rebuildScreen
+    this.rebuildScreen = debounce(this.rebuildScreen, 300);
   },
   watch: {
     definition: {
       deep: true,
       handler(definition) {
-        if (!isEqual(definition, this.currentDefinition)) {
-          this.currentDefinition = cloneDeep(definition);
-          this.component = this.buildComponent(this.currentDefinition);
-        }
+        this.rebuildScreen(definition);
       },
     },
   },
   methods: {
+    rebuildScreen(definition) {
+      if (!isEqual(definition, this.currentDefinition)) {
+        this.currentDefinition = cloneDeep(definition);
+        this.component = this.buildComponent(this.currentDefinition);
+      }
+    },
+    onAsyncWatcherOn() {
+      this.displayAsyncLoading = typeof this._parent === 'undefined';
+    },
+    onAsyncWatcherOff() {
+      this.displayAsyncLoading = false;
+    },
     getCurrentPage() {
       return this.$refs.component.getCurrentPage();
     },

--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -27,8 +27,7 @@ export default {
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
     this.component = this.buildComponent(this.currentDefinition);
-    // debounce rebuildScreen
-    this.rebuildScreen = debounce(this.rebuildScreen, 300);
+    this.rebuildScreen = debounce(this.rebuildScreen, 25);
   },
   watch: {
     definition: {

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -2,7 +2,7 @@ import extensions from './extensions';
 import ScreenBase from './ScreenBase';
 import CountElements from '../CountElements';
 import ValidationsFactory from '../ValidationsFactory';
-import _ from 'lodash';
+import _, { debounce, isEqual } from 'lodash';
 
 let screenRenderer;
 
@@ -322,19 +322,43 @@ export default {
     },
     addValidationRulesLoader(component, definition) {
       const firstPage = parseInt(this.currentPage) || 0;
+      function getKeys(input) {
+        if (input instanceof Array) {
+          const response = [];
+          input.forEach((item) => {
+            response.push(getKeys(item));
+          });
+          return response;
+        }
+        if (!(input instanceof Object)) {
+          return typeof input;
+        }
+        const keys = Object.keys(input);
+        const response = {};
+        keys.forEach((key) => {
+          response[key] = getKeys(input[key]);
+        });
+        return response;
+      }
+      let updateValidationRules = function(screenComponent, validations) {
+        const a = getKeys(screenComponent.ValidationRules__);
+        const b = getKeys(validations);
+        if (isEqual(a, b)) {
+          return;
+        }
+        screenComponent.ValidationRules__ = validations;
+        screenComponent.$nextTick(() => {
+          if (screenComponent.$v) {
+            screenComponent.$v.$touch();
+          }
+        });
+      };
+      updateValidationRules = debounce(updateValidationRules, 100);
       component.methods.loadValidationRules = function() {
         // Asynchronous loading of validations
         const validations = {};
         ValidationsFactory(definition, { screen: definition, firstPage, data: {_parent: this._parent, ...this.vdata} }).addValidations(validations).then(() => {
-          if (_.isEqual(this.ValidationRules__, validations)) {
-            return;
-          }
-          this.ValidationRules__ = validations;
-          this.$nextTick(() => {
-            if (this.$v) {
-              this.$v.$touch();
-            }
-          });
+          updateValidationRules(this, validations);
         });
       };
       component.mounted.push('this.loadValidationRules()');

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -353,7 +353,7 @@ export default {
           }
         });
       };
-      updateValidationRules = debounce(updateValidationRules, 100);
+      updateValidationRules = debounce(updateValidationRules, 25);
       component.methods.loadValidationRules = function() {
         // Asynchronous loading of validations
         const validations = {};

--- a/tests/e2e/specs/NestedCalcRadioFreeze.spec.js
+++ b/tests/e2e/specs/NestedCalcRadioFreeze.spec.js
@@ -10,6 +10,8 @@ describe('nested calc radio freeze', () => {
     cy.get('[data-cy=mode-preview]').click();
 
     cy.get('[data-cy=preview-content] button:contains(Continue)').click();
+    // Wait until you load the screen
+    cy.wait(500);
 
     // Check the data of the screen
     cy.assertPreviewData({


### PR DESCRIPTION
Fix: https://processmaker.atlassian.net/browse/FOUR-4925

## Issue
- Since validation rules object contains Function, isEqual do not check properly if validations have changed
- Visibility rules could trigger multiple times at once the re-render of the screen
- Some nested screens are loaded 

## Fix
- Improve the comparition of validation rules
- Add a debounce to re-render screen function
- Include https://github.com/ProcessMaker/screen-builder/pull/1130 to cache properly the screens

## How to test

- Import the attached process
- Open the main screen in preview or Run the process
- Navigate through the tabs, some of them take time to render

Attached files:

[Test Performance Process.zip](https://github.com/ProcessMaker/screen-builder/files/7764303/Test.Performance.Process.zip)
