### PR TITLE
Bugfix FOUR 5117 (for 4.1) - Remove pagination in Forms tab when a request is complete

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -159,7 +159,7 @@ const jsonOptionsActionsColumn = {
 
 export default {
   mixins: [mustacheEvaluation],
-  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig', 'formComputed', 'formWatchers'],
+  props: ['name', 'label', 'fields', 'value', 'editable', '_config', 'form', 'validationData', 'formConfig', 'formComputed', 'formWatchers', '_perPage'],
   data() {
     return {
       editFormVersion: 0,
@@ -189,6 +189,11 @@ export default {
       },
       initFormValues: {},
     };
+  },
+  mounted() {
+    if (this._perPage) {
+      this.perPage = this._perPage;
+    }
   },
   computed: {
     popupConfig() {


### PR DESCRIPTION
## Issue & Reproduction Steps
Can't see all the records within a record list when a request is completed.

This Pull Request is part of a solution of [Pull Request 4257 in Core](https://github.com/ProcessMaker/processmaker/pull/4257).

## Solution
- Be able to modify the `perPage` value from other components.

## Related Tickets & Packages
- [FOUR-5117](https://processmaker.atlassian.net/browse/FOUR-5117)
- [Pull Request 4257 in Core](https://github.com/ProcessMaker/processmaker/pull/4257)
