### PR TITLE
Bugfix/FOUR-5865: Error in captcha inside a loops 

### DIFF
--- a/src/components/inspector/screen-selector.vue
+++ b/src/components/inspector/screen-selector.vue
@@ -102,6 +102,12 @@ export default {
     },
   },
   mounted() {
+    this.$root.$on('remove-nested', (nestedScreenId) => {
+      if (this.value === nestedScreenId) {
+        this.$emit('input', null);
+      }
+    });
+
     let pmql = '(type = "FORM" or type = "DISPLAY")';
     if (this.screenType === formTypes.display) {
       pmql = '(type = "DISPLAY")';

--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -116,6 +116,7 @@ export default {
                 globalObject['nestedScreens'] = {};
               }
               globalObject.nestedScreens['id_' + id] = this.config;
+              this.$root.$emit('nested-screen-updated');
             }
           });
       }

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -538,7 +538,7 @@ export default {
         if (item.items) {
           this.checkForCaptcha(item.items, true);
         }
-        if (item.component == 'FormNestedScreen' && insideLoop && item.config.screen) {
+        if (item.component == 'FormNestedScreen' && insideLoop && item.config.screen && window.nestedScreens) {
           let nestedScreenItems = window.nestedScreens['id_' + item.config.screen];
           if (nestedScreenItems) {
             nestedScreenItems.forEach(nestedScreenPage => {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a screen
- Add loop control
- Add captcha control inside loop 
- Press preview button

Current behavior 
- After adding captcha controls inside loops an error message is displayed in the top screen.

Acceptance criteria
- When try to add a captcha in a loop a warning message should shows with the following text:
`CAPTCHA controls cannot be placed within a Loop control.`
- When try to add a nested screen with a captcha in a loop a warning message should shows with the following text:
`You are trying to place a nested screen within CAPTCHA elements inside a loop. CAPTCHA controls cannot be placed within a Loop control.`

## Solution
- Recursively search for captcha controls inside loops in all screen config, including nested screens.
- Added warning message when placing captcha inside loops

## How to Test
Test the steps above
- Also try to add a nested screen that contains a captcha inside a loop.

**Working video**

https://user-images.githubusercontent.com/90727999/165388446-4a5614b2-87a7-4606-8cb7-19a07f8c3257.mov


## Related Tickets & Packages
- [FOUR-5865](https://processmaker.atlassian.net/browse/FOUR-5865)
- [Processmaker core PR](https://github.com/ProcessMaker/processmaker/pull/4357)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
