### PR TITLE
 Bugfix FOUR-6101 - Error validations are not marked with the color selected in Customize UI (ScreenBuilder) 

### DIFF
--- a/src/components/inspector/form-multiselect.vue
+++ b/src/components/inspector/form-multiselect.vue
@@ -57,9 +57,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss">
-  .is-invalid .multiselect__tags {
-    border-color: red !important;
-  }
-</style>

--- a/src/components/inspector/form-multiselect.vue
+++ b/src/components/inspector/form-multiselect.vue
@@ -57,3 +57,9 @@ export default {
   },
 };
 </script>
+
+<style lang="scss">
+  .is-invalid .multiselect__tags {
+    border-color: red;
+  }
+</style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List and signature controls, still mark in red, the validation of the required field

1. Go to admin
2. Open Customize UI
3. Select a color different to red in "Danger" option
4. Save the changes
5. Create a Screen
6. Add controls like(line input, textarea, select list, signature)
7. Add Required validation in each control
8. Press preview button

## Solution
- Remove `!important` from the multiselect, this way it will use the custom style from Core.

## Note: 

When `package-savedsearch` is installed you will notice it still has the inline style `border: red !important`. That's because the package uses `"@processmaker/screen-builder": "^0.24.2",`. We should update screen-builder version in package savedsearch when changes in ScreenBuilder are merged.

## How to Test
- Compile assets, please run `npm link` for screen builder and vue-form-elements.

## Related Tickets & Packages
- [FOUR-6101](https://processmaker.atlassian.net/browse/FOUR-6101)
- [Core Pull Request](https://github.com/ProcessMaker/processmaker/pull/4397)
- [Vue form elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/340)