### PR TITLE
Fix interstitial not progressing to next task with web entry start events

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -322,7 +322,7 @@ export default {
               return;
             } else if (this.task && requestId == this.task.process_request_id && this.parentRequest && this.task.process_request.status === 'COMPLETED') {
               // Only emit completed after getting the subprocess tasks and there are no tasks and process is completed
-                this.$emit('completed', this.parentRequest);
+              this.$emit('completed', this.parentRequest);
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -320,11 +320,9 @@ export default {
               this.redirecting = task.process_request_id;
               this.$emit('redirect', task.id, true);
               return;
-            } else {
+            } else if (this.task && requestId == this.task.process_request_id && this.parentRequest && this.task.process_request.status === 'COMPLETED') {
               // Only emit completed after getting the subprocess tasks and there are no tasks and process is completed
-              if (requestId == this.task.process_request_id && this.parentRequest && this.task.process_request.status === 'COMPLETED') {
                 this.$emit('completed', this.parentRequest);
-              }
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-5414](https://processmaker.atlassian.net/browse/FOUR-5414)

Web entry Start Event with interstitial screen configured does not progress to the next assigned task. Console error appears `Cannot read properties of null (reading 'process_request_id')`

1. Create a Web Entry Start Event and configure an interstitial screen.  
 2. Add a form task and enable Web Entry
3. Add end event 
4. Save and run the process. 

Expected behavior: 
When selecting the submit button the interstitial displays then loads the next assigned task.

Actual behavior: 
When selecting the submit button the interstitial screen continuously displays and never loads the next assigned task.

## Solution
- Check if `this.task` exists before retrieving the `process_request_id` key.

## How to Test
1. Test the replication steps above.
2. Test the use cases in this [PR](https://github.com/ProcessMaker/screen-builder/pull/1173) to ensure the fix for subprocesses isn't broken. 

## Related Tickets & Packages
- 

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
