### PR TITLE
Bugfix/FOUR-4950: e2e tests for Field Date picker does not correctly validate the minimum date (For 4.1)

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -49,4 +49,104 @@ describe('Date Picker', () => {
       form_date_picker_1: today.toISOString(),
     });
   });
+
+  it('Date picker with minDate less than first datepicker should return null data', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateBefore = moment(new Date()).subtract(1, 'days').format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateBefore);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] [data-action="close"]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).format('YYYY-MM-DD'),
+      form_date_picker_2: null,
+    });
+  });
+
+  it('Date picker with minDate equal than first datepicker should return the current date', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateSame = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateSame);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] [data-action="close"]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).format('YYYY-MM-DD'),
+      form_date_picker_2: moment(dateSame).format('YYYY-MM-DD'),
+    });
+  });
+
+  it('Date time picker with minDate less than first datepicker should return null data', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateBefore = moment(new Date()).subtract(1, 'days').format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateBefore);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] [data-action="close"]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).toISOString(),
+      form_date_picker_2: null,
+    });
+  });
+
+  it('Date time picker with minDate equal than first datepicker should return the current date', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateSame = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateSame);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] [data-action="close"]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).toISOString(),
+      form_date_picker_2: moment(dateSame).toISOString(),
+    });
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
Reproduction steps
- Create a screen with 2 datepickers (date1 and date2)
- In date2 in Configuration section, add {{date1}} in Minimum Date field.
- Go to preview and select a date in date1
- Date2 will set the minimum date to the selected date - 1

## Solution
Removed timeZone in config. 

## How to Test
- Create a screen with 2 datepickers (date1 and date2)
- In date2 in Configuration section, add {{date1}} in Minimum Date field.
- Go to preview and select a date in date1
- Date2 will set the minimum date to the selected date

**Working video**

https://user-images.githubusercontent.com/90727999/148285428-d2efd318-5ad4-49e7-a1de-4137f84c6202.mov


## Related Tickets & Packages
- [FOUR-4950](https://processmaker.atlassian.net/browse/FOUR-4950)
- [PR vue-form-elements](https://github.com/ProcessMaker/vue-form-elements/pull/325)