### PR TITLE
Fix Loop running validations on hidden fields

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -221,17 +221,17 @@ class FormElementValidations extends Validations {
   camelCase(name) {
     return name.replace(/_\w/g, m => m.substr(1, 1).toUpperCase());
   }
-}
 
-function checkVisibilityRule(conditionalHide, data) {
-  if (conditionalHide) {
-    let visible = true;
-    try {
-      visible = !!Parser.evaluate(conditionalHide, data);
-    } catch (error) {
-      visible = false;
+  checkVisibilityRule(conditionalHide, data) {
+    if (conditionalHide) {
+      let visible = true;
+      try {
+        visible = !!Parser.evaluate(conditionalHide, data);
+      } catch (error) {
+        visible = false;
+      }
+      return visible;
     }
-    return visible;
   }
 }
 function ValidationsFactory(element, options) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -192,7 +192,15 @@ class FormElementValidations extends Validations {
           validationFn = validationFn(...params);
         }
         fieldValidation[rule] = function(...props) {
-          const visible = this.checkVisibilityRule(conditionalHide, props[1]);
+          const data = props[1];
+          let visible = true;
+          if (conditionalHide) {
+            try {
+              visibile = !!Parser.evaluate(conditionalHide, data);
+            } catch (error) {
+              visible = false;
+            }
+          }
           if (!visible) {
             return true;
           }
@@ -207,7 +215,15 @@ class FormElementValidations extends Validations {
         return;
       }
       fieldValidation[validationConfig] = function(...props) {
-        const visible = this.checkVisibilityRule(conditionalHide, props[1]);
+        const data = props[1];
+        let visible = true;
+        if (conditionalHide) {
+          try {
+            visibile = !!Parser.evaluate(conditionalHide, data);
+          } catch (error) {
+            visible = false;
+          }
+        }
         if (!visible) {
           return true;
         }
@@ -220,18 +236,6 @@ class FormElementValidations extends Validations {
   }
   camelCase(name) {
     return name.replace(/_\w/g, m => m.substr(1, 1).toUpperCase());
-  }
-
-  checkVisibilityRule(conditionalHide, data) {
-    if (conditionalHide) {
-      let visible = true;
-      try {
-        visible = !!Parser.evaluate(conditionalHide, data);
-      } catch (error) {
-        visible = false;
-      }
-      return visible;
-    }
   }
 }
 function ValidationsFactory(element, options) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -193,10 +193,11 @@ class FormElementValidations extends Validations {
         }
         fieldValidation[rule] = function(...props) {
           const data = props[1];
+          const dataWithParent = this.addReferenceToParents(data);
           let visible = true;
           if (conditionalHide) {
             try {
-              visibile = !!Parser.evaluate(conditionalHide, data);
+              visible = !!Parser.evaluate(conditionalHide, dataWithParent);
             } catch (error) {
               visible = false;
             }
@@ -216,10 +217,11 @@ class FormElementValidations extends Validations {
       }
       fieldValidation[validationConfig] = function(...props) {
         const data = props[1];
+        const dataWithParent = this.addReferenceToParents(data);
         let visible = true;
         if (conditionalHide) {
           try {
-            visibile = !!Parser.evaluate(conditionalHide, data);
+            visible = !!Parser.evaluate(conditionalHide, dataWithParent);
           } catch (error) {
             visible = false;
           }

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -231,6 +231,7 @@ function checkVisibilityRule(conditionalHide, data) {
     } catch (error) {
       visible = false;
     }
+    return visible;
   }
 }
 function ValidationsFactory(element, options) {

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -53,4 +53,42 @@ describe('Loop control', () => {
       ],
     });
   });
+
+  it('Run validation only on visible fields', () => {
+    cy.visit('/');
+    // Add loop control
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]');
+    cy.get('[data-cy=inspector-source]').select('existing');
+
+     // Add input to loop
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
+
+    // Configure Validation rule
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-label]').click().clear().type('New Input 2');
+    cy.get('[data-cy=add-rule]').click();
+    cy.get('[data-cy=select-rule]').click().type('Required{enter}{esc');
+    cy.get('[data-cy=save-rule]').click();
+
+    // Set Visibility rule
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
+
+    // Add submit button
+    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+
+    cy.setPreviewDataInput('{"loop_1":[{"name": "foo"}]}');
+
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_input_2]').should('be.not.visible');
+
+    //submit form valid
+    cy.get('[data-cy=preview-content] [name="Default"] > :nth-child(1) > .form-group > .btn').click();
+    cy.on('window:alert', (str) => {
+      expect(str).to.equal('Preview Form was Submitted');
+    });
+  });
 });

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -62,7 +62,7 @@ describe('Loop control', () => {
     cy.get('[data-cy=inspector-name]');
     cy.get('[data-cy=inspector-source]').select('existing');
 
-     // Add input to loop
+    // Add input to loop
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-5076](https://processmaker.atlassian.net/browse/FOUR-5076)

Hidden fields with validations in loops are being validated, preventing form submission.

<h2>To Reproduce:</h2>

 1. Create a screen
 2. Add loop with the next configuration:
 3. Data source: Existing Array
 4. Variable Name: accounts
 5. Add line input 
 6. Add validation between Min-Max
 7. Add visibility rule: product  != "dos" ; in such a way that one records are visible and others are not 
 8. Press the preview button
 9. Populate the accounts loops with the next data

```
{
	"accounts": [
		{
			"product": "uno",
			"initialDeposit": 0
		},
		{
			"product": "dos"
		}
	]
}
```

 10. Fill the data with validations
 11. Press submit button

Expected behavior: 

The form submits with no errors.

Actual behavior: 

The form does not submit due to validations running on the hidden fields.

## Solution

Before setting the validation on the field, check if the field is visible. If the field is not visible skip setting the validation. 

## How to Test
Use the above reproductions steps to test manually. 

Run the Loop.spec.js test locally.

## Related Tickets & Packages

4.2 Fix - https://github.com/ProcessMaker/screen-builder/pull/1160

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
