### PR TITLE
Fix hardcoded PM4ConfigOverride Screen Endpoint 

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -242,6 +242,11 @@ export default {
           .then((response) => {
             this.task = response.data;
             this.checkTaskStatus();
+            if (window.PM4ConfigOverrides.getScreenEndpoint && window.PM4ConfigOverrides.getScreenEndpoint.includes('tasks/')) {
+              const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');              
+              screenPath[1] = this.task.id;
+              window.PM4ConfigOverrides.getScreenEndpoint = screenPath.join('/');
+            }
           })
           .catch(() => {
             this.hasErrors = true;

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -257,4 +257,64 @@ describe('Task component', () => {
       cy.get('.form-group > :nth-child(1) > div').should('contain.text', 'Please wait');
     });
   });
+  it('It updates the PM4ConfigOverrides', () => {
+    cy.server();
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested',
+      {
+        id: 1,
+        advanceStatus: 'open',
+        component: 'task-screen',
+        created_at: moment().toISOString(),
+        completed_at: moment().toISOString(),
+        due_at: moment().add(1, 'day').toISOString(),
+        status: 'ACTIVE',
+        user: {
+          avatar: '',
+          fullname: 'Assigned User',
+        },
+        screen: Screens.screens[0],
+        process_request: {
+          id: 1,
+          status: 'ACTIVE',
+          user: {
+            avatar: '',
+            fullname: 'Requester User',
+          },
+        },
+        process: {
+          id: 1,
+          name: 'Process Name',
+        },
+        request_data: {
+          firstname: 'John',
+          lastname: 'Doe',
+        },
+      }
+    );
+    cy.visit('/?scenario=TaskAssigned', {
+      onBeforeLoad(win) {
+        // setup request-id=1
+        const requestIdMeta = win.document.createElement('meta');
+        requestIdMeta.setAttribute('name', 'request-id');
+        requestIdMeta.setAttribute('content', '1');
+        win.document.head.appendChild(requestIdMeta);
+        win.PM4ConfigOverrides = {
+          getScreenEndpoint: 'tasks/123/screens'
+        } 
+        // Call some code to initialize the fake server part using MockSocket
+        cy.stub(win, 'WebSocket').callsFake((url) => ({
+          url,
+          onclose: null,
+          onopen: null,
+          close(){},
+          send(){},
+        }));
+        cy.stub(win, 'alert').as('windowAlert');
+      },
+    });
+    cy.wait(2000);
+    cy.window().its('PM4ConfigOverrides.getScreenEndpoint').should('equal', 'tasks/1/screens');
+  });
 });

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -301,8 +301,8 @@ describe('Task component', () => {
         requestIdMeta.setAttribute('content', '1');
         win.document.head.appendChild(requestIdMeta);
         win.PM4ConfigOverrides = {
-          getScreenEndpoint: 'tasks/123/screens'
-        } 
+          getScreenEndpoint: 'tasks/123/screens',
+        };
         // Call some code to initialize the fake server part using MockSocket
         cy.stub(win, 'WebSocket').callsFake((url) => ({
           url,

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -314,7 +314,6 @@ describe('Task component', () => {
         cy.stub(win, 'alert').as('windowAlert');
       },
     });
-    cy.wait(2000);
     cy.window().its('PM4ConfigOverrides.getScreenEndpoint').should('equal', 'tasks/1/screens');
   });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket [FOUR-5146](https://processmaker.atlassian.net/browse/FOUR-5146)

Issue is due to the `PM4ConfigOverride.getScreenEndpoint` variable being hardcoded.  The task IDs are not updating to the latest task causing an error when trying to load an interstitial on a task that is followed by a script task. 

1. Ensure you have a non-admin user created
2. Import this process
[test.json.txt](https://github.com/ProcessMaker/screen-builder/files/7947122/test.json.txt)

3. Assign the start permissions to a non-admin user
4. log in as the user and run the process
5. On the first task select 'Button B'

Expected behavior: 
No errors when displaying an interstitial

Actual behavior: 
After completing the task an error is displayed when loading the interstitial. 

## Solution
- Update the `PM4ConfigOverride.getScreenEndpoint` variable when a new task is loaded via the `loadTask()` method

## How to Test
Test the steps above

## Related Tickets & Packages
- Core [PR](https://github.com/ProcessMaker/processmaker/pull/4256)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
