### PR TITLE
Bugfix/FOUR-4953: Console error, when I click on a created text area (FOR 4.1)

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -57,8 +57,8 @@
             </div>
           </b-card-header>
           <b-collapse :id="formatRuleContentAsId(rule.content)" :accordion="formatRuleContentAsId(rule.content)" :visible="rule.visible" role="tabpanel">
-            <b-card-body> 
-              <div class="p-2"> 
+            <b-card-body>
+              <div class="p-2">
                 <div v-for="config in rule.configs" :key="config.label" class="mb-2">
                   <div v-if="config.type === 'FormInput'">
                     <form-input :label="config.label" :name="config.name || config.label" v-model="config.value" :validation="config.validation" :helper="config.helper"/>
@@ -294,7 +294,7 @@ export default {
       if (this.rules && this.rules.length) {
         return true;
       }
-      
+
       return false;
     },
   },
@@ -314,9 +314,8 @@ export default {
       },
     },
     value() {
-      this.rules = this.value;
+      this.rules = this.value || [];
       this.cloneSetRules();
-      
     },
     selectedOption: {
       deep: true,
@@ -380,13 +379,13 @@ export default {
             }
           });
 
-          if (ruleConfigs.length > 1) {  
+          if (ruleConfigs.length > 1) {
             ruleConfigs = ruleConfigs.join(',');
           }
           if (ruleConfigs.length) {
             rule.value = rule.field + ruleConfigs;
           }
-          
+
         }
       });
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
A console error shows when you add a text area and immediately add another and select the unselected textarea
- Create a screen
- Add a textarea 
- Immediately add a second textarea
- Click on the other text area
- You will see an error in console

## Solution
- If value is undefined set an empty array

## How to Test
- Create a screen
- Add a textarea 
- Immediately add a second textarea
- Click on the other text area
- You will NOT see an error in console

**Working video**

https://user-images.githubusercontent.com/90727999/147284978-6da4e724-3cac-4b5c-9052-d313c1907e01.mov


## Related Tickets & Packages
- [FOUR-4953](https://processmaker.atlassian.net/browse/FOUR-4953)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
