### PR TITLE
Bugfix/FOUR-6284: The button to upload files in public files is not visible

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -18,7 +18,7 @@
     >
       <uploader-unsupport/>
 
-      <uploader-drop v-if="this.$refs['uploader']" class="form-control-file">
+      <uploader-drop v-if="uploaderLoaded" class="form-control-file">
         <p>{{ $t('Drop a file here to upload or') }}</p>
         <uploader-btn
           :attrs="nativeButtonAttrs"
@@ -287,10 +287,13 @@ export default {
       disabled: false,
       files: [],
       nativeFiles: {},
-      uploading: false, 
+      uploading: false,
     };
   },
   methods: {
+    uploaderLoaded() {
+      return this.$refs['uploader'];
+    },
     setFiles() {
       if (_.isEqual(this.filesData, this.files)) {
         return;


### PR DESCRIPTION
## Issue & Reproduction Steps

Steps to Reproduce:
- Go to admin
- Click on File manager
- Click on public files 
- Click on Add public files  

Current Behavior:
The button to upload files in public files is not there.
We can't upload files. 

Expected Behavior:
You have to be able to upload files in public files

## Solution
- Moved checking if uploader exists to a method to avoid issue in modal

**Working video**

https://user-images.githubusercontent.com/90727999/169551193-8babc87f-196c-4f0d-bb48-2f29400de165.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6284](https://processmaker.atlassian.net/browse/FOUR-6284)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
