### PR TITLE
Bugfix FOUR-6158 - Error message of validation does not disappear with pagination

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -38,10 +38,11 @@ export default {
   computed: {
     classList() {
       let variant = this.variant || 'primary';
+      let isInvalid = this.$store.getters['globalErrorsModule/isValidScreen'] === false;
       return {
         btn: true,
         ['btn-' + variant]: true,
-        disabled: this.errors,
+        disabled: this.event === 'submit' && isInvalid,
       };
     },
     options() {

--- a/src/mixins/extensions/PageNavigate.js
+++ b/src/mixins/extensions/PageNavigate.js
@@ -4,6 +4,7 @@ export default {
     pageNavigate() {},
     pageNavigationProperties({ properties }) {
       properties['@page-navigate'] = 'pageNavigate';
+      properties[':validate'] = '$v';
     },
     pageNavigationBuild(screen) {
       this.addData(screen, 'currentPage__', 'this._initialPage');
@@ -19,7 +20,7 @@ export default {
   mounted() {
     this.extensions.push({
       onloadproperties(params) {
-        if (params.componentName === 'FormButton') {
+        if (params.element.component === 'FormButton' && params.element.config.event === 'pageNavigate') {
           this.pageNavigationProperties(params);
         }
       },


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen or import the attached file from JIRA.
2. Add more that one control with required field.
3. Create a page navigation
4. On the second page put the submit button.
5. Press preview button.

Expected behavior: 
Message error should disappears, when the fields are fixed in pagination.

Actual behavior: 
Message error  does not disappears, when the fields are fixed in pagination.

## Solution
- Added code to perform the necessary validations when there's only one FormButton of Nagivation type.
- Improved the way to set the disabled state for a FormButton of submit type.

## How to Test
Test the steps of above.

Working Video:

https://user-images.githubusercontent.com/90741874/168863189-8df59a57-b3b0-4abd-9033-5404b592f572.mov

## Related Tickets & Packages
- [FOUR-6158](https://processmaker.atlassian.net/browse/FOUR-6158)
