### PR TITLE
Do not reset default values on nested objects after a data has changed

### DIFF
--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -35,7 +35,11 @@ export default {
         get: new Function(`return this.tryFormField(${JSON.stringify(name)}, () => ${value});`),
         set() {},
       };
-      this.addWatch(screen, defaultComputedName, `!this.${name}_was_filled__ && this.setValue(${JSON.stringify(name)}, this.${defaultComputedName}, this.vdata, this);`);
+
+      // Do not reset default values on nested objects after a data has changed
+      const watchOptions = { deep: false };
+
+      this.addWatch(screen, defaultComputedName, `!this.${name}_was_filled__ && this.setValue(${JSON.stringify(name)}, this.${defaultComputedName}, this.vdata, this);`, watchOptions);
     },
   },
   mounted() {


### PR DESCRIPTION
## Issue & Reproduction Steps

This appears to be an order of operations issue. The logic that sets the default value is running after the the data is updated. This is somewhat expected since some default values rely on (using mustache syntax) other values in the data that could change.

Steps to reproduce:

1. Create a watcher or select list that uses a data source or a script that sets a variable with nested data: `{ output: { foo: 'bar'} }`
1. Create a form input and set the variable name to output.foo
1. Add a default value to the input field: abc
1. Preview and activate the watcher
1. Expected result: output.foo input field changes to bar
1. Actual result: output.foo input field does not change, stays abc

## Solution

Instead of re-ordering the methods that change the data, or skipping the default value setting logic if it follows a watcher, the simplest solution is for the default value logic to not watch for data changes on nested objects to begin with (deep = false). This will allow default values to continue to operate as expected but only on the value they are directly referencing.

Current (broken) order of operations:

1. The input element sets the screen data to it’s default value on load: `{ output: { foo: 'abc' } }`
1. A watcher runs and sets the data to `{ output: { foo: 'bar'} }`
1. The default values watcher notices that 1output.foo1 has changed
1. It checks if the value has been modified by the end user and if it has not (and it hasn’t in this case) it re-runs the default value setter, so the data becomes `{ output: { foo: 'abc'} }` once again

This fix: set the default values watcher option to deep: false

1. The input element sets the screen data to the it’s default value on load: `{ output: { foo: 'abc' } }`
1. A watcher runs and sets the data to `{ output: { foo: 'bar'} }`
1. The default values watcher does not notice the change.
1. The data is unchanged and the value in the input correctly updates to `bar`

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-4973

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
