### PR TITLE
Bugfix/FOUR-622: Forms in the Detail review tab allow for checkbox toggle modification

### DIFF
--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -92,6 +92,27 @@ export default {
 
       });
     },
+    disableForm(config) {
+      config.forEach(item => {
+
+        //If the element has containers
+        if (Array.isArray(item)) {
+          this.disableForm(item);
+        }
+
+        //If the element has items
+        if (item.items) {
+          this.disableForm(item.items);
+        }
+
+        //Disable element
+        if (item && item.config) {
+          item.config.disabled = true;
+          item.config.readonly = true;
+          item.config.editable = false;
+        }
+      });
+    },
     loadScreen(id) {
       this.config = defaultConfig;
       this.computed = [];
@@ -108,6 +129,10 @@ export default {
             this.customCSS = response.data.custom_css;
             this.watchers = response.data.watchers;
             this.screenTitle = response.data.title;
+
+            if (this.$attrs['disabled']) {
+              this.disableForm(this.config);
+            }
 
             if (this.ancestorScreens.includes(this.screenTitle)) {
               globalObject.ProcessMaker.alert(`Rendering of nested "${this.screenTitle}" screen was disallowed to prevent loop.`, 'warning');


### PR DESCRIPTION
## Issue & Reproduction Steps

If a form has a toggle/checkbox, this is not read-only when the submitted form is reviewed in the Forms tab. When you preview the submitted you can actually modify the toggle value. Which, if you have visibility rules added to the toggle value, will also trigger in the Form preview. 

- Create a screen with some Checkbox/Toggle elements
- You can add some Visibility Rules
- Create another screen and add a Nested screen with the previous screen configured
- Add the screen to a process
- Run a request and complete the task
- Go to Form tab and then expand the details
- Checkbox and toggle elements should be disable also for nested screen

## Solution
- Disable elements in nested screens

**Working video**

https://user-images.githubusercontent.com/90727999/168336641-02cc4b20-7d93-45a5-89ec-43af3745e394.mov

## How to Test
Test the steps above
- Create different scenarios, Nested screens inside nested screens, or inside Loops

## Related Tickets & Packages
- [FOUR-622](https://processmaker.atlassian.net/browse/FOUR-622)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
