### PR TITLE
Fix backspacing a decimal character in currency input

### DIFF
--- a/src/components/renderer/form-input-masked.vue
+++ b/src/components/renderer/form-input-masked.vue
@@ -1,5 +1,5 @@
 <template>
-  <input type="text" class="form-control" v-model="currencyValue" ref="currencyInput" >
+  <input type="text" class="form-control" @keyup="keyup" v-model="currencyValue" ref="currencyInput" >
 </template>
 
 <script>
@@ -64,6 +64,13 @@ export default {
       }).mask(this.currencyInput);
       if (this.value) {
         this.currencyInput.inputmask.setValue(this.value);
+      }
+    },
+    keyup(event) {
+      // Workaround for a bug in inputmask where backspacing after
+      // the decimal does not trigger an input event
+      if (this.currencyValue !== event.target.value) {
+        this.currencyValue = event.target.value;
       }
     },
   },

--- a/tests/e2e/specs/FormInput.spec.js
+++ b/tests/e2e/specs/FormInput.spec.js
@@ -57,6 +57,20 @@ describe('Form Input', () => {
       form_input_1: 1234,
     });
   });
+  it('Data type Currency when backspacing a decimal digit', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Currency');
+    cy.get('[data-cy=mode-preview]').click();
+
+    cy.get('[name=form_input_1]:visible').type('1.1');
+    cy.get('[data-cy=preview-data-input]').click(); // blur the text box
+    cy.assertPreviewData({ form_input_1: 1.1 });
+
+    cy.get('[name=form_input_1]:visible').type('{home}{rightArrow}{rightArrow}{rightArrow}{backspace}');
+    cy.assertPreviewData({ form_input_1: 1 });
+  });
   it('Validation rule', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');


### PR DESCRIPTION
## Issue & Reproduction Steps

Backspacing a character after the decimal was not working. See https://processmaker.atlassian.net/browse/FOUR-5425

Expected behavior: see ticket

Actual behavior: see ticket

## Solution
This is a bug in the inputmask package. Workaround is to listen for the keyup event and manually set the currencyValue if it's not the same

## How to Test
Follow video in ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5425

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
