### PR TITLE
Fix Interstitial redirecting before a script task is completed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -326,8 +326,8 @@ export default {
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;
-          } else {
-            this.$emit('completed', (this.parentRequest ? this.parentRequest : requestId));
+          } else if (this.parentRequest) {
+            this.$emit('completed', this.parentRequest);
           }
         });
     },

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -561,8 +561,11 @@ describe('Task component', () => {
 
       getTasks('http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1');
 
-      cy.wait(2000);
-      cy.reload();
+    });
+
+    cy.socketEvent('ProcessMaker\\Events\\ProcessUpdated', {
+      requestId: 1,
+      event: 'ACTIVITY_COMPLETED',
     });
 
     cy.url().should('eq', 'http://localhost:8080/requests/1');


### PR DESCRIPTION
## Issue & Reproduction Steps
Fixes Tickets
- [FOUR-5299](https://processmaker.atlassian.net/browse/FOUR-5299)
- [FOUR-5806](https://processmaker.atlassian.net/browse/FOUR-5806)

Reproduce:

1. Create a process with the next configuration
![image-20220205-044840](https://user-images.githubusercontent.com/52755494/159799612-acd0795b-3434-4bb1-bea5-c43882d12e7a.png)


2. Put an interstitial in Form Task

3. Put a screen display in the end event

4. Create a request

5. Route to script to the process finished

Expected behavior: 

Insterstitial should wait until the script task is completed.

Actual behavior: 

Insterstitial completes BEFORE the script task is executed/completed.

Issue:
The issue was due to emitting the "completed" status of the current task if there was no assigned task to load next. Script tasks are not considered "tasks" that the user has access to, this caused the interstitial to complete before the script task had time to execute or be completed. 

## Solution
- Add `else if` conditional that checks if the process has a parent request via the `this.parentRequest` variable before emitting the "completed" status if no assigned task is loaded.

## How to Test

1. Test the steps above
3. Test the subprocess scenarios in this [PR](https://github.com/ProcessMaker/screen-builder/pull/1173)



## Related Tickets & Packages
- https://github.com/ProcessMaker/screen-builder/pull/1173

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
