### PR TITLE
Bugfix FOUR-6438 - Screen still validates validation rules of hidden controls

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -51,7 +51,7 @@ class Validations {
    hasVisibleContainers(containers) {
     const visibles = containers.filter(container => {
       let visible = true;
-      if (container.config.conditionalHide) {
+      if (!this.data.noData && container.config.conditionalHide) {
         try {
           visible = !!Parser.evaluate(container.config.conditionalHide, this.data);
         } catch (error) {
@@ -252,12 +252,6 @@ class PageNavigateValidations extends Validations {
  */
 class FormElementValidations extends Validations {
   async addValidations(validations) {
-    // Disable validations if parent containers are hidden.
-    const hasVisibleContainers = this.hasVisibleContainers(this.getContainers(this.screen, this.element));
-    if (!hasVisibleContainers) {
-      return false;
-    }
-
     if (this.element.config && this.element.config.readonly) {
       //readonly elements do not need validation
       return;
@@ -269,6 +263,11 @@ class FormElementValidations extends Validations {
     if (!(this.element.config && this.element.config.name && typeof this.element.config.name === 'string' && this.element.config.name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/))) {
       //element invalid
       return;
+    }
+    // Disable validations if parent containers are hidden.
+    const hasVisibleContainers = this.hasVisibleContainers(this.getContainers(this.screen, this.element));
+    if (!hasVisibleContainers) {
+      return false;
     }
     const fieldName = this.element.config.name;
     const validationConfig = this.element.config.validation;

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -33,13 +33,9 @@ class Validations {
    * Check if element/container is visible.
    */
   isVisible() {
-    if (this.element.component === 'FormNestedScreen') {
-      this.data.noData = false;
-    }
-
-    // Disable validations if field is hidden.
+    // Disable validations if field is hidden
     let visible = true;
-    if (!this.data.noData && this.element.config.conditionalHide) {
+    if (this.element.config.conditionalHide) {
       try {
         visible = !!Parser.evaluate(this.element.config.conditionalHide, this.data);
       } catch (error) {
@@ -119,7 +115,8 @@ class FormLoopValidations extends Validations {
     const loopField = get(validations, this.element.config.name);
     loopField['$each'] = {};
     this.checkForSiblings(validations);
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, noData:true }, parentVisibilityRule: this.element.config.conditionalHide, insideLoop: true }).addValidations(loopField['$each']);
+    const firstRow = (get(this.data, this.element.config.name) || [{}])[0];
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, ...firstRow }, parentVisibilityRule: this.element.config.conditionalHide, insideLoop: true }).addValidations(loopField['$each']);
   }
   checkForSiblings(validations) {
     const siblings = [];

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -33,6 +33,10 @@ class Validations {
    * Check if element/container is visible.
    */
   isVisible() {
+    if (this.element.component === 'FormNestedScreen') {
+      this.data.noData = false;
+    }
+
     // Disable validations if field is hidden.
     let visible = true;
     if (!this.data.noData && this.element.config.conditionalHide) {
@@ -43,55 +47,6 @@ class Validations {
       }
     }
     return visible;
-  }
-
-  /**
-   * Check if parent containers are visible.
-   */
-   hasVisibleContainers(containers) {
-    const visibles = containers.filter(container => {
-      let visible = true;
-      if (!this.data.noData && container.config.conditionalHide) {
-        try {
-          visible = !!Parser.evaluate(container.config.conditionalHide, this.data);
-        } catch (error) {
-          visible = false;
-        }
-      }
-      return visible;
-    });
-    
-    return visibles.length === containers.length;
-  }
-
-  getContainers(screen, element) {
-    let containers = [];
-
-    screen.config.forEach(page => {
-      containers = [];
-      if (!page || !page.items) {
-        return;
-      }
-      
-      let elements = [];
-      page.items.forEach(arr => elements.push(arr));
-      while(elements.length) {
-        let item = elements.shift();
-        if (!item.hasOwnProperty('container') && (item.config && item.config.name === element.config.name)) {
-          return true;
-        }
-        
-        if (item.items && item.items.length) {
-          elements.push(...item.items);
-        }
-        
-        if (item.container) {
-          containers.push(item);
-        }
-      }
-    });
-    
-    return containers;  
   }
 }
 
@@ -263,11 +218,6 @@ class FormElementValidations extends Validations {
     if (!(this.element.config && this.element.config.name && typeof this.element.config.name === 'string' && this.element.config.name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/))) {
       //element invalid
       return;
-    }
-    // Disable validations if parent containers are hidden.
-    const hasVisibleContainers = this.hasVisibleContainers(this.getContainers(this.screen, this.element));
-    if (!hasVisibleContainers) {
-      return false;
     }
     const fieldName = this.element.config.name;
     const validationConfig = this.element.config.validation;

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -28,9 +28,7 @@ export default {
         const data = Object.assign({ _parent: this._parent }, this.vdata);
         const isVisible = !!Parser.evaluate(rule, Object.assign({}, data));
 
-        window.setTimeout(() => {
-          this.refreshValidationRulesByName(fieldName, isVisible);
-        }, 1000);
+        this.refreshValidationRulesByName(fieldName, isVisible);
         return isVisible;
       } catch (e) {
         return false;

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -3,7 +3,7 @@ import { debounce } from 'lodash';
 
 export default {
   mounted() {
-    this.refreshValidationRulesByName = debounce(this.refreshValidationRulesByName, 1000);
+    this.refreshValidationRulesByName = debounce(this.refreshValidationRulesByName, 300);
 
     this.$root.$on('refresh-validation-rules', () => {
       this.loadValidationRules();

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -3,7 +3,7 @@ import { debounce } from 'lodash';
 
 export default {
   mounted() {
-    this.refreshValidationRulesByName = debounce(this.refreshValidationRulesByName, 300);
+    this.refreshValidationRulesByName = debounce(this.refreshValidationRulesByName, 500);
 
     this.$root.$on('refresh-validation-rules', () => {
       this.loadValidationRules();
@@ -28,7 +28,9 @@ export default {
         const data = Object.assign({ _parent: this._parent }, this.vdata);
         const isVisible = !!Parser.evaluate(rule, Object.assign({}, data));
 
-        this.refreshValidationRulesByName(fieldName, isVisible);
+        window.setTimeout(() => {
+          this.refreshValidationRulesByName(fieldName, isVisible);
+        }, 250);
         return isVisible;
       } catch (e) {
         return false;


### PR DESCRIPTION
## Issue & Reproduction Steps

Screen still validates validation rules of hidden controls.

1. You can use the next screen for testing purposes (remove .txt extension).

[hidden-errors.json.txt](https://github.com/ProcessMaker/screen-builder/files/9057091/hidden-errors.json.txt)


2. Press preview button
3. Put the next data in **Data Input**

```
{
    "business": [
        {
            "hasBeneficialOwners": "Yes"
        }
    ]
}
```

4. Try to press submit button

Expected behavior: 

- Screen should not validate validation rules for hidden controls, like PM 4.2.24

Actual behavior: 

- Screen still validates validation rules of hidden controls

## Solution
- No need of complex algorithm, fixed allowing NestedScreens to enter isVisible Parser condition.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6438](https://processmaker.atlassian.net/browse/FOUR-6438)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
