### PR TITLE
FOUR-6050: Interstitial does not route to next task on sub-processes

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -327,17 +327,26 @@ export default {
               this.redirecting = task.process_request_id;
               this.$emit('redirect', task.id, true);
               return;
-            } else if (this.task && requestId == this.task.process_request_id && this.parentRequest && this.task.process_request.status === 'COMPLETED') {
-              // Only emit completed after getting the subprocess tasks and there are no tasks and process is completed
-              this.$emit('completed', this.parentRequest);
+            } else {
+              this.emitIfTaskCompleted(requestId);
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;
-          } else if (this.parentRequest) {
+          } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.parentRequest);
           }
         });
     },
+    emitIfTaskCompleted(requestId) {
+      // Only emit completed after getting the subprocess tasks and there are no tasks and process is completed
+      if (this.task
+          && this.parentRequest
+          && requestId == this.task.process_request_id
+          && this.task.process_request.status === 'COMPLETED') {
+        this.$emit('completed',  this.parentRequest);
+      }
+    },
+
     classHeaderCard(status) {
       let header = 'bg-success';
       switch (status) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -346,7 +346,6 @@ export default {
         this.$emit('completed',  this.parentRequest);
       }
     },
-
     classHeaderCard(status) {
       let header = 'bg-success';
       switch (status) {

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -577,7 +577,7 @@ describe('Task component', () => {
                        (DNAT)
    After childTask1 and not pending tasks should redirect to parent Request
   */
-  it('Subprocess without pending task should redirect to parent request', () => {
+  it.only('Subprocess without pending task should redirect to parent request', () => {
     cy.server();
     cy.route(
       'GET',

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -577,7 +577,7 @@ describe('Task component', () => {
                        (DNAT)
    After childTask1 and not pending tasks should redirect to parent Request
   */
-  it.only('Subprocess without pending task should redirect to parent request', () => {
+  it('Subprocess without pending task should redirect to parent request', () => {
     cy.server();
     cy.route(
       'GET',

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -394,6 +394,75 @@ describe('Task component', () => {
   });
 
   /* DNAT = Display Next Assigned Task
+   parentTask1                                                     parentTask2
+              \_______childTask1___scriptTask____childTask2_______/
+                        (DNAT)
+  */
+  it('Task with display next assigned task checked in subprocess and no pending task and status closed or open should redirect to parent requests', () => {
+    cy.server();
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested',
+      {
+        id: 1,
+        advanceStatus: 'open',
+        component: 'task-screen',
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: 'ACTIVE',
+        },
+      }
+    );
+
+    cy.visit('/?scenario=TaskRedirect', {});
+
+    cy.wait(2000);
+    cy.get('.form-group').find('button').click();
+
+    cy.route('PUT', 'http://localhost:8080/api/1.0/tasks/1').then(function() {
+      let responseDataTask1 = {
+        'status': 'CLOSED',
+        'process_request_id': 2,
+        'id': 1,
+        'screen': SingleScreen.screens[0],
+        'allow_interstitial': true,
+        'interstitial_screen': InterstitialScreen.screens[0],
+        'parent_request_id': 1,
+      };
+
+      getTask(
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested',
+        responseDataTask1
+      );
+
+      getTasks(
+        'http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1',
+        null
+      );
+
+      let responseDataTask2 = {
+        'status': 'ACTIVE',
+        'process_request_id': 2,
+        'taskId': 2,
+        'screen': Screens.screens[0],
+        'allow_interstitial': false,
+        'interstitial_screen': null,
+      };
+
+      getTask(
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested',
+        responseDataTask2
+      );
+
+      cy.wait(2000);
+      cy.reload();
+    });
+
+    cy.url().should('eq', 'http://localhost:8080/requests/1');
+  });
+
+  /* DNAT = Display Next Assigned Task
    parentTask1                           parentTask2
               \_______childTask1_______/
                         (DNAT)


### PR DESCRIPTION
## Issue & Reproduction Steps
- Import this process 
[MainAndSubprocess.zip](https://github.com/ProcessMaker/screen-builder/files/8662584/MainAndSubprocess.zip)
- Run the main process
- Execute until the first task of the subprocess

Expected behavior: 
Task 2 of sub-process should be displayed after the script is completed 

Actual behavior: 
Interstitial does not route to next task on sub-processes, If the sub-process has a script task 
## Solution
-

## How to Test
- Test the steps above
- Test with different processes: processes withou and without subprocess, with and without interstitial. Some processes to test:
[testProcesses.zip](https://github.com/ProcessMaker/screen-builder/files/8662650/testProcesses.zip)


## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-6050](https://processmaker.atlassian.net/browse/FOUR-6050)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
