### PR TITLE
Bugfix 6101-B: Error validations are not marked with the color selected in Customize UI 

### DIFF
--- a/src/components/inspector/form-multiselect.vue
+++ b/src/components/inspector/form-multiselect.vue
@@ -45,7 +45,7 @@ export default {
   computed: {
     classList() {
       return {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+        'has-errors': (this.validator && this.validator.errorCount) || this.error,
       };
     },
   },
@@ -59,7 +59,7 @@ export default {
 </script>
 
 <style lang="scss">
-  .is-invalid .multiselect__tags {
+  .has-errors .multiselect__tags {
     border-color: red;
   }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List still mark in red the validation of the required field

1. Go to admin
2. Open Customize UI
3. Select a color different to red in "Danger" option
4. Save the changes
5. Create a Screen
6. Add controls like(line input, textarea, select list, signature)
7. Add Required validation in each control
8. Press preview button

## Solution
- Another class is used for errors, since other packages like saved search overwrite using inline css and the !important property.

## How to Test
- Compile assets, please run `npm link` for screen builder and vue-form-elements.

## Related Tickets & Packages
- [FOUR-6101](https://processmaker.atlassian.net/browse/FOUR-6101)