### PR TITLE
Allow ability to download HTML file generated by a script in the request File Manager preview

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -175,6 +175,11 @@ export default {
       const fileId = this.value ? this.value : _.get(this.requestData, this.fileDataName, null);
       let endpoint = this.endpoint;
       
+      if (this.requestFiles) {
+        this.filesInfo.push(_.get(this.requestFiles, this.fileDataName, null));
+        return;
+      }
+      
       if (!this.requestId || !fileId) {
         return;
       }


### PR DESCRIPTION
## Issue & Reproduction Steps

Ticket: [FOUR-6022](https://processmaker.atlassian.net/browse/FOUR-6022)

HTML files cannot be previewed by PM4, but they can be downloaded. In this case the download button does not appear, like in previous versions. 

Expected behavior: 

The download button appears and allows downloading of the generated HTML file.

Actual behavior: 

The download button does **NOT** appear. The user is unable to download the generated HTML file.

## Solution
- There was a `requestFiles` variable that was not being accounted for with the refactor of the file download. This variable contained all of the file information needed. The solution is to include the `requestFiles` variable in the `filesInfo` array, allowing the proper file info to be displayed for download. 

## How to Test
Test the steps above

1. Import this process: [process Generated FIle H.txt](https://github.com/ProcessMaker/screen-builder/files/8626581/process.Generated.FIle.H.txt). (replace the .txt with .json)
2. Run the process

Expected behavior: 

The download button appears and allows downloading of the generated HTML file.


## Related Tickets & Packages
NONE

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
