### PR TITLE
FOUR-6019: File Upload does not show the upload progress of a large file

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -287,7 +287,7 @@ export default {
       disabled: false,
       files: [],
       nativeFiles: {},
-      uploading: false
+      uploading: false, 
     };
   },
   methods: {

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -33,8 +33,13 @@
         <span v-if="validation === 'required' && !value" class="required">{{ $t('Required') }}</span>
       </uploader-drop>
       <uploader-list>
-        <template>
-          <ul>
+        <template slot-scope = "{ fileList }">
+          <ul v-if="uploading">
+            <li v-for="file in fileList" :key="file.id">
+              <uploader-file :file="file" :list="true"/>
+            </li>
+          </ul>
+          <ul v-else>
             <li v-for="(file, i) in files " :key="i" :data-cy="file.id">
               <div class="">
                 <div class="" style="display:flex; background:rgb(226 238 255)">
@@ -282,6 +287,7 @@ export default {
       disabled: false,
       files: [],
       nativeFiles: {},
+      uploading: false
     };
   },
   methods: {
@@ -470,6 +476,7 @@ export default {
       }
     },
     fileUploaded(rootFile, file, message) {
+      this.uploading = false;
       let name = file.name;
       if (message) {
         const msg = JSON.parse(message);
@@ -511,6 +518,7 @@ export default {
       return null;
     },
     start() {
+      this.uploading = true;
       if (this.parentRecordList(this) === null) {
         this.row_id = null;
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a screen with 2 file uploads: one configured as single upload, the other as multiple upload
- Create a process that uses this screen
- Start the process and upload files (better large ones > 10 MB)

*Current behavior:* 
Files are uploaded but there is no clue that the file is being uploaded - no progress bar is displayed.

Expected behavior: 
When loading a file, a progress bar should be displayed
![image](https://user-images.githubusercontent.com/14875032/166710930-436ad3df-b597-454b-b2ac-842f4d66255f.png)


## Solution
- Render the filesList array of the simple upload component to display the files while they are being uploaded.


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-6019](https://processmaker.atlassian.net/browse/FOUR-6019)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
