### PR TITLE
Bugfix/FOUR-5949: Upload File Size Loading Bar not fitting inside the auxiliary screen

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -38,7 +38,7 @@
             <li v-for="(file, i) in files " :key="i" :data-cy="file.id">
               <div class="">
                 <div class="" style="display:flex; background:rgb(226 238 255)">
-                  <div v-if="nativeFiles[file.id]" style="flex: 1" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
+                  <div v-if="nativeFiles[file.id]" style="flex: 1" class="overflow-hidden" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
                     <uploader-file :file="nativeFiles[file.id]" :list="true" />
                   </div>
                   <div v-else style="flex: 1">
@@ -378,7 +378,7 @@ export default {
         }
       }
     },
-    async removeFile(file) { 
+    async removeFile(file) {
       const id = file.id;
       const token = file.token ? file.token : null;
 
@@ -386,13 +386,13 @@ export default {
       if (!isNaN(id)) {
         await this.$dataProvider.deleteFile(id, token);
       }
-      
+
       this.removeFromFiles(id);
     },
     removeFromFiles(id) {
       const idx = this.files.findIndex(f => f.id === id);
       this.$delete(this.files, idx);
-      
+
       if (this.nativeFiles[id]) {
         if (this.$refs.uploader) {
           this.$refs.uploader.uploader.removeFile(this.nativeFiles[id]);
@@ -478,13 +478,13 @@ export default {
         if (this.collection) {
           id = msg.id;
         }
-        
+
         const fileInfo = {
           id,
           file_name: name,
           mime_type: rootFile.fileType,
         };
-       
+
         this.$set(this.nativeFiles, id, rootFile);
         this.addToFiles(fileInfo);
       } else {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Import the attached process
- Set up configuration
- Run request


**Current behavior** 
Uploading bar does not fit

![Screenshot from 2022-04-13 15-56-57](https://user-images.githubusercontent.com/90727999/166932526-34e653fb-4b22-4ebc-8f81-eb0dab35538d.png)

**Expected behavior** 
Uploading bar should fit

![Screenshot from 2022-04-13 16-17-25](https://user-images.githubusercontent.com/90727999/166932496-b093b3cb-397a-4677-8659-7cb2196cc42f.png)

## Solution
- Added overflow hidden class

**Working video**

https://user-images.githubusercontent.com/90727999/166932853-b7ca5efd-7a56-4429-81e7-ca8b90987e58.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-5949](https://processmaker.atlassian.net/browse/FOUR-5949)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
