### PR TITLE
Bugfix/FOUR-6617: Create PR to address not being able to run cypress locally (screen builder)

### DIFF
--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -1,6 +1,6 @@
 module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config);
-  on('file:preprocessor', require('@cypress/code-coverage/use-browserify-istanbul'));
+  on('file:preprocessor', require('@cypress/code-coverage/use-babelrc'));
   return Object.assign({}, config, {
     fixturesFolder: 'tests/e2e/fixtures',
     integrationFolder: 'tests/e2e/specs',


### PR DESCRIPTION
## Issue & Reproduction Steps
Fixed issue when trying to run cypress in screen builder

![Screen Shot 2022-08-02 at 11 40 48](https://user-images.githubusercontent.com/90727999/185207644-fd437eb3-dd1a-4d67-b94b-a608c0b71c16.png)

## Solution
- Replaced browserify to use babelrc

![Screen Shot 2022-08-17 at 14 46 01](https://user-images.githubusercontent.com/90727999/185207794-a15bf2f3-1ced-4670-95d7-f41eac5a188c.png)

## Related Tickets & Packages
-  [FOUR-6617](https://processmaker.atlassian.net/browse/FOUR-6617)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
