### PR TITLE
Add error type field

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -5,7 +5,6 @@
 </template>
 
 <script>
-import Mustache from 'mustache';
 import { getValidPath } from '@/mixins';
 
 export default {
@@ -18,45 +17,6 @@ export default {
         btn: true,
         ['btn-' + variant]: true,
       };
-    },
-    options() {
-      if (!this.tooltip || this.event === 'submit') {
-        return {};
-      }
-
-      let content = '';
-      try {
-        content = Mustache.render(this.tooltip.content || '', this.transientData);
-      } catch (error) { error; }
-
-      return {
-        title: content,
-        html: true,
-        placement: this.tooltip.position || '',
-        trigger: 'hover',
-        variant: this.tooltip.variant || '',
-        boundary: 'window',
-      };
-    },
-    valid() {
-      if (this.$attrs.validate) {
-        return !this.$attrs.validate.$invalid;
-      }
-      return true;
-    },
-    message() {
-      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-      this.errors = 0;
-      if (!this.valid) {
-        this.countErrors(this.$attrs.validate.vdata);
-        this.countErrors(this.$attrs.validate.schema);
-        let message = 'There are {{items}} validation errors in your form.';
-        if (this.errors === 1) {
-          message = 'There is a validation error in your form.';
-        }
-        return this.$t(message, {items: this.errors});
-      }
-      return '';
     },
   },
   data() {

--- a/src/mixins/ValidationRules.js
+++ b/src/mixins/ValidationRules.js
@@ -21,6 +21,7 @@ import {
   not,
   or,
   and,
+  type,
 } from 'vuelidate/lib/validators';
 
 export const ValidationMsg = {
@@ -55,6 +56,7 @@ export const ValidationMsg = {
   invalid_default_value: 'Invalid default value',
   customDate: 'Must be a valid Date',
   regex: 'Invalid value',
+  type: 'Invalid type.',
 };
 
 export const custom_date = (date) => {
@@ -225,4 +227,5 @@ export const validators = {
   notIn,
   regex,
   afterOrEqual: after_or_equal,
+  type,
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

- create a screen with a field with text type validation.
- create a vocabulary with an integer validation field.
- add everything to a process.
- run the process, no error messages are displayed.

Expected behavior: display errors of form

Actual behavior: 

## Solution
- add messages in form
- add message error type field

## How to Test

https://user-images.githubusercontent.com/1747025/148108471-6fdb1080-d5a7-4b1e-bb1e-0f8da22f41fc.mp4



## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
