### PR TITLE
Bugfix/FOUR-5949: Upload File Size Loading Bar not fitting inside the auxiliary screen

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -46,7 +46,7 @@
                   <div v-if="nativeFiles[file.id]" style="flex: 1" class="overflow-hidden" :data-cy="file.file_name.replace(/[^0-9a-zA-Z\-]/g, '-')">
                     <uploader-file :file="nativeFiles[file.id]" :list="true" />
                   </div>
-                  <div v-else style="flex: 1">
+                  <div v-else class="text-truncate" :title="file.file_name" style="flex: 1">
                     <i class="fas fa-paperclip"/> {{ file.file_name }}
                   </div>
                   <div class="pt-1">
@@ -287,7 +287,7 @@ export default {
       disabled: false,
       files: [],
       nativeFiles: {},
-      uploading: false, 
+      uploading: false,
     };
   },
   methods: {


### PR DESCRIPTION
## Issue & Reproduction Steps

Please see Paola comment on https://processmaker.atlassian.net/browse/FOUR-5949
When **editing** a record that have a fileupload with a large name, the file name was not cut and not fitting in the screen

## Solution
- Added text-truncate to filename

**Working video**

https://user-images.githubusercontent.com/90727999/169105820-8a383ea1-e6d9-4899-b2bd-041fa38c7073.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-5949](https://processmaker.atlassian.net/browse/FOUR-5949)