### PR TITLE
Fix validation data context on visibility evaluation

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -243,12 +243,8 @@ class FormElementValidations extends Validations {
         }
         fieldValidation[rule] = function(...props) {
           const data = props[1];
-          let dataWithParent = this.addReferenceToParents(data);
-          const nestedDataWithParent = this.addReferenceToParents(this.findParent(data));
-          if (nestedDataWithParent) {
-            dataWithParent = Object.assign(nestedDataWithParent, dataWithParent);
-          }
-          // Check Parent Visibility
+          const level = fieldName.split('.').length - 1;
+          const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
           if (parentVisibilityRule) {
             let isParentVisible = true;
             try {
@@ -285,11 +281,8 @@ class FormElementValidations extends Validations {
       }
       fieldValidation[validationConfig] = function(...props) {
         const data = props[1];
-        let dataWithParent = this.addReferenceToParents(data);
-        const nestedDataWithParent = this.addReferenceToParents(this.findParent(data));
-        if (nestedDataWithParent) {
-          dataWithParent = Object.assign(nestedDataWithParent, dataWithParent);
-        }
+        const level = fieldName.split('.').length - 1;
+        const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
         // Check Parent Visibility
         if (parentVisibilityRule) {
           let isParentVisible = true;


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a screen with a checkbox and a form input
- Name the Form Input like: `user.properties.form_input_1`
- Add rules to input field: `Require If`, `Email`
- Add a visibility rule to input field: `form_checkbox_1`
- Check/Uncheck the field to show/hide the target field


Expected behavior: 
The validations should be enabled when the inputs is visible
The validations should be disabled when the inputs is hidden

Actual behavior: 
The validations are disabled when the inputs is visible
This fails because the variable name use 3 or more levels

## Solution
- Fix the ValidationFactory.js

## How to Test
- Import the screen
- Check/Uncheck the field to show/hide the target field
- Verify the validations are enabled/disabled properlty
- 
[test_validation_rules.zip](https://github.com/ProcessMaker/screen-builder/files/8490013/test_validation_rules.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/TRI4-6085

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
