### PR TITLE
Bugfix/FOUR-6507: Interstitial keeps loading and the summary is not displayed when having Send Email task as the final task

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -250,7 +250,7 @@ export default {
             this.task = response.data;
             this.checkTaskStatus();
             if (window.PM4ConfigOverrides.getScreenEndpoint && window.PM4ConfigOverrides.getScreenEndpoint.includes('tasks/')) {
-              const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');              
+              const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');
               screenPath[1] = this.task.id;
               window.PM4ConfigOverrides.getScreenEndpoint = screenPath.join('/');
             }
@@ -334,6 +334,8 @@ export default {
             this.nodeId = task.element_id;
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.parentRequest);
+          } else {
+            this.$emit('closed');
           }
         });
     },

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -1,6 +1,6 @@
 module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config);
-  on('file:preprocessor', require('@cypress/code-coverage/use-browserify-istanbul'));
+  on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
   return Object.assign({}, config, {
     fixturesFolder: 'tests/e2e/fixtures',
     integrationFolder: 'tests/e2e/specs',


### PR DESCRIPTION
## Issue & Reproduction Steps
Create a process with 2 tasks with the option **Load Next Assigned task ...** checked, and:
- For Task 1 set assignment rules to User A
- For Task 2 set assignment rules to User B

- Run a request
- Complete the first task.
- Process get stuck in interstitial screen.

Explanation:
When complete the first task and then tries to loadNextAssignedTask for User A, the list of tasks for user A is empty (no pending tasks for user A) so is not redirecting to task list (process is not completed yet because there are another task pending for User B) and process get stuck in interstitial screen.

Expected behavior: 
When process still active (maybe because another user have pending tasks and process is not completed), with Load Next Assigned task option active, after complete Task 1, the process should redirect to task list.

Actual behavior: 
After complete the first task process get stuck in interstitial screen.

## Solution
- In loadNextAssignedTask method after retrieve the list of task for current user (?user_id=${this.userId}), if not pending tasks for the current user AND process still active, redirect to task list.

**Working video**

https://user-images.githubusercontent.com/90727999/182418050-1d9230ca-fedf-4ee1-bfe3-ba62f2a4c7c5.mov

![Screen Shot 2022-08-02 at 12 36 57](https://user-images.githubusercontent.com/90727999/182418190-801ab2dd-5463-43a8-8dd1-6ea66891c7d8.png)


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6507](https://processmaker.atlassian.net/browse/FOUR-6507)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
