### PR TITLE
FOUR-6069 - Update lodash for security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.29.0",
       "dependencies": {
         "is-proxy": "^1.0.6",
-        "lodash": "^4.17.20",
+        "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.27",
         "scrollparent": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "is-proxy": "^1.0.6",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.27",
     "scrollparent": "^2.0.1",


### PR DESCRIPTION
## Issue & Reproduction Steps

It's necessary upgrade to Lodash version **4.17.21** or later to avoid Multiple Vulnerabilities and Prototype Pollution Vulnerability.

## Solution
- Updated lodash to latest version `npm update lodash --save` 

## Related Tickets & Packages
- [FOUR-6069](https://processmaker.atlassian.net/browse/FOUR-6069)
- [Modeler Pull Request](https://github.com/ProcessMaker/modeler/pull/1446)
- [Core Pull Request](https://github.com/ProcessMaker/processmaker/pull/4428)