### PR TITLE
Check for captcha elements also in mounted

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -874,6 +874,7 @@ export default {
   },
   mounted() {
     this.loadVariablesTree();
+    this.checkForCaptchaInLoops();
     this.$root.$on('nested-screen-updated', () => {
       this.checkForCaptchaInLoops();
     });

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -536,13 +536,13 @@ export default {
           }
         }
         if (item.items) {
-          this.checkForCaptcha(item.items, true);
+          this.checkForCaptcha(item.items, true, nestedScreen);
         }
-        if (item.component == 'FormNestedScreen' && insideLoop && item.config.screen && window.nestedScreens) {
+        if (item.component == 'FormNestedScreen' && item.config.screen && window.nestedScreens) {
           let nestedScreenItems = window.nestedScreens['id_' + item.config.screen];
           if (nestedScreenItems) {
             nestedScreenItems.forEach(nestedScreenPage => {
-              this.checkForCaptcha(nestedScreenPage.items, true, item);
+              this.checkForCaptcha(nestedScreenPage.items, insideLoop, item);
             });
           }
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

Not checking for captcha elements for imported screens with captcha inside loops.
Please refers to [FOUR-5865](https://processmaker.atlassian.net/browse/FOUR-5865)

- Import a screen with captcha elements inside a loop
- Open the screen
- Captcha inside loops still there and error shows in preview

## Solution
- Check for captcha also on mounted

## How to Test
- Import a screen with captcha elements inside a loop. 
- An alert should shows and captcha should be removed from loops.

**Working video**

https://user-images.githubusercontent.com/90727999/165822814-73344d94-50a6-41c1-8841-9d79c1bef7eb.mov


## Related Tickets & Packages
- [FOUR-5865](https://processmaker.atlassian.net/browse/FOUR-5865)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
