### PR TITLE
Bugfix FOUR-5920 - file download with loop in a record list, does not work correctly in 4.2.x

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -92,7 +92,7 @@ export default {
     this.removeDefaultClasses();
   },
   mounted() {
-    this.$root.$on('set-upload-data-name',
+    this.$root.$once('set-upload-data-name',
       (recordList, index, id) => this.listenRecordList(recordList, index, id));
 
     this.$root.$on('removed-record',
@@ -409,11 +409,9 @@ export default {
       }
     },
     listenRecordList(recordList, index, id) {
-      const parent = this.parentRecordList(this);
-      if (parent !== recordList) {
-        return;
+      if (recordList) {
+        this.row_id = id;
       }
-      this.row_id = (parent !== null) ? id : null;
     },
     setPrefix() {
       let parent = this.$parent;

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -175,7 +175,6 @@ export default {
       plural: '',
       addItem: {},
       editItem: {},
-      editIndex: null,
       currentPage: 1,
       paginatorPage: 1,
       perPageSelectEnabled: false,
@@ -371,7 +370,6 @@ export default {
       let pageIndex = ((this.currentPage-1) * this.perPage) + index;
       // Reset edit to be a copy of our data model item
       this.editItem = _.find(this.tableData.data, {'row_id': rowId});
-      this.editIndex = pageIndex;
       // rebuild the edit screen to avoid
       this.editFormVersion++;
       this.$nextTick(() => {
@@ -387,7 +385,7 @@ export default {
 
       // Edit the item in our model and emit change
       let data = this.tableData.data ? JSON.parse(JSON.stringify(this.tableData.data)) : [];
-      var index = _.findIndex(data, {'row_id': this.editItem.rowId});
+      var index = _.findIndex(data, {'row_id': this.editItem.row_id});
       data[index] = JSON.parse(JSON.stringify(this.editItem));
 
       // Remove the parent object

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -397,7 +397,6 @@ export default {
     showAddForm() {
       const uniqueId = Math.random().toString(36).substring(2) + Date.now().toString(36);
       this.$set(this.addItem, 'row_id', uniqueId);
-      this.setUploadDataNamePrefix();
       if (!this.form) {
         this.$refs.infoModal.show();
         return;

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -89,7 +89,6 @@
         debug-context="Record List Add"
         :key="Array.isArray(value) ? value.length : 0"
         :_parent="validationData"
-        @update="updateRowDataNamePrefix"
       />
     </b-modal>
     <b-modal
@@ -116,7 +115,6 @@
         debug-context="Record List Edit"
         :_parent="validationData"
         :key="editFormVersion"
-        @update="updateRowDataNamePrefix"
       />
     </b-modal>
     <b-modal
@@ -202,7 +200,6 @@ export default {
     if (this._perPage) {
       this.perPage = this._perPage;
     }
-    this.updateRowDataNamePrefix = _.debounce(this.updateRowDataNamePrefix, 100);
   },
   computed: {
     popupConfig() {
@@ -282,9 +279,6 @@ export default {
     },
   },
   methods: {
-    updateRowDataNamePrefix() {
-      this.setUploadDataNamePrefix(this.currentRowIndex);
-    },
     emitShownEvent() {
       window.ProcessMaker.EventBus.$emit('modal-shown');
     },
@@ -372,8 +366,8 @@ export default {
       this.editItem = _.find(this.tableData.data, {'row_id': rowId});
       // rebuild the edit screen to avoid
       this.editFormVersion++;
+      this.setUploadDataNamePrefix(pageIndex);
       this.$nextTick(() => {
-        this.setUploadDataNamePrefix(pageIndex);
         this.$refs.editModal.show();
       });
     },
@@ -395,8 +389,6 @@ export default {
       this.$emit('input', data);
     },
     showAddForm() {
-      const uniqueId = Math.random().toString(36).substring(2) + Date.now().toString(36);
-      this.$set(this.addItem, 'row_id', uniqueId);
       if (!this.form) {
         this.$refs.infoModal.show();
         return;
@@ -417,12 +409,16 @@ export default {
 
       // Add the item to our model and emit change
       // @todo Also check that value is an array type, if not, reset it to an array
+      const uniqueId = Math.random().toString(36).substring(2) + Date.now().toString(36);
+      this.$set(this.addItem, 'row_id', uniqueId);
+
       let data = this.value ? JSON.parse(JSON.stringify(this.value)) : [];
       const item = JSON.parse(JSON.stringify({...this.addItem, _parent: undefined }));
       delete item._parent;
       data[data.length] = item;
 
       // Emit the newly updated data model
+      this.setUploadDataNamePrefix();
       this.$emit('input', data);
 
       // Reset our add item

--- a/tests/e2e/specs/MultipleUpload.spec.js
+++ b/tests/e2e/specs/MultipleUpload.spec.js
@@ -102,9 +102,7 @@ describe('Multiple Upload', () => {
     // The global variable should store the uploaded item
     cy.window().its('PM4ConfigOverrides.requestFiles')
       .then(requestFiles => {
-        const firstMapFileVar = Object.keys(requestFiles).find(x => x.startsWith('map'));
-        const rowId = firstMapFileVar.split('map.')[1];
-        expect(requestFiles['map.' + rowId][0].file_name).to.equal('avatar.jpeg');
+        expect(requestFiles['map'][0].file_name).to.equal('avatar.jpeg');
       });
 
     // Upload a file in multiple file mode

--- a/tests/e2e/specs/RecordList.spec.js
+++ b/tests/e2e/specs/RecordList.spec.js
@@ -325,6 +325,8 @@ describe('Record list', () => {
   it('FileUpload in record lists within loops', () => {
     cy.loadFromJson('record_list_fileupload_loops.json', 0);
     cy.get('[data-cy=mode-preview]').click();
+
+    // Add 1 row to the record list.
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=add-row]').click();
 
     // Upload the first file.
@@ -352,6 +354,7 @@ describe('Record list', () => {
     // Edit record and check the uploaded files are displayed.
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=edit-row]').click();
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [data-cy="screen-field-file_upload_2"]').eq(0).should('contain.text', 'avatar.jpeg');
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [name=form_input_4]').eq(1).clear().type('Second edited');
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] [data-cy="screen-field-file_upload_2"]').eq(1).should('contain.text', 'avatar.jpeg');
 
     // Add a third file in edit modal.
@@ -373,10 +376,15 @@ describe('Record list', () => {
     cy.wait(500);
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-edit] button:contains(Save)').click();
 
+    // Add 2nd. row to the record list.
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=add-row]').click();
+    cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] button:contains(Ok)').click();
+
     // Verify the data structure.
     cy.get('#screen-builder-container').then((div) => {
       const data = div[0].__vue__.previewData;
       const record_row_id = data.form_record_list_1[0].row_id;
+      const second_record_row_id = data.form_record_list_1[1].row_id;
       expect(data).to.eql({
         'form_record_list_1': [
           {
@@ -386,11 +394,20 @@ describe('Record list', () => {
                 'file_upload_2': 1,
               },
               {
-                'form_input_4': 'Second',
+                'form_input_4': 'Second edited',
                 'file_upload_2': 2,
               },
             ],
             'row_id': record_row_id,
+          },
+          {
+            'loop_1': [
+              {
+                'form_input_4': '',
+                'file_upload_2': null,
+              },
+            ],
+            'row_id': second_record_row_id,
           },
         ],
         'loop_1': [

--- a/tests/e2e/specs/RecordList.spec.js
+++ b/tests/e2e/specs/RecordList.spec.js
@@ -156,6 +156,7 @@ describe('Record list', () => {
       fileUploadId: 2,
     }));
     cy.uploadFile('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] [data-cy="screen-field-file2"] input[type=file]', 'record_list_fileupload_required.json', 'application/json');
+    cy.wait(1000);
     cy.get('[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=modal-add] button:contains(Ok)').click();
 
     // Check the file is rendered in the record list


### PR DESCRIPTION
## Issue & Reproduction Steps
Expected behavior: 
- The documents uploaded should be shown correctly on the File Upload UI.

Actual behavior: 
- When a record is edited and then another record is added, the reference to the loaded files is lost.

## Solution
- Removed `this.setUploadDataNamePrefix();` function since it was executed twice and caused the bug.
- e2e tests were improved to avoid problems in the future.

## How to Test
- Import the attached process in JIRA
- Run a new request
- Add new records in record list
- Upload documents on the loop control
    - You can override the same file
    - Delete an item from the loop
    - Add more items and files within the loop.
    - Add another record in Record List and repeat

The files must be stored and/or deleted correctly in `storage/app/public` backend. When submitting the task, everything should be displayed correctly and the files can be downloaded.

## Related Tickets & Packages
- [FOUR-5920](https://processmaker.atlassian.net/browse/FOUR-5920)