### PR TITLE
FOUR-5877 Mustache doesn't work on input label

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -103,6 +103,7 @@ export default {
     },
     mustache(text) {
       try {
+        const test = !!this._parent ? Object.assign({}, this._parent) : Object.assign({_parent: this._parent}, this.vdata);
         const data = new Proxy(this, {
           get(target, name) {
             if (name === '_parent') {
@@ -111,8 +112,12 @@ export default {
               return target.vdata[name];
             }
           },
+          ownKeys(target) { // to intercept property list
+            return Object.keys(target).filter(key => !key.startsWith('_'));
+          },
         });
-        return text && Mustache.render(text, data);
+        console.log(Mustache.render(text, test));
+        return text && Mustache.render(text, test);
       } catch (e) {
         return 'MUSTACHE: ' + e.message;
       }

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -103,21 +103,8 @@ export default {
     },
     mustache(text) {
       try {
-        const test = !!this._parent ? Object.assign({}, this._parent) : Object.assign({_parent: this._parent}, this.vdata);
-        const data = new Proxy(this, {
-          get(target, name) {
-            if (name === '_parent') {
-              return target._parent;
-            } else {
-              return target.vdata[name];
-            }
-          },
-          ownKeys(target) { // to intercept property list
-            return Object.keys(target).filter(key => !key.startsWith('_'));
-          },
-        });
-        console.log(Mustache.render(text, test));
-        return text && Mustache.render(text, test);
+        const data = !!this._parent ? Object.assign({}, this._parent) : Object.assign({_parent: this._parent}, this.vdata);
+        return text && Mustache.render(text, data);
       } catch (e) {
         return 'MUSTACHE: ' + e.message;
       }

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -103,7 +103,7 @@ export default {
     },
     mustache(text) {
       try {
-        const data = !!this._parent ? Object.assign({}, this._parent) : Object.assign({_parent: this._parent}, this.vdata);
+        const data = Object.assign({_parent: this._parent}, this.vdata);
         return text && Mustache.render(text, data);
       } catch (e) {
         return 'MUSTACHE: ' + e.message;
@@ -179,7 +179,7 @@ export default {
           this.$set(
             object,
             attr,
-            setValue
+            setValue,
           );
 
           object = get(object, attr);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Input label with a variable set in a label should have the variable visible in the label

Actual behavior: 
Variable set is not visible in the label

## Solution
- Took a look at https://github.com/ProcessMaker/screen-builder/pull/1155 and actually reverted the change and seems to be working. 
Maybe from January since that PR until today, another PR actually fixed the issue at hand?

## How to Test
Test the steps above
- Create a Rich Text
- Set a {{ variable }}
- Create a input line
- In the label input, set a {{ variable }} at the end
- Go to preview
- in the editor json, set 
```json
{
  "variable" : "hello"
}
```


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5877
- https://processmaker.atlassian.net/browse/FOUR-5084

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
