### PR TITLE
Fix Loop running validations on nested hidden fields 4.2

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -34,7 +34,7 @@ class Validations {
   isVisible() {
     // Disable validations if field is hidden
     let visible = true;
-    if (this.element.config.conditionalHide) {
+    if (!this.data.noData && this.element.config.conditionalHide) {
       try {
         visible = !!Parser.evaluate(this.element.config.conditionalHide, this.data);
       } catch (error) {
@@ -112,8 +112,7 @@ class FormLoopValidations extends Validations {
     set(validations, this.element.config.name, {});
     const loopField = get(validations, this.element.config.name);
     loopField['$each'] = {};
-    const firstRow = (get(this.data, this.element.config.name) || [{}])[0];
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, ...firstRow } }).addValidations(loopField['$each']);
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, noData:true } }).addValidations(loopField['$each']);
   }
 }
 

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -51,7 +51,7 @@ class Validations {
 class ArrayOfFieldsValidations extends Validations {
   async addValidations(validations) {
     for (const item of this.element) {
-      await ValidationsFactory(item, { screen: this.screen, data: this.data }).addValidations(validations);
+      await ValidationsFactory(item, { screen: this.screen, data: this.data, parentVisibilityRule: this.parentVisibilityRule }).addValidations(validations);
     }
   }
 }
@@ -81,8 +81,9 @@ class FormNestedScreenValidations extends Validations {
       return;
     }
     const definition = await this.loadScreen(this.element.config.screen);
+    let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
     if (definition && definition[0] && definition[0].items) {
-      await ValidationsFactory(definition[0].items, { screen: this.screen, data: this.data }).addValidations(validations);
+      await ValidationsFactory(definition[0].items, { screen: this.screen, data: this.data, parentVisibilityRule }).addValidations(validations);
     }
   }
 
@@ -112,7 +113,7 @@ class FormLoopValidations extends Validations {
     set(validations, this.element.config.name, {});
     const loopField = get(validations, this.element.config.name);
     loopField['$each'] = {};
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, noData:true } }).addValidations(loopField['$each']);
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, noData:true }, parentVisibilityRule: this.element.config.conditionalHide }).addValidations(loopField['$each']);
   }
 }
 
@@ -125,7 +126,7 @@ class FormMultiColumnValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: this.data }).addValidations(validations);
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: this.data, parentVisibilityRule: this.element.config.conditionalHide }).addValidations(validations);
   }
 }
 
@@ -167,7 +168,7 @@ class FormElementValidations extends Validations {
     const fieldName = this.element.config.name;
     const validationConfig = this.element.config.validation;
     const conditionalHide = this.element.config.conditionalHide;
-
+    const parentVisibilityRule = this.parentVisibilityRule;
 
     set(validations, fieldName, get(validations, fieldName, {}));
     const fieldValidation = get(validations, fieldName);
@@ -193,7 +194,25 @@ class FormElementValidations extends Validations {
         }
         fieldValidation[rule] = function(...props) {
           const data = props[1];
-          const dataWithParent = this.addReferenceToParents(data);
+          let dataWithParent = this.addReferenceToParents(data);
+          const nestedDataWithParent = this.addReferenceToParents(this.findParent(data));
+          if (nestedDataWithParent) {
+            dataWithParent = Object.assign(nestedDataWithParent, dataWithParent);
+          }
+          // Check Parent Visibility
+          if (parentVisibilityRule) {
+            let isParentVisible = true;
+            try {
+              isParentVisible = !!Parser.evaluate(parentVisibilityRule, dataWithParent);              
+            } catch (error) {
+              isParentVisible = false;
+            }
+
+            if (!isParentVisible ) {
+              return true;
+            }
+          }
+          // Check Field Visibility
           let visible = true;
           if (conditionalHide) {
             try {
@@ -217,7 +236,25 @@ class FormElementValidations extends Validations {
       }
       fieldValidation[validationConfig] = function(...props) {
         const data = props[1];
-        const dataWithParent = this.addReferenceToParents(data);
+        let dataWithParent = this.addReferenceToParents(data);
+        const nestedDataWithParent = this.addReferenceToParents(this.findParent(data));
+        if (nestedDataWithParent) {
+          dataWithParent = Object.assign(nestedDataWithParent, dataWithParent);
+        }
+        // Check Parent Visibility
+        if (parentVisibilityRule) {
+          let isParentVisible = true;
+          try {
+            isParentVisible = !!Parser.evaluate(parentVisibilityRule, dataWithParent);
+          } catch (error) {
+            isParentVisible = false;
+          }
+
+          if (!isParentVisible) {
+            return true;
+          }
+        }
+        // Check Field Visibility
         let visible = true;
         if (conditionalHide) {
           try {

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -91,4 +91,55 @@ describe('Loop control', () => {
       expect(str).to.equal('Preview Form was Submitted');
     });
   });
+
+  it('Verify validation with multicolumn ', () => {
+    cy.visit('/');
+    let alert = false;
+    cy.on('window:alert', msg => alert = msg);
+
+    // Add loop control
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]');
+    cy.get('[data-cy=inspector-source]').select('existing');
+
+    // Add multicolumn to loop
+    cy.get('[data-cy=controls-FormMultiColumn]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
+
+    // Set multicolumn Visibility Rule
+    cy.get('.mb-1 > :nth-child(1) > .row > :nth-child(1)').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
+
+    // Add input to multicolumn
+    cy.get('[data-cy=controls-FormInput]').drag('.mb-1 > :nth-child(1) > .row > :nth-child(1)', 'bottom');
+
+    // Configure Validation rule
+    cy.get('#form_input_1 > .m-2').click();
+    cy.get('[data-cy=add-rule]').click();
+    cy.get('[data-cy=select-rule]').click().type('Required{enter}{esc');
+    cy.get('[data-cy=save-rule]').click();
+
+    // Add submit button
+    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+
+    // Set preview data
+    cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');
+
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get(':nth-child(2) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > .row > :nth-child(1)').should('be.not.visible');
+
+    // Ensure form cannot be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal(false));  
+
+    // Add data to input field
+    cy.get(':nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > .row > :nth-child(1) > :nth-child(1) > .form-group > [data-cy=screen-field-form_input_1]').clear().type('foobar');
+
+    // Ensure form can be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal('Preview Form was Submitted'));
+  });
 });

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -54,7 +54,7 @@ describe('Loop control', () => {
     });
   });
 
-  it('Run validation only on visible fields', () => {
+  it('Verify validation on visible fields', () => {
     cy.visit('/');
     // Add loop control
     cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom'); 

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -142,4 +142,56 @@ describe('Loop control', () => {
       .click()
       .then(() => expect(alert).to.equal('Preview Form was Submitted'));
   });
+
+  it('Verify validation with nested loop ', () => {
+    cy.visit('/');
+    let alert = false;
+    cy.on('window:alert', msg => alert = msg);
+
+    // Add loop control
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]');
+    cy.get('[data-cy=inspector-source]').select('existing');
+
+    // Add loop to loop
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
+
+    // Set nested loop Visibility Rule
+    cy.get('.m-2').click();
+    cy.get('[data-cy=inspector-times]').clear().type(1);
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
+
+    // Add input to nested loop
+    cy.get('[data-cy=controls-FormInput]').drag('.m-2 > .column-draggable > div', 'bottom');
+
+    // Configure Input Validation rule
+    cy.get('#form_input_1 > .m-2').click();
+    cy.get('[data-cy=add-rule]').click();
+    cy.get('[data-cy=select-rule]').click().type('Required{enter}{esc');
+    cy.get('[data-cy=save-rule]').click();
+
+    // Add submit button
+    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+
+    // Set preview data
+    cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');
+
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[name="loop_1"] > :nth-child(2) > :nth-child(1)').should('be.not.visible');
+
+    // Ensure form cannot be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal(false));
+
+    // Add data to input field
+    cy.get(':nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > [name="loop_2"] > :nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > .form-group > [data-cy=screen-field-form_input_1]').clear().type('foobar');
+
+    // Ensure form can be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal('Preview Form was Submitted'));
+  });
 });

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -194,4 +194,92 @@ describe('Loop control', () => {
       .click()
       .then(() => expect(alert).to.equal('Preview Form was Submitted'));
   });
+
+  it('Verify validation with nested screen ', () => {
+    // Load Nested Screen
+    cy.server();
+    cy.route('GET', '/api/1.0/screens/1', JSON.stringify({
+      id: 1,
+      screen_category_id: 1,
+      title: 'Sub screen example',
+      description: 'A sub screen example',
+      type: 'FORM',
+      config: [
+        {
+          name: 'Sub screen example',
+          items: [
+            {
+              'config': {
+                'icon': 'far fa-square',
+                'label': 'First name',
+                'name': 'firstname',
+                'placeholder': '',
+                'validation': 'required',
+                'helper': null,
+                'type': 'text',
+                'dataFormat': 'string',
+                'customCssSelector': 'first-name',
+              },
+              'inspector': [],
+              'component': 'FormInput',
+              'editor-component': 'FormInput',
+              'editor-control': 'FormInput',
+              'label': 'Line Input',
+              'value': '__vue_devtool_undefined__',
+            },
+          ],
+        },
+      ],
+      computed: [],
+      watchers: [],
+      custom_css: '[selector=\'first-name\'] label { font-style: italic; }',
+      status: 'ACTIVE',
+    }));
+
+    cy.visit('/');
+    let alert = false;
+    cy.on('window:alert', msg => alert = msg);
+
+    // Add loop control
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]');
+    cy.get('[data-cy=inspector-source]').select('existing');
+
+    // Add nested screen to loop
+    cy.get('[data-cy=controls-FormNestedScreen]').drag('[data-cy=screen-element-container] .column-draggable div', 'bottom');
+    cy.get('.m-2').click();
+    cy.get('.multiselect__tags').click().wait(1000).type('{downarrow}{enter}{esc}');
+
+    // Set Nested Screen Visibility Rule
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
+
+    // Add submit button
+    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+
+    // Set preview data
+    cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');
+
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[name="loop_1"] > :nth-child(2) > :nth-child(1)').should('be.not.visible');
+    cy.wait(1000);
+    cy.get(':nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > [data-cy="screen-field-Nested Screen"] > [data-cy=screen-renderer] > :nth-child(1) > .page > [selector="first-name"] > .form-group > [data-cy=screen-field-firstname]')
+      .parent()
+      .find('.invalid-feedback')
+      .should('be.visible');
+
+    // Ensure form cannot be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal(false));
+
+    // Add data to input field
+    cy.get(':nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(1) > [data-cy="screen-field-Nested Screen"] > [data-cy=screen-renderer] > :nth-child(1) > .page > [selector="first-name"] > .form-group > [data-cy=screen-field-firstname]').clear().type('foobar');
+
+    // Ensure form can be submitted
+    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+      .click()
+      .then(() => expect(alert).to.equal('Preview Form was Submitted'));
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
[FOUR-5077](https://processmaker.atlassian.net/browse/FOUR-5077)

1. Create a screen
2. Add loop with the next configuration:
3. Data source: Existing Array
4. Variable Name: accounts
5. Add Multicolumn
6. Add visibility rule: `required` ; to the multicolumn
7. Add line input
8. Add validation between Min-Max
9. Press the preview button
10. Populate the accounts loops with the next data

```
{
	"accounts": [
		{
			"product": "uno",
			"initialDeposit": 0
		},
		{
			"product": "dos"
		}
	]
}
```

11. Fill the data with validations
12. Press submit button

Expected behavior: 

The form submits with no errors.

Actual behavior: 

The form does not submit due to validations running on the nested hidden fields.

## Solution
- Check if the nested field parent component is visible before setting validations on the field. If the parent is not visible set the field validation to `true`. 

## How to Test
Test the steps above

## Related Tickets & Packages

**Known Issue:**
- [FOUR-5188](https://processmaker.atlassian.net/browse/FOUR-5188), Validations with multiple loops on a single page only validates the last loop. 
- 4.1 PR - https://github.com/ProcessMaker/screen-builder/pull/1170

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
