### PR TITLE
FOUR-5420: Screen Freeze with calcs

### DIFF
--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { Parser } from 'expr-eval';
 
 export default {
@@ -10,9 +11,14 @@ export default {
         // Monitor if variable belongs to data (defined variables) or
         // vdata (external variables)in this way the event is not
         // executed again when the variable is update
-        const data = new Proxy(Object.assign({}, self, self.vdata), {
+
+        const data = new Proxy(Object.assign({}, this), {
           get(data, name) {
-            return undefined === data[name] ? self.vdata[name] : data[name];
+            if (data[name] === undefined || !_.isEqual(data[name]), self.vdata[name]) {
+              return self.vdata[name];
+            } else {
+              return data[name];
+            }
           },
           set() {
             throw 'You are not allowed to set properties from inside an expression';


### PR DESCRIPTION
## Issue & Reproduction Steps

Two previous tickets are affected by this PR:
https://processmaker.atlassian.net/browse/FOUR-5420
https://processmaker.atlassian.net/browse/FOUR-4853


**Steps to reproduce for FOUR-5420:**

- Import the process  [Process Calc.json.txt](https://github.com/ProcessMaker/screen-builder/files/8126312/Process.Calc.json.txt)
- Create a new request of the process above. Open the first task 
- 
Expected behavior: 
The screen should displayed without problems

Current behavior:
The screen will or halt or a console error will be printed saying " infinite loop detect with form_date_picker_1"

![image](https://user-images.githubusercontent.com/14875032/157678883-149dc53e-aceb-401c-af67-47f38680f9db.png)


## Solution
- include the attribute vdata just when it is different from the one stored in the object 'this'

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-5420](https://processmaker.atlassian.net/browse/FOUR-5420)

**IMPORTANT:** The issue was introduced with the solution to FOUR-5139, so verify that it is not broken:
[https://processmaker.atlassian.net/browse/FOUR-5139](https://processmaker.atlassian.net/browse/FOUR-5139)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.