### PR TITLE
[4.1] a record cannot be added to the Record List, if the screen has a vocabulary

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -382,7 +382,7 @@ export default {
     handleOk(bvModalEvt) {
       bvModalEvt.preventDefault();
 
-      if (this.$refs.addRenderer.$refs.renderer.$refs.component.$v.$invalid) {
+      if (this.$refs.addRenderer.$refs.renderer.$refs.component.$v.vdata.$invalid) {
         return;
       }
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- create a screen with recordlist
- add a vocabulary
- add new register to recordlist
- does not allow adding new records to the record list.
Expected behavior: 
- allow adding new records to the record list.

Actual behavior: 
does not allow adding new records to the record list.
## Solution
- validation only vdata in recordlist

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-5176](https://processmaker.atlassian.net/browse/FOUR-5176)



https://user-images.githubusercontent.com/1747025/150209455-b241ee3e-82dd-4bfd-8f63-a2b9cf93dc63.mp4


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
