### PR TITLE
Bugfix/FOUR-6039: Console error "e.uploader.uploader is null" in Task - Screen with fileupload in loop and RecordList

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -18,7 +18,7 @@
     >
       <uploader-unsupport/>
 
-      <uploader-drop class="form-control-file">
+      <uploader-drop v-if="this.$refs['uploader']" class="form-control-file">
         <p>{{ $t('Drop a file here to upload or') }}</p>
         <uploader-btn
           :attrs="nativeButtonAttrs"
@@ -378,7 +378,7 @@ export default {
         }
       }
     },
-    async removeFile(file) { 
+    async removeFile(file) {
       const id = file.id;
       const token = file.token ? file.token : null;
 
@@ -386,13 +386,13 @@ export default {
       if (!isNaN(id)) {
         await this.$dataProvider.deleteFile(id, token);
       }
-      
+
       this.removeFromFiles(id);
     },
     removeFromFiles(id) {
       const idx = this.files.findIndex(f => f.id === id);
       this.$delete(this.files, idx);
-      
+
       if (this.nativeFiles[id]) {
         if (this.$refs.uploader) {
           this.$refs.uploader.uploader.removeFile(this.nativeFiles[id]);
@@ -478,13 +478,13 @@ export default {
         if (this.collection) {
           id = msg.id;
         }
-        
+
         const fileInfo = {
           id,
           file_name: name,
           mime_type: rootFile.fileType,
         };
-       
+
         this.$set(this.nativeFiles, id, rootFile);
         this.addToFiles(fileInfo);
       } else {

--- a/tests/e2e/specs/FileDownload.spec.js
+++ b/tests/e2e/specs/FileDownload.spec.js
@@ -16,20 +16,20 @@ describe('File Download', () => {
 
     // The file should be listed in the file download control
     cy.get(':nth-child(2) > .row > :nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"]').contains('avatar.jpeg');
-    
+
     // The file using the `_parent` variable should be listed in the file download control
     cy.get('.page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"]').contains('avatar.jpeg');
 
     // The file should be listed in the Record List file download control
     cy.get('[data-cy=add-row]').click();
-    cy.get('#__BVID__99___BV_modal_body_ > .custom-css-scope > [data-cy=screen-renderer] > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"]').contains('avatar.jpeg');
+    cy.get('[data-cy=screen-renderer] > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"]').contains('avatar.jpeg');
   });
 
   it('Can download a single file', () => {
     uploadSingleFile();
     // Mock file download
     cy.route('/api/1.0/files/1/contents', 'avatar.jpeg').as('download');
-    
+
     // A standard file is downloadable
     cy.get('.row > :nth-child(1) > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn').click();
     cy.wait('@download').then((xhr) => {
@@ -44,7 +44,7 @@ describe('File Download', () => {
 
     // A Record List file is downloadable
     cy.get('[data-cy=add-row]').click();
-    cy.get('#__BVID__99___BV_modal_body_ > .custom-css-scope > [data-cy=screen-renderer] > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn').click();
+    cy.get('[data-cy=screen-renderer] > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn').eq(0).click();
     cy.wait('@download').then((xhr) => {
       expect(xhr.response.body).to.equal('avatar.jpeg');
     });
@@ -52,15 +52,15 @@ describe('File Download', () => {
 
   it('Lists multiple files in download control', () => {
     uploadMultiFile();
-    
+
     // The files should be listed in a standard multiple file download control
     cy.get('.col-sm-6 div').as('file_upload_1').should('include.text', 'avatar.jpeg');
     cy.get('.col-sm-6 div').as('file_upload_1').should('include.text', 'file1.jpeg');
 
     // The files should be listed in a Record List multiple file download control
     cy.get('[data-cy=add-row]').click();
-    cy.get('#__BVID__101___BV_modal_body_').should('include.text', 'avatar.jpeg');
-    cy.get('#__BVID__101___BV_modal_body_').should('include.text', 'file1.jpeg');
+    cy.get('.modal-body').eq(0).should('include.text', 'avatar.jpeg');
+    cy.get('.modal-body').eq(0).should('include.text', 'file1.jpeg');
   });
 
   it('Can download multiple files', () => {
@@ -68,8 +68,8 @@ describe('File Download', () => {
     // Mock the first file download
     cy.route('/api/1.0/files/1/contents', 'avatar.jpeg').as('download');
     // Mock the second file download
-    cy.route('/api/1.0/files/2/contents', 'file1.jpeg').as('download');        
-        
+    cy.route('/api/1.0/files/2/contents', 'file1.jpeg').as('download');
+
     // The first file should be downloaded
     cy.get('.row > :nth-child(1) > :nth-child(1) > [icon="fas fa-redo"] > :nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn')
       .click();
@@ -87,14 +87,16 @@ describe('File Download', () => {
     // Assert Record List multiple files are downloadable
     cy.get('[data-cy=add-row]').click();
     // The first file should be downloaded
-    cy.get('#__BVID__101___BV_modal_body_ > .custom-css-scope > [data-cy=screen-renderer] > :nth-child(1) > [name="record_page"] > :nth-child(1) > [icon="fas fa-redo"] > :nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn')
+    cy.get('[data-cy=screen-renderer] > :nth-child(1) > [name="record_page"] > :nth-child(1) > [icon="fas fa-redo"] > :nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="1-avatar"] > .btn')
+      .eq(0)
       .click();
     cy.wait('@download').then((xhr) => {
       expect(xhr.response.body).to.equal('avatar.jpeg');
     });
 
     // The second file should be downloaded
-    cy.get('#__BVID__101___BV_modal_body_ > .custom-css-scope > [data-cy=screen-renderer] > :nth-child(1) > [name="record_page"] > :nth-child(1) > [icon="fas fa-redo"] > :nth-child(2) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="2-file1"] > .btn')
+    cy.get('[data-cy=screen-renderer] > :nth-child(1) > [name="record_page"] > :nth-child(1) > [icon="fas fa-redo"] > :nth-child(2) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > :nth-child(1) > :nth-child(2) > [data-cy="2-file1"] > .btn')
+      .eq(0)
       .click();
     cy.wait('@download').then((xhr) => {
       expect(xhr.response.body).to.equal('file1.jpeg');
@@ -111,12 +113,12 @@ function uploadSingleFile() {
     fileUploadId: 1,
   }));
   cy.uploadFile('[data-cy=preview-content] [data-cy=screen-field-file_upload_1] input[type=file]', 'avatar.jpeg', 'image/jpg');
-        
+
   // Mock file info
-  cy.route('/api/1.0/requests/1/files?id=*', 
+  cy.route('/api/1.0/requests/1/files?id=*',
     {
-      id: 1, 
-      file_name: 'avatar.jpeg', 
+      id: 1,
+      file_name: 'avatar.jpeg',
       name: 'avatar',
     }
   ).as('getFileInfo');
@@ -125,31 +127,31 @@ function uploadSingleFile() {
 function uploadMultiFile() {
   cy.loadFromJson('multiple_file_download.json', 0);
   cy.get('[data-cy=mode-preview]').click();
-    
+
   // Upload first file
   cy.route('POST', '/api/1.0/requests/1/files', JSON.stringify({
     message: 'The file was uploaded.',
     fileUploadId: 1,
   }));
   cy.uploadFile('[data-cy=preview-content] [data-cy=screen-field-file_upload_1] input[type=file]', 'avatar.jpeg', 'image/jpg');
-  cy.route('/api/1.0/requests/1/files?id=1', 
+  cy.route('/api/1.0/requests/1/files?id=1',
     {
-      id: 1, 
-      file_name: 'avatar.jpeg', 
+      id: 1,
+      file_name: 'avatar.jpeg',
       name: 'avatar',
     }
   ).as('getFileInfo');
-    
+
   // Upload second file
   cy.route('POST', '/api/1.0/requests/1/files', JSON.stringify({
     message: 'The file was uploaded.',
     fileUploadId: 2,
   }));
   cy.uploadFile('[data-cy=preview-content] [data-cy=screen-field-file_upload_1] input[type=file]', 'file1.jpeg', 'image/jpg');
-  cy.route('/api/1.0/requests/1/files?id=2', 
+  cy.route('/api/1.0/requests/1/files?id=2',
     {
-      id: 2, 
-      file_name: 'file1.jpeg', 
+      id: 2,
+      file_name: 'file1.jpeg',
       name: 'file1',
     }
   ).as('getFileInfo');


### PR DESCRIPTION
## Issue & Reproduction Steps

When you have a screen with a file upload inside a loop inside a record list, a console error shows in the task when running a new request in Firefox browser.

- Import the attached process.
- Run a new request.
- When the Task is opened, the console error appears.

[PRUEBA DE BUCLE.json.txt](https://github.com/ProcessMaker/screen-builder/files/8592869/PRUEBA.DE.BUCLE.json.txt)

## Solution
- Check in file upload if uploader exists when rendering uploader-drop 

## How to Test
Test the steps above

**Working video**

https://user-images.githubusercontent.com/90727999/166001430-e74d3531-48b5-4fad-984e-79179587e1e3.mov


## Related Tickets & Packages
- [FOUR-6039](https://processmaker.atlassian.net/browse/FOUR-6039)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
