### PR TITLE
Fix Values from being overwritten in loops with nested screens

### DIFF
--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -26,7 +26,7 @@ import Json2Vue from '../mixins/Json2Vue';
 import CurrentPageProperty from '../mixins/CurrentPageProperty';
 import WatchersSynchronous from '@/components/watchers-synchronous';
 import ScreenRendererError from '../components/renderer/screen-renderer-error';
-import { cloneDeep, isEqual, debounce } from 'lodash';
+import { cloneDeep, isEqual } from 'lodash';
 
 export default {
   name: 'screen-renderer',

--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -43,7 +43,6 @@ export default {
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
     this.component = this.buildComponent(this.currentDefinition);
-    this.rebuildScreen = debounce(this.rebuildScreen, 25);
   },
   watch: {
     definition: {


### PR DESCRIPTION
## Issue & Reproduction Steps
Ticket: [FOUR-5359](https://processmaker.atlassian.net/browse/FOUR-5359)

When two loops on a page contain the same nested screen and the nested screen has an input variable value of `nested.form_input_1` Loop B inherits Loop A's  values when navigating between pages.  

Note:  There is more complexity with the replication steps to make it simpler import the screen attached, however if you would like to build your own below are some more detailed instructions.
1. The nested screen must have an input field variable value of an object ex `nested.form_input_1` 
2. Loop B needs to have a visibility rule set
3. Page 2 of the screen needs to reference Loop A as an existing loop and also contain a visibility rule same as Loop B

## Reproduction Steps
1. Import this screen [FOUR-5359.json.txt](https://github.com/ProcessMaker/screen-builder/files/8218881/FOUR-5359.json.txt)
5. Preview the screen and input data in the New input field. Take notice of `nested.form_input_1` value in the Data Preview for both `loop_1` and `loop_2`
6. Select the Page Navigation Button to go to the second page
7. Take notice of `nested.form_input_1` value in the Data Preview for both `loop_1` and `loop_2`
8. Select the Page Navigation button to go to the first page.
9. Select the checkbox
10. Notice the second loop nested screen now has the value of the first loop nested screen.

Expected behavior: 

When Loop B contains the same nested screen in Loop A, Loop B should not inherit Loop A values when navigating between pages.

Actual behavior: 

When Loop B contains the same nested screen in Loop A, Loop B inherits Loop A values when navigating between pages.

## Solution
- Remove the `rebuildScreen` in the mounting method. This was added in this [PR](https://github.com/ProcessMaker/screen-builder/pull/1139) to improve the screen rendering, however when removing this method on mount it there isn't any noticalble changes when testing the screen in the PR. It does fix this bug that was introduced.

## How to Test
Test the steps above

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
