### PR TITLE
FOUR-5906: Screen Freeze with calcs

### DIFF
--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -32,7 +32,7 @@ export default {
         this.tryFormField(${JSON.stringify(name)}, () => {this.${this.dot2bracket(name)} = ${value};});
       }`);
       screen.computed[defaultComputedName] = {
-        get: new Function(`return this.tryFormField(${JSON.stringify(name)}, () => ${value});`),
+        get: new Function(`if (this.vdata['${name}']) return; return this.tryFormField(${JSON.stringify(name)}, () => ${value});`),
         set() {},
       };
       this.addWatch(screen, defaultComputedName, `!this.${name}_was_filled__ && this.setValue(${JSON.stringify(name)}, this.${defaultComputedName}, this.vdata, this);`);


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a Screen 

- Add a line input

- Add a calc with the next code

var aleatorio = Math.floor(Math.random()*394)+79
return aleatorio;

- Assign the calc with default value in the line input (i.e the default value should be {{calc}})

- Press preview button

**Expected behavior:** 
The screen should not freeze with calc as default value in a control,

**Actual behavior:** 
Screen freeze with the calc is assigned to line input as default value.

## Solution
- Default values is evaluated just when the variable is not initialized.
*NOTE* In this particular case the default value is set to a dynamic computed field (calc is a random number). Every time that the user interacts this variable calc is recalculated and a new number is assigned. But the control will maintain the first calc value that it received. Default values are set  when loading the screen for the first time, not afterwards.

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-5906](https://processmaker.atlassian.net/browse/FOUR-5906)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
