### PR TITLE
Bugfix/FOUR-5590: Console error when adding a value for Maximum Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1738,9 +1738,9 @@
       }
     },
     "@processmaker/vue-form-elements": {
-      "version": "0.28.6",
-      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.28.6.tgz",
-      "integrity": "sha512-uxHsOkCNLJEF4mJu7dK4+qn2SL/mWDswdoV1kQjNjQkwBk10uGXDdAbtliHRbld3HDMAPUQAu69c+1fS8pDqjA==",
+      "version": "0.28.7",
+      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.28.7.tgz",
+      "integrity": "sha512-CVtaOlyrrcWLoY8bqUyb0KOi9e7kKf0oDdACyrvTpy7UzsaYP05lf6KOqMKyKUXAvpHg8UVJKjxJTbJfflNDKA==",
       "dev": true,
       "requires": {
         "@tinymce/tinymce-vue": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@cypress/code-coverage": "^3.8.1",
     "@fortawesome/fontawesome-free": "^5.6.1",
     "@panter/vue-i18next": "^0.15.2",
-    "@processmaker/vue-form-elements": "0.28.6",
+    "@processmaker/vue-form-elements": "0.28.7",
     "@processmaker/vue-multiselect": "^2.2.0",
     "@vue/cli-plugin-babel": "^3.6.0",
     "@vue/cli-plugin-e2e-cypress": "^4.0.3",

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -283,6 +283,7 @@ export default [
           type: 'FormInput',
           field: 'minDate',
           config: {
+            name: 'Minimum Date',
             label: 'Minimum Date',
             validation: 'date_or_mustache',
           },
@@ -291,8 +292,9 @@ export default [
           type: 'FormInput',
           field: 'maxDate',
           config: {
+            name: 'Maximum Date',
             label: 'Maximum Date',
-            validation: 'date_or_mustache',
+            validation: 'after_min_date|date_or_mustache',
           },
         },
         keyNameProperty,

--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -1,6 +1,39 @@
 import moment from 'moment';
 
 describe('Date Picker', () => {
+
+  it('Date time picker with maxDate before minDate should show a validation error', () => {
+    const today = moment(new Date());
+    const yesterday = moment(new Date()).subtract(1, 'days');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type(today.format('YYYY-MM-DD'));
+    cy.get('[data-cy=inspector-maxDate]').clear().type(yesterday.format('YYYY-MM-DD'));
+
+    // Assert error validation showing
+    cy.get('.invalid-feedback > div')
+      .should('be.visible')
+      .should('contain.text', 'Must be after or equal Minimum Date');
+  });
+  it('Date time picker with maxDate after minDate should not show a validation error', () => {
+    const today = moment(new Date());
+    const tomorrow = moment(new Date()).add(1, 'days');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type(today.format('YYYY-MM-DD'));
+    cy.get('[data-cy=inspector-maxDate]').clear().type(tomorrow.format('YYYY-MM-DD'));
+    // Assert error validation not showing
+    cy.get('.invalid-feedback > div')
+      .should('be.not.visible');
+  });
   it('Date type', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');


### PR DESCRIPTION
## Issue & Reproduction Steps
- Add a Date Picker control to a screen
- Open the browser dev console
- Open the Configuration right side menu and insert a value for the Maximum Date

## Solution
- Added method to check if max date is valid.
- Added new validation rule to show the error under the field.

## How to Test
- Add a Date Picker control to a screen
- Open the browser dev console
- Open the Configuration right side menu and insert a value for the Maximum Date
- Should not display any errors in the console.
- Try adding a min date and then a max date before the min date, you should see the error under Maximum Date input
- Try adding a min date and then a max date after the min date, you should NOT see the error under Maximum Date input

Run DatePicker.specs e2e tests

**Working video**

https://user-images.githubusercontent.com/90727999/156592050-80d796a2-2f2d-4408-80cc-218ca413545a.mov


## Related Tickets & Packages
- [FOUR-5590](https://processmaker.atlassian.net/browse/FOUR-5590)
- [Vue Form Elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/333)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
