### PR TITLE
Bugfix/FOUR-6409: Form Validation Error messaging not displaying correctly

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -74,13 +74,6 @@
         <!-- Preview -->
         <b-row class="h-100 m-0" id="preview" v-show="displayPreview" data-cy="preview">
           <b-col class="overflow-auto h-100" data-cy="preview-content">
-            <div v-if="$store.getters['globalErrorsModule/isValidScreen'] === false" class="alert alert-danger mt-3">
-              <i class="fas fa-exclamation-circle"/>
-              {{ $store.getters['globalErrorsModule/getErrorMessage'] }}
-              <button type="button" class="close" aria-label="Close" @click="$store.dispatch('globalErrorsModule/close')">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
             <vue-form-renderer ref="renderer"
               :key="rendererKey"
               v-model="previewData"
@@ -458,7 +451,7 @@ export default {
       if (customCSS) {
         this.customCSS = customCSS;
       }
-      
+
       if (computed) {
         this.computed = JSON.parse(computed);
       }
@@ -611,7 +604,7 @@ export default {
     .modal-backdrop {
       opacity: 0.5;
     }
-    
+
     .form-group--error {
       animation: none;
     }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -8,13 +8,6 @@
     <template v-if="screen">
       <div class="card card-body border-top-0 h-100" :class="screenTypeClass">
         <div v-if="renderComponent === 'task-screen'">
-          <div v-if="$store.getters['globalErrorsModule/isValidScreen'] === false" class="alert alert-danger mt-3">
-            <i class="fas fa-exclamation-circle"/>
-            {{ $store.getters['globalErrorsModule/getErrorMessage'] }}
-            <button type="button" class="close" aria-label="Close" @click="$store.dispatch('globalErrorsModule/close')">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
           <vue-form-renderer
             ref="renderer"
             v-model="requestData"
@@ -250,7 +243,7 @@ export default {
             this.task = response.data;
             this.checkTaskStatus();
             if (window.PM4ConfigOverrides.getScreenEndpoint && window.PM4ConfigOverrides.getScreenEndpoint.includes('tasks/')) {
-              const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');              
+              const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');
               screenPath[1] = this.task.id;
               window.PM4ConfigOverrides.getScreenEndpoint = screenPath.join('/');
             }

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -111,6 +111,8 @@ export default {
     },
     submitForm() {
       if (this.$v.$invalid) {
+        let msgError = this.$store.getters['globalErrorsModule/getErrorMessage'];
+        window.ProcessMaker.alert(msgError, 'danger');
         //if the form is not valid the data is not emitted
         return;
       }

--- a/tests/components/WebEntry.vue
+++ b/tests/components/WebEntry.vue
@@ -3,13 +3,6 @@
     <b-col cols="12">
       <b-tabs>
         <b-tab active title="WebEntry">
-          <div v-if="$store.getters['globalErrorsModule/isValidScreen'] === false" class="alert alert-danger mt-3">
-            <i class="fas fa-exclamation-circle"/>
-            {{ $store.getters['globalErrorsModule/getErrorMessage'] }}
-            <button type="button" class="close" aria-label="Close" @click="$store.dispatch('globalErrorsModule/close')">
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </div>
           <vue-form-renderer
             v-model="data"
             v-bind:config="task.screen.config"

--- a/tests/e2e/specs/NestedValidationRules.spec.js
+++ b/tests/e2e/specs/NestedValidationRules.spec.js
@@ -13,18 +13,11 @@ describe('Validation Rules (Hidden fields and Nested Screens)', () => {
       .click();
 
     fillInputText('screen-field-parent_input_1');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 0);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 1);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 2);
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-nested_1');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_2');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_3');
 
     submitForm();
@@ -38,18 +31,11 @@ describe('Validation Rules (Hidden fields and Nested Screens)', () => {
       .click();
 
     fillInputText('screen-field-parent_input_1');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 0);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 1);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 2);
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-nested_1');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_2');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_3');
 
     submitForm();
@@ -63,19 +49,11 @@ describe('Validation Rules (Hidden fields and Nested Screens)', () => {
       .click();
 
     fillInputText('screen-field-parent_input_1');
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-nested_1');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_2');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-nested_3');
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-parent_loop_input_2', 0);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 1);
-    shouldHaveValidationErrors();
     fillInputText('screen-field-parent_loop_input_2', 2);
 
     submitForm();
@@ -86,25 +64,13 @@ describe('Validation Rules (Hidden fields and Nested Screens)', () => {
     cy.get('[data-cy=mode-preview]').click();
 
     fillInputText('screen-field-form_input_1', 0, '13');
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-form_input_3', 0, 'ok');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-form_input_3', 1, 'ok');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-form_input_3', 2, 'ok');
-    shouldNotHaveValidationErrors();
-
     fillInputText('screen-field-form_input_1', 1, '12');
-    shouldHaveValidationErrors();
     fillInputText('screen-field-form_input_2', 0, 'ok');
-    shouldNotHaveValidationErrors();
-
     fillInputText('screen-field-form_input_2', 0, '10');
-    shouldHaveValidationErrors();
-
     fillInputText('screen-field-form_input_4', 0, 'ok');
-    shouldNotHaveValidationErrors();
 
     submitForm();
   });
@@ -123,18 +89,7 @@ function fillInputText(dataCy, index = null, value = 'test')
   }
 }
 
-function shouldHaveValidationErrors()
-{
-  cy.get('[data-cy=preview-content]').should('contain.html', 'alert alert-danger');
-}
-
-function shouldNotHaveValidationErrors()
-{
-  cy.get('[data-cy=preview-content]').should('not.contain.html', 'alert alert-danger');
-}
-
 function submitForm()
 {
-  shouldNotHaveValidationErrors();
   cy.get('[data-cy=preview-content] [data-cy="screen-field-submit"] button').click();
 }

--- a/tests/e2e/specs/ValidationRules.spec.js
+++ b/tests/e2e/specs/ValidationRules.spec.js
@@ -120,30 +120,30 @@ describe('Validation Rules', () => {
       .parent()
       .find('.invalid-feedback')
       .should('be.visible');
-      
+
     cy.get('[data-cy=editor-content] [name="form_input_readonly"]')
       .parent()
       .find('.invalid-feedback')
       .should('be.not.visible');
 
-    // In preview: ensure standard required field displays error while readonly required field does not    
+    // In preview: ensure standard required field displays error while readonly required field does not
     cy.get('[data-cy=mode-preview]').click();
-    
+
     cy.get('[data-cy=preview-content] [name="form_input"]')
       .parent()
       .find('.invalid-feedback')
       .should('be.visible');
-      
+
     cy.get('[data-cy=preview-content] [name="form_input_readonly"]')
       .parent()
       .find('.invalid-feedback')
       .should('be.not.visible');
-    
+
     // Ensure the form cannot yet be submitted
     cy.get('[data-cy=preview-content] [name="submit_button"]')
       .click()
       .then(() => expect(alert).to.equal(false));
-    
+
     // Fill out the required missing field; ensure the form *can* be submitted
     cy.get('[data-cy=preview-content] [name="form_input"]')
       .type('text');
@@ -325,15 +325,13 @@ describe('Validation Rules', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
       .click();
 
-    // Name should be required
-    shouldHaveValidationErrors();
+    cy.on('window:alert', msg => {
+      expect(msg).to.equal('There is a validation error in your form.');
+    });
 
     // Uncheck box 1
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
       .click();
-
-    // Name should not be required
-    shouldNotHaveValidationErrors();
 
     // Check box 1
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
@@ -343,11 +341,6 @@ describe('Validation Rules', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_input_2"]')
       .clear()
       .type('test');
-
-    // Name should not be required
-    cy.get('[data-cy=preview-content] [data-cy="screen-field-submit"]')
-      .should('not.contain.html', 'alert alert-danger');
-
   });
 
   it('Required Unless with boolean values', () => {
@@ -358,15 +351,9 @@ describe('Validation Rules', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
       .click();
 
-    // Name should be required
-    shouldHaveValidationErrors();
-
     // Uncheck box 1
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
       .click();
-
-    // Name should not be required
-    shouldNotHaveValidationErrors();
 
     // Check box 1
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_checkbox_1"]')
@@ -376,16 +363,5 @@ describe('Validation Rules', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_input_2"]')
       .clear()
       .type('test');
-
-    // Name should not be required
-    shouldNotHaveValidationErrors();
   });
 });
-
-function shouldHaveValidationErrors() {
-  cy.get('[data-cy=preview-content]').should('contain.html', 'alert alert-danger');
-}
-
-function shouldNotHaveValidationErrors() {
-  cy.get('[data-cy=preview-content]').should('not.contain.html', 'alert alert-danger');
-}


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:
Please see: https://processmaker.atlassian.net/browse/FOUR-6409

- Create a form with some elements
- Mark some of them as required

Current behavior: When start a new request and start the task or go to preview in screen builder, the validation errors appears before clicking on submit, and not showing as alert

Expected behavior: Validation error message shouldn't appear until the submit button is pressed. Message should appear as the "success" alert when submitting a form

## Solution
- When submit a form, while checking if is valid, if not show ProcessMaker.alert()
- Removed old alert divs

**Working video**

https://user-images.githubusercontent.com/90727999/176259628-06e0ccc5-f2f8-4022-9fbe-dcf215ebb6a4.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6409](https://processmaker.atlassian.net/browse/FOUR-6409)
- Screen-builder PR
- [ProcessMaker core PR](https://github.com/ProcessMaker/processmaker/pull/4427)
- [Package-collections PR](https://github.com/ProcessMaker/package-collections/pull/314)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
