### PR TITLE
Bugfix/four 5420

### DIFF
--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -9,19 +9,11 @@ export default {
       const self = this;
 
       try {
-        // 'this' will be used in the Proxy, to have the correct data will add to it all the vdata
-        // excluding the computed properties (to avoid circular references)
-        for (const attr in this.vdata) {
-          if (!_.has(this._computedWatchers, attr)) {
-            this[attr] = this.vdata[attr];
-          }
-        }
-
         //monitor if variable belongs to data (defined variables) or vdata (external variables)
         //in this way the event is not executed again when the variable is update
         const data = new Proxy(Object.assign({}, this), {
           get(data, name) {
-            if (data[name] === undefined) {
+            if (data[name] === undefined || !_.isEqual(data[name]), self.vdata[name]) {
               return self.vdata[name];
             } else {
               return data[name];

--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -6,15 +6,26 @@ export default {
     evaluateExpression(expression, type) {
       let value = null;
 
-      const merged = {};
-      _.merge(merged, this.vdata, this._data);
+      const self = this;
 
       try {
+        // 'this' will be used in the Proxy, to have the correct data will add to it all the vdata
+        // excluding the computed properties (to avoid circular references)
+        for (const attr in this.vdata) {
+          if (!_.has(this._computedWatchers, attr)) {
+            this[attr] = this.vdata[attr];
+          }
+        }
+
         //monitor if variable belongs to data (defined variables) or vdata (external variables)
         //in this way the event is not executed again when the variable is update
-        const data = new Proxy(merged, {
+        const data = new Proxy(Object.assign({}, this), {
           get(data, name) {
-            return data[name];
+            if (data[name] === undefined) {
+              return self.vdata[name];
+            } else {
+              return data[name];
+            }
           },
           set() {
             throw 'You are not allowed to set properties from inside an expression';


### PR DESCRIPTION
## Issue & Reproduction Steps

Two previous tickets are affected by this PR:
https://processmaker.atlassian.net/browse/FOUR-5420
https://processmaker.atlassian.net/browse/FOUR-4853


**Steps to reproduce for FOUR-5420:**

- Import the process  [Process Calc.json.txt](https://github.com/ProcessMaker/screen-builder/files/8126312/Process.Calc.json.txt)
- Create a new request of the process above. Open the first task 
- 
Expected behavior: 
The screen should displayed without problems
Current behavior:

 the screen will or halt or a console error will be printed saying " infinite loop detect with form_date_picker_1"

**Steps to reproduce for FOUR-4853:**
- Import the screen 
[FOUR-4853.json.txt](https://github.com/ProcessMaker/screen-builder/files/8126359/FOUR-4853.json.txt)
- Create a calculated prop called output with js return this.foo.one;
- Create a screen with an input name foo.two
- Create a rich text that shows the output variable
- Go to preview and add this example input data

{
    "foo": {
        "one": "one",
        "two": "two"
    }
}

Expected behavior: 
The second input should display "one"

Actual behavior: 
The second input is left empty

## Solution
- invlude the attribute vdata just when it is different from the one stored in the object 'this'

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-5420](https://processmaker.atlassian.net/browse/FOUR-5420)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
