### PR TITLE
Bugfix/FOUR-5103: Using the sort option in a record list, doesn't update the records when using the edit action

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -263,15 +263,6 @@ export default {
       return this.form && this.form === this.$parent.currentPage;
     },
   },
-  watch: {
-    'tableData.total': {
-      deep: true,
-      handler(total) {
-        let totalPages = Math.ceil(total / this.perPage);
-        this.currentPage = (this.currentPage > totalPages ? totalPages : this.currentPage);
-      },
-    },
-  },
   methods: {
     sortChanged(payload) {
       this.lastSortConfig = payload;

--- a/tests/e2e/fixtures/record_list_single_input.json
+++ b/tests/e2e/fixtures/record_list_single_input.json
@@ -1,0 +1,779 @@
+{
+    "type": "screen_package",
+    "version": "2",
+    "screens": [
+        {
+            "id": 418,
+            "screen_category_id": "2",
+            "title": "Record List Single",
+            "description": "Record List Single",
+            "type": "FORM",
+            "config": [
+                {
+                    "name": "Record List Single",
+                    "items": [
+                        {
+                            "label": "Record List",
+                            "config": {
+                                "form": "1",
+                                "icon": "fas fa-th-list",
+                                "name": "form_record_list_1",
+                                "label": "New Record List",
+                                "fields": {
+                                    "jsonData": "[{\"content\":\"name\",\"value\":\"name\"}]",
+                                    "editIndex": null,
+                                    "dataSource": "provideData",
+                                    "optionsList": [
+                                        {
+                                            "value": "name",
+                                            "content": "name"
+                                        }
+                                    ],
+                                    "removeIndex": null,
+                                    "showJsonEditor": false,
+                                    "showOptionCard": false,
+                                    "showRemoveWarning": false
+                                },
+                                "editable": true
+                            },
+                            "component": "FormRecordList",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "List Label",
+                                        "helper": "The label describes this record list"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "editable",
+                                    "config": {
+                                        "label": "Editable?",
+                                        "helper": "Should records be editable/removable and can new records be added"
+                                    }
+                                },
+                                {
+                                    "type": "ColumnSetup",
+                                    "field": "fields",
+                                    "config": {
+                                        "label": "Columns",
+                                        "helper": "List of columns to display in the record list"
+                                    }
+                                },
+                                {
+                                    "type": "PageSelect",
+                                    "field": "form",
+                                    "config": {
+                                        "label": "Record Form",
+                                        "helper": "The form to use for adding/editing records"
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormRecordList",
+                            "editor-component": "FormText"
+                        },
+                        {
+                            "label": "Submit Button",
+                            "config": {
+                                "icon": "fas fa-share-square",
+                                "name": null,
+                                "event": "submit",
+                                "label": "New Submit",
+                                "tooltip": [],
+                                "variant": "primary",
+                                "fieldValue": null,
+                                "defaultSubmit": true
+                            },
+                            "component": "FormButton",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the button's text"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$/|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "event",
+                                    "config": {
+                                        "label": "Type",
+                                        "helper": "Choose whether the button should submit the form",
+                                        "options": [
+                                            {
+                                                "value": "submit",
+                                                "content": "Submit Button"
+                                            },
+                                            {
+                                                "value": "script",
+                                                "content": "Regular Button"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "props": [
+                                            "label",
+                                            "value",
+                                            "helper"
+                                        ],
+                                        "watch": {
+                                            "value": {
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "inheritAttrs": false,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "tooltip",
+                                    "config": {
+                                        "label": "Tooltip"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "fieldValue",
+                                    "config": {
+                                        "label": "Value",
+                                        "helper": "The value being submitted"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "variant",
+                                    "config": {
+                                        "label": "Button Variant Style",
+                                        "helper": "The variant determines the appearance of the button",
+                                        "options": [
+                                            {
+                                                "value": "primary",
+                                                "content": "Primary"
+                                            },
+                                            {
+                                                "value": "secondary",
+                                                "content": "Secondary"
+                                            },
+                                            {
+                                                "value": "success",
+                                                "content": "Success"
+                                            },
+                                            {
+                                                "value": "danger",
+                                                "content": "Danger"
+                                            },
+                                            {
+                                                "value": "warning",
+                                                "content": "Warning"
+                                            },
+                                            {
+                                                "value": "info",
+                                                "content": "Info"
+                                            },
+                                            {
+                                                "value": "light",
+                                                "content": "Light"
+                                            },
+                                            {
+                                                "value": "dark",
+                                                "content": "Dark"
+                                            },
+                                            {
+                                                "value": "link",
+                                                "content": "Link"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormSubmit",
+                            "editor-component": "FormButton"
+                        }
+                    ]
+                },
+                {
+                    "name": "test",
+                    "items": [
+                        {
+                            "label": "Line Input",
+                            "config": {
+                                "icon": "far fa-square",
+                                "name": "name",
+                                "type": "text",
+                                "label": "name",
+                                "helper": null,
+                                "readonly": false,
+                                "dataFormat": "string",
+                                "validation": [],
+                                "placeholder": null
+                            },
+                            "component": "FormInput",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*[^.]$/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the field's name"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "dataFormat",
+                                    "config": {
+                                        "name": "Data Type",
+                                        "label": "Data Type",
+                                        "helper": "The data type specifies what kind of data is stored in the variable.",
+                                        "options": [
+                                            {
+                                                "value": "string",
+                                                "content": "Text"
+                                            },
+                                            {
+                                                "value": "int",
+                                                "content": "Integer"
+                                            },
+                                            {
+                                                "value": "currency",
+                                                "content": "Currency"
+                                            },
+                                            {
+                                                "value": "percentage",
+                                                "content": "Percentage"
+                                            },
+                                            {
+                                                "value": "float",
+                                                "content": "Decimal"
+                                            },
+                                            {
+                                                "value": "datetime",
+                                                "content": "Datetime"
+                                            },
+                                            {
+                                                "value": "date",
+                                                "content": "Date"
+                                            },
+                                            {
+                                                "value": "password",
+                                                "content": "Password"
+                                            }
+                                        ],
+                                        "validation": "required"
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "extends": {
+                                            "props": [
+                                                "label",
+                                                "error",
+                                                "options",
+                                                "helper",
+                                                "name",
+                                                "value",
+                                                "selectedControl"
+                                            ],
+                                            "mixins": [
+                                                {
+                                                    "props": {
+                                                        "validation": {
+                                                            "type": null
+                                                        },
+                                                        "validationData": {
+                                                            "type": null
+                                                        },
+                                                        "validationField": {
+                                                            "type": null
+                                                        },
+                                                        "validationMessages": {
+                                                            "type": null
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "validationData": {
+                                                            "deep": true
+                                                        }
+                                                    },
+                                                    "methods": [],
+                                                    "computed": []
+                                                }
+                                            ],
+                                            "methods": [],
+                                            "computed": [],
+                                            "_compiled": true,
+                                            "inheritAttrs": false,
+                                            "staticRenderFns": []
+                                        },
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "dataMask",
+                                    "config": {
+                                        "name": "Data Format",
+                                        "label": "Data Format",
+                                        "helper": "The data format for the selected type."
+                                    }
+                                },
+                                {
+                                    "type": "ValidationSelect",
+                                    "field": "validation",
+                                    "config": {
+                                        "label": "Validation Rules",
+                                        "helper": "The validation rules needed for this field"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "placeholder",
+                                    "config": {
+                                        "label": "Placeholder Text",
+                                        "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "helper",
+                                    "config": {
+                                        "label": "Helper Text",
+                                        "helper": "Help text is meant to provide additional guidance on the field's value"
+                                    }
+                                },
+                                {
+                                    "type": "FormCheckbox",
+                                    "field": "readonly",
+                                    "config": {
+                                        "label": "Read Only",
+                                        "helper": null
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "props": [
+                                            "value",
+                                            "helper"
+                                        ],
+                                        "watch": {
+                                            "value": {
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "_scopeId": "data-v-172d71e1",
+                                        "computed": {
+                                            "effectiveValue": []
+                                        },
+                                        "_compiled": true,
+                                        "components": {
+                                            "MonacoEditor": {
+                                                "name": "monaco-editor",
+                                                "_Ctor": [],
+                                                "props": {
+                                                    "amdRequire": []
+                                                },
+                                                "extends": {
+                                                    "name": "MonacoEditor",
+                                                    "model": {
+                                                        "event": "change"
+                                                    },
+                                                    "props": {
+                                                        "theme": {
+                                                            "default": "vs"
+                                                        },
+                                                        "value": {
+                                                            "required": true
+                                                        },
+                                                        "options": [],
+                                                        "language": [],
+                                                        "original": [],
+                                                        "amdRequire": [],
+                                                        "diffEditor": {
+                                                            "default": false
+                                                        }
+                                                    },
+                                                    "watch": {
+                                                        "options": {
+                                                            "deep": true,
+                                                            "user": true
+                                                        }
+                                                    },
+                                                    "methods": []
+                                                },
+                                                "methods": []
+                                            }
+                                        },
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "defaultValue",
+                                    "config": {
+                                        "label": "Default Value",
+                                        "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##/##/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormInput",
+                            "editor-component": "FormInput"
+                        }
+                    ]
+                }
+            ],
+            "computed": [],
+            "custom_css": null,
+            "created_at": "2022-01-19T17:18:40+00:00",
+            "updated_at": "2022-01-19T17:19:25+00:00",
+            "status": "ACTIVE",
+            "key": null,
+            "watchers": [],
+            "categories": [
+                {
+                    "id": 2,
+                    "name": "Uncategorized",
+                    "status": "ACTIVE",
+                    "is_system": 0,
+                    "created_at": "2021-08-30T13:58:53+00:00",
+                    "updated_at": "2021-08-30T13:58:53+00:00",
+                    "pivot": {
+                        "assignable_id": 418,
+                        "category_id": 2,
+                        "category_type": "ProcessMaker\\Models\\ScreenCategory"
+                    }
+                }
+            ]
+        }
+    ],
+    "screen_categories": [],
+    "scripts": []
+}

--- a/tests/e2e/specs/RecordList.spec.js
+++ b/tests/e2e/specs/RecordList.spec.js
@@ -144,4 +144,109 @@ describe('Record list', () => {
       });
     });
   });
+
+  it('Check editing the correct record in recordlist after sorting', () => {
+    cy.loadFromJson('record_list_single_input.json', 0);
+    cy.get('[data-cy=mode-preview]').click();
+
+    let data = ['B', 'C', 'A', 'E', 'D', 'G', 'F'];
+
+    //Add 7 rows
+    for (let i = 0; i < 7; i++) {
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=add-row]').click();
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] [name=name]').type(data[i]);
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] button.btn-primary').click();
+    }
+
+    //Sort data
+    cy.get('.b-table-sort-icon-left').click();
+
+    // Select and edit "B" to "BBB"
+    cy.get('[aria-rowindex="2"] > .text-right > .actions > .btn-group > [data-cy=edit-row]').click();
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [name=name]');
+    //Check after sort the field has B
+    cy.should('have.value', 'B');
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [name=name]').type('BB');
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] button.btn-primary').click();
+    //Check the data is correct after edit
+    cy.get('[aria-rowindex="1"] > .table-column').should('contain.text', 'A');
+    cy.get('[aria-rowindex="2"] > .table-column').should('contain.text', 'BBB');
+    cy.get('[aria-rowindex="3"] > .table-column').should('contain.text', 'C');
+    cy.get('[aria-rowindex="4"] > .table-column').should('contain.text', 'D');
+    cy.get('[aria-rowindex="5"] > .table-column').should('contain.text', 'E');
+    // Go to pagination page 2
+    cy.get(':nth-child(4) > .page-link').click();
+    cy.get('[aria-rowindex="6"] > .table-column').should('contain.text', 'F');
+    cy.get('[aria-rowindex="7"] > .table-column').should('contain.text', 'G');
+
+    //Sort data
+    cy.get('.b-table-sort-icon-left').click();
+    //Check last row A has the correct value "A" in the modal
+    cy.get('[aria-rowindex="7"] > .text-right > .actions > .btn-group > [data-cy=edit-row]').click();
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [name=name]').should('have.value', 'A');
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] button.btn-primary').click();
+
+    // Go to pagination page 1
+    cy.get(':nth-child(3) > .page-link').click();
+    //Sort data
+    cy.get('.b-table-sort-icon-left').click();
+    //Get record "D" and replace to "Z"
+    cy.get('[aria-rowindex="4"] > .text-right > .actions > .btn-group > [data-cy=edit-row]').click();
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [name=name]').should('have.value', 'D').clear().type('Z');
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] button.btn-primary').click();
+
+    //Check the data is correct after edit
+    cy.get('[aria-rowindex="1"] > .table-column').should('contain.text', 'A');
+    cy.get('[aria-rowindex="2"] > .table-column').should('contain.text', 'BBB');
+    cy.get('[aria-rowindex="3"] > .table-column').should('contain.text', 'C');
+    cy.get('[aria-rowindex="4"] > .table-column').should('contain.text', 'E');
+    cy.get('[aria-rowindex="5"] > .table-column').should('contain.text', 'F');
+  });
+
+  it('Check deleting the correct record in recordlist after sorting', () => {
+    cy.loadFromJson('record_list_single_input.json', 0);
+    cy.get('[data-cy=mode-preview]').click();
+
+    let data = ['B', 'C', 'A', 'E', 'D', 'G', 'F'];
+
+    //Add 7 rows
+    for (let i = 0; i < 7; i++) {
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=add-row]').click();
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] [name=name]').type(data[i]);
+      cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] button.btn-primary').click();
+    }
+
+    //Sort data
+    cy.get('.b-table-sort-icon-left').click();
+
+    // Go to pagination page 2
+    cy.get(':nth-child(4) > .page-link').click();
+
+    // Delete H
+    cy.get('[aria-rowindex="6"] > .text-right > .actions > .btn-group > [data-cy=remove-row]').click();
+    cy.get('[data-cy=modal-remove] .btn-primary').click();
+
+    //Check after Delete it was deleted the correct row and other data are in table
+    cy.get('.table-column').should('contain.text', 'G');
+    cy.get(':nth-child(3) > .page-link').click();
+    cy.get('[aria-rowindex="1"] > .table-column').should('contain.text', 'A');
+    cy.get('[aria-rowindex="2"] > .table-column').should('contain.text', 'B');
+    cy.get('[aria-rowindex="3"] > .table-column').should('contain.text', 'C');
+    cy.get('[aria-rowindex="4"] > .table-column').should('contain.text', 'D');
+    cy.get('[aria-rowindex="5"] > .table-column').should('contain.text', 'E');
+
+    //Sort data
+    cy.get('.b-table-sort-icon-left').click();
+
+    // Delete B
+    cy.get('[aria-rowindex="5"] > .text-right > .actions > .btn-group > [data-cy=remove-row]').click();
+    cy.get('[data-cy=modal-remove] .btn-primary').click();
+
+    //Check after Delete B, it was deleted the correct row and other data are in table
+    cy.get('[aria-rowindex="1"] > .table-column').should('contain.text', 'G');
+    cy.get('[aria-rowindex="2"] > .table-column').should('contain.text', 'E');
+    cy.get('[aria-rowindex="3"] > .table-column').should('contain.text', 'D');
+    cy.get('[aria-rowindex="4"] > .table-column').should('contain.text', 'C');
+    cy.get('[aria-rowindex="5"] > .table-column').should('contain.text', 'A');
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
When try to edit or delete a row in record list after sorting, it is taking the wrong record.
- Create a screen with only a record list control
- Add one column named ID to the record list
- Create a new page in order to add values to the record list
- Add a line input with ID as the variable
- In the first page check the Editable option and choose the new page in the record form field
- Click on preview add some rows
- Sort the column and try to edit one record or delete

The data shown in the edit option and in the record list is not the same. If you try to delete the record, will remove the wrong record

## Solution
- After sorting, listen the sortChanged event and sort also the parent tableData (to have the same order that the local vuetable) and retrieve the edit or delete row from the tableData variable

## How to Test
- Create a screen with only a record list control
- Add one column named ID to the record list
- Create a new page in order to add values to the record list
- Add a line input with ID as the variable
- In the first page check the Editable option and choose the new page in the record form field
- Click on preview add some rows
- Sort the column and try to edit one record or delete
- You will get the correct row for edit and delete.

Run tests/e2e/specs/RecordList.spec.js tests

**Working video**

https://user-images.githubusercontent.com/90727999/150342975-f4741998-f06f-4c67-afb3-d6a324f85484.mov


## Related Tickets & Packages
- [FOUR-5103](https://processmaker.atlassian.net/browse/FOUR-5103)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
