### PR TITLE
FOUR-5348: 4.2.- Variable is not created if has default value dependent

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -93,7 +93,8 @@ export default {
     },
     tryFormField(variableName, callback, defaultValue = null) {
       try {
-        return callback() || '';
+        let result = callback();
+        return (result === undefined) ? null : result;
       } catch (e) {
         set(this.$v, `${variableName}.$invalid`, true);
         set(this.$v, `${variableName}.invalid_default_value`, false);

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -93,7 +93,7 @@ export default {
     },
     tryFormField(variableName, callback, defaultValue = null) {
       try {
-        return callback() || "";
+        return callback() || '';
       } catch (e) {
         set(this.$v, `${variableName}.$invalid`, true);
         set(this.$v, `${variableName}.invalid_default_value`, false);

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -93,7 +93,7 @@ export default {
     },
     tryFormField(variableName, callback, defaultValue = null) {
       try {
-        return callback();
+        return callback() || "";
       } catch (e) {
         set(this.$v, `${variableName}.$invalid`, true);
         set(this.$v, `${variableName}.invalid_default_value`, false);


### PR DESCRIPTION
## Issue & Reproduction Steps

The problem was produced because for the default value was used a JavaScript expression that didn't return any value. By default JavaScript returns "undefined". 

Expected behavior: 
Even if the the expression used for the default value of a select list is undefined, its value should be able to be set.

Actual behavior: 
The select list variable with the undefined default value it is not updated when an item is selected.

## Solution
If the JavaScript function returns undefined, by default the variable is initialized with a null value.

## How to Test
Steps to Reproduce:

    Create Screen

    Add select list 1 with default values

     

[{"content":"1","value":"1"},{"content":"2","value":"2"}]

Put default value = 2

Add select list 2 with data connector

Put default value JS

 
if (this.form_select_list_2 != 2) {

    return null;

}

Press preview button

Select an option in the second select list and verify that this 2nd dropdown variable update its corresponding variable.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-5348](https://processmaker.atlassian.net/browse/FOUR-5348)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
