### PR TITLE
Bugfix/FOUR-4986: The fileUpload control inside a loop in the record list, is duplicating itself with the second item of the loop (For 4.2)

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -192,10 +192,10 @@ export default {
       if (!this.value) {
         return;
       }
-
+      let index = (Array.isArray(this.value) ? this.value[0].file : this.value);
       let requestFiles = _.get(
         window,
-        `PM4ConfigOverrides.requestFiles["${this.value[0].file}"]`,
+        `PM4ConfigOverrides.requestFiles["${index}"]`,
         []
       );
 

--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -195,7 +195,7 @@ export default {
 
       let requestFiles = _.get(
         window,
-        `PM4ConfigOverrides.requestFiles["${this.fileDataName}"]`,
+        `PM4ConfigOverrides.requestFiles["${this.value[0].file}"]`,
         []
       );
 

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -125,7 +125,8 @@ export default {
       if (!this.value) {
         return [];
       }
-      return _.get(window, `PM4ConfigOverrides.requestFiles["${this.value[0].file}"]`, []).filter(file => {
+      let index = (Array.isArray(this.value) ? this.value[0].file : this.value);
+      return _.get(window, `PM4ConfigOverrides.requestFiles["${index}"]`, []).filter(file => {
         // Filter any requestFiles that don't exist in this component's value. This can happen if
         // a file is uploaded but the task is not saved.
         if (this.multipleUpload) {

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -175,6 +175,7 @@ export default {
       perPageSelectEnabled: false,
       perPage: 5,
       lastPage: 1,
+      currentRowId: null,
       css: {
         tableClass: 'table table-hover table-responsive text-break mb-0 d-table',
         loadingClass: 'loading',
@@ -191,6 +192,9 @@ export default {
       },
       initFormValues: {},
     };
+  },
+  mounted() {
+    this.$root.$on('get-current-row-id', () => this.getCurrentRowId());
   },
   computed: {
     popupConfig() {
@@ -259,6 +263,9 @@ export default {
     },
   },
   methods: {
+    getCurrentRowId() {
+      this.$root.$emit('current-row-id', this.currentRowId);
+    },
     formatIfDate(string) {
       return dateUtils.formatIfDate(string);
     },
@@ -280,6 +287,7 @@ export default {
         }
       }
 
+      this.currentRowId = rowId;
       this.$root.$emit('set-upload-data-name', this, index, rowId);
     },
     getTableFieldsFromDataSource() {


### PR DESCRIPTION
## Issue & Reproduction Steps
There were a lot of issue related with this:
- File uploads inside recordlist were not showing the correct name of files inside a loop when adding more than one file
- File download for a fileupload inside recordlist were not allowing to download files and displaying they names
- If you uploaded some files in a record list row and after that tried to add another row with more files, some files were deleted.

Reproduction Steps
- Import the following process 
[26955 (1).json.zip](https://github.com/ProcessMaker/screen-builder/files/7862708/26955.1.json.zip)
- Run a new request
- Add a new record in the record list control
- Add document on the loop control
- Add another loop and upload another document
- Repeat step 3 - 4 - 5
- Submit the task  or  click on edit  to  record list 
- The documents uploaded are not correct or are repeated or are simply be deleted.

## Solution
- Added unique file ID as index for requestFiles variable
- Fixed rowID that was sent as null for files inside a loop in recordlist (this fixes the files deleting)
- Retrieve files mapped with file id index and grouped by first file ID of each group, this fixes the download option.

## How to Test
Test the steps above (Watch working video)

**Working video**

https://user-images.githubusercontent.com/90727999/149571039-103526d5-b5d3-4a67-baf3-2ae559180c7f.mov


## Related Tickets & Packages
- [FOUR-4986](https://processmaker.atlassian.net/browse/FOUR-4986)
- [Processmaker core PR](https://github.com/ProcessMaker/processmaker/pull/4244)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
