### PR TITLE
Bugfix FOUR-6123 - Fix file preview refresh on new record and loop.

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -268,6 +268,7 @@ export default {
             this.loading = false;
           });
       }
+      this.loading = false;
     },
     setFileInfoFromCache() {
       const info = _.get(window.ProcessMaker.CollectionData, this.prefix + this.name, null);


### PR DESCRIPTION
## Issue & Reproduction Steps

The File Preview is refreshed with each row add/edit and when we add a new item in the loop.

Steps to Reproduce:

1. Import process the attached process from JIRA.
2. Start a new request
3. Click on ADD of record list
4. Upload files in file upload
5. Click on the + of the loop
6. Upload a new file

Expected behavior: 
- The file preview control should not be refreshed with each record list row edit, nor when we load a new file in the loop item.

## Solution
1. The loading flag is set to false, to avoid an infinite loading state in the FileDownload component and File Preview.

## How to Test
- Please follow the reproduction steps of above.

NOTE: Branches:
-  `4.1.27-patch4` in PM Core.
- `bugfix/FOUR-6123` in Package Files.

Working video:

https://user-images.githubusercontent.com/90741874/166939608-9e119871-0a6b-411e-b855-4a442534bc9b.mov

## Related Tickets & Packages
- [FOUR-6123](https://processmaker.atlassian.net/browse/FOUR-6123)
- [Package Files Pull Request](https://github.com/ProcessMaker/package-files/pull/76)