### PR TITLE
Prevent referencing array index in variable name

### DIFF
--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -95,7 +95,8 @@ export const keyNameProperty = {
   config: {
     label: 'Variable Name',
     name: 'Variable Name',
-    validation: 'regex:/^(?:[A-Za-z])(?:[0-9A-Z_a-z])*(?:\\.[0-9A-Z_a-z]+)*$/|required|not_in:' + javascriptReservedKeywords,
+    // Update tests/e2e/specs/Builder.spec.js when changing this
+    validation: 'regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:' + javascriptReservedKeywords,
     helper: 'A variable name is a symbolic name to reference information.',
   },
 };

--- a/tests/e2e/specs/Builder.spec.js
+++ b/tests/e2e/specs/Builder.spec.js
@@ -36,4 +36,40 @@ describe('Screen Builder', () => {
       form_input_1: '',
     });
   });
+
+  it('Validates variable names', () => {
+    cy.get('[data-cy=screen-element-container]').eq(0).click();
+    
+    // Valid variable names
+    [
+      'A',
+      'aaa',
+      'aaa.bbb',
+      'aaa.BBB.ccc',
+      'aaa1',
+      'aaa_abc.abc_1',
+      'aaa1.bbb1',
+    ].forEach(name => {
+      cy.get('[data-cy=inspector-name]').clear().type(name);
+      cy.get('[data-cy=inspector-name]').should('not.have.class', 'is-invalid');
+    });
+    
+    // Invalid variable names
+    [
+      '1',
+      '1.aaa',
+      'aaa.0',
+      'aaa.',
+      'aaa.bbb.',
+      'aaa._',
+      'aaa._.ccc',
+      'aaa..ccc',
+      'aaa.123.ccc',
+      'aaa.1.ccc',
+    ].forEach(name => {
+      cy.get('[data-cy=inspector-name]').clear().type(name);
+      cy.get('[data-cy=inspector-name]').should('have.class', 'is-invalid');
+    });
+
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-4972

## Solution
Instead of supporting array indexes in variable names, update the regex to prevent referencing them.

## How to Test
Add an input with a variable name that references an array index like `aaa.0.bbb`. The variable should be invalid.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-4972

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
