### PR TITLE
Bugfix/FOUR-6675: The task menu container does not display the accordion with the options in 4.2.35

### DIFF
--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -1,52 +1,87 @@
 <template>
   <b-container fluid>
-    <div v-if="displayAsyncLoading" ref="watchersAsynchronous" class="alert alert-light" role="alert">
-      <svg class="lds-gear" width="20px" height="20px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+    <div
+      v-if="displayAsyncLoading"
+      ref="watchersAsynchronous"
+      class="alert alert-light"
+      role="alert"
+    >
+      <svg
+        class="lds-gear"
+        width="20px"
+        height="20px"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        viewBox="0 0 100 100"
+        preserveAspectRatio="xMidYMid"
+      >
         <g transform="translate(50 50)">
           <g transform="rotate(248.825)">
-            <animateTransform attributeName="transform" type="rotate" values="0;360" keyTimes="0;1" dur="4.7s" repeatCount="indefinite"/>
-            <path d="M37.43995192304605 -6.5 L47.43995192304605 -6.5 L47.43995192304605 6.5 L37.43995192304605 6.5 A38 38 0 0 1 35.67394948182593 13.090810836924174 L35.67394948182593 13.090810836924174 L44.33420351967032 18.090810836924174 L37.83420351967032 29.34914108612188 L29.17394948182593 24.34914108612188 A38 38 0 0 1 24.34914108612188 29.17394948182593 L24.34914108612188 29.17394948182593 L29.34914108612188 37.83420351967032 L18.090810836924184 44.33420351967032 L13.090810836924183 35.67394948182593 A38 38 0 0 1 6.5 37.43995192304605 L6.5 37.43995192304605 L6.500000000000001 47.43995192304605 L-6.499999999999995 47.43995192304606 L-6.499999999999996 37.43995192304606 A38 38 0 0 1 -13.09081083692417 35.67394948182593 L-13.09081083692417 35.67394948182593 L-18.09081083692417 44.33420351967032 L-29.34914108612187 37.834203519670325 L-24.349141086121872 29.173949481825936 A38 38 0 0 1 -29.17394948182592 24.34914108612189 L-29.17394948182592 24.34914108612189 L-37.83420351967031 29.349141086121893 L-44.33420351967031 18.0908108369242 L-35.67394948182592 13.090810836924193 A38 38 0 0 1 -37.43995192304605 6.5000000000000036 L-37.43995192304605 6.5000000000000036 L-47.43995192304605 6.500000000000004 L-47.43995192304606 -6.499999999999993 L-37.43995192304606 -6.499999999999994 A38 38 0 0 1 -35.67394948182593 -13.090810836924167 L-35.67394948182593 -13.090810836924167 L-44.33420351967032 -18.090810836924163 L-37.834203519670325 -29.34914108612187 L-29.173949481825936 -24.34914108612187 A38 38 0 0 1 -24.349141086121893 -29.17394948182592 L-24.349141086121893 -29.17394948182592 L-29.349141086121897 -37.834203519670304 L-18.0908108369242 -44.334203519670304 L-13.090810836924195 -35.67394948182592 A38 38 0 0 1 -6.500000000000005 -37.43995192304605 L-6.500000000000005 -37.43995192304605 L-6.500000000000007 -47.43995192304605 L6.49999999999999 -47.43995192304606 L6.499999999999992 -37.43995192304606 A38 38 0 0 1 13.090810836924149 -35.67394948182594 L13.090810836924149 -35.67394948182594 L18.090810836924142 -44.33420351967033 L29.349141086121847 -37.83420351967034 L24.349141086121854 -29.17394948182595 A38 38 0 0 1 29.17394948182592 -24.349141086121893 L29.17394948182592 -24.349141086121893 L37.834203519670304 -29.349141086121897 L44.334203519670304 -18.0908108369242 L35.67394948182592 -13.090810836924197 A38 38 0 0 1 37.43995192304605 -6.500000000000007 M0 -20A20 20 0 1 0 0 20 A20 20 0 1 0 0 -20"/>
+            <animateTransform
+              attributeName="transform"
+              type="rotate"
+              values="0;360"
+              keyTimes="0;1"
+              dur="4.7s"
+              repeatCount="indefinite"
+            />
+            <path
+              d="M37.43995192304605 -6.5 L47.43995192304605 -6.5 L47.43995192304605 6.5 L37.43995192304605 6.5 A38 38 0 0 1 35.67394948182593 13.090810836924174 L35.67394948182593 13.090810836924174 L44.33420351967032 18.090810836924174 L37.83420351967032 29.34914108612188 L29.17394948182593 24.34914108612188 A38 38 0 0 1 24.34914108612188 29.17394948182593 L24.34914108612188 29.17394948182593 L29.34914108612188 37.83420351967032 L18.090810836924184 44.33420351967032 L13.090810836924183 35.67394948182593 A38 38 0 0 1 6.5 37.43995192304605 L6.5 37.43995192304605 L6.500000000000001 47.43995192304605 L-6.499999999999995 47.43995192304606 L-6.499999999999996 37.43995192304606 A38 38 0 0 1 -13.09081083692417 35.67394948182593 L-13.09081083692417 35.67394948182593 L-18.09081083692417 44.33420351967032 L-29.34914108612187 37.834203519670325 L-24.349141086121872 29.173949481825936 A38 38 0 0 1 -29.17394948182592 24.34914108612189 L-29.17394948182592 24.34914108612189 L-37.83420351967031 29.349141086121893 L-44.33420351967031 18.0908108369242 L-35.67394948182592 13.090810836924193 A38 38 0 0 1 -37.43995192304605 6.5000000000000036 L-37.43995192304605 6.5000000000000036 L-47.43995192304605 6.500000000000004 L-47.43995192304606 -6.499999999999993 L-37.43995192304606 -6.499999999999994 A38 38 0 0 1 -35.67394948182593 -13.090810836924167 L-35.67394948182593 -13.090810836924167 L-44.33420351967032 -18.090810836924163 L-37.834203519670325 -29.34914108612187 L-29.173949481825936 -24.34914108612187 A38 38 0 0 1 -24.349141086121893 -29.17394948182592 L-24.349141086121893 -29.17394948182592 L-29.349141086121897 -37.834203519670304 L-18.0908108369242 -44.334203519670304 L-13.090810836924195 -35.67394948182592 A38 38 0 0 1 -6.500000000000005 -37.43995192304605 L-6.500000000000005 -37.43995192304605 L-6.500000000000007 -47.43995192304605 L6.49999999999999 -47.43995192304606 L6.499999999999992 -37.43995192304606 A38 38 0 0 1 13.090810836924149 -35.67394948182594 L13.090810836924149 -35.67394948182594 L18.090810836924142 -44.33420351967033 L29.349141086121847 -37.83420351967034 L24.349141086121854 -29.17394948182595 A38 38 0 0 1 29.17394948182592 -24.349141086121893 L29.17394948182592 -24.349141086121893 L37.834203519670304 -29.349141086121897 L44.334203519670304 -18.0908108369242 L35.67394948182592 -13.090810836924197 A38 38 0 0 1 37.43995192304605 -6.500000000000007 M0 -20A20 20 0 1 0 0 20 A20 20 0 1 0 0 -20"
+            />
           </g>
         </g>
       </svg>
-      {{ $t('Loading...') }}
+      {{ $t("Loading...") }}
     </div>
-    <component ref="component" :is="component" :vdata="value" :_parent="_parent" :_initial-page="currentPage"
+    <component
+      ref="component"
+      :is="component"
+      :vdata="value"
+      :_parent="_parent"
+      :_initial-page="currentPage"
       @submit="submit"
       @asyncWatcherTriggered="onAsyncWatcherOn"
       @asyncWatcherCompleted="onAsyncWatcherOff"
     />
-    <screen-renderer-error v-if="showErrors && building.error" v-model="building" />
-    <watchers-synchronous ref="watchersSynchronous"/>
+    <screen-renderer-error
+      v-if="showErrors && building.error"
+      v-model="building"
+    />
+    <watchers-synchronous ref="watchersSynchronous" />
   </b-container>
 </template>
 
 <script>
-import Json2Vue from '../mixins/Json2Vue';
-import CurrentPageProperty from '../mixins/CurrentPageProperty';
-import WatchersSynchronous from '@/components/watchers-synchronous';
-import ScreenRendererError from '../components/renderer/screen-renderer-error';
-import { cloneDeep, isEqual, debounce, get as getFromObject} from 'lodash';
+import Json2Vue from "../mixins/Json2Vue";
+import CurrentPageProperty from "../mixins/CurrentPageProperty";
+import WatchersSynchronous from "@/components/watchers-synchronous";
+import ScreenRendererError from "../components/renderer/screen-renderer-error";
+import { cloneDeep, isEqual, debounce, get as getFromObject } from "lodash";
 
 export default {
-  name: 'screen-renderer',
+  name: "screen-renderer",
   components: { WatchersSynchronous, ScreenRendererError },
-  mixins: [ Json2Vue, CurrentPageProperty ],
+  mixins: [Json2Vue, CurrentPageProperty],
   data() {
     return {
       currentDefinition: null,
-      codigo: '',
+      codigo: "",
       self: this,
-      displayAsyncLoading: false,
+      displayAsyncLoading: false
     };
   },
   mounted() {
     this.currentDefinition = cloneDeep(this.definition);
 
-    let screenName =  getFromObject(this.currentDefinition, 'config.0.name');
+    if (this.value.noCache) {
+      this.component = this.buildComponent(this.currentDefinition);
+      return;
+    }
+
+    let screenName = getFromObject(this.currentDefinition, "config.0.name");
     const itemName = `hash${this.hash(JSON.stringify(this.currentDefinition))}`;
 
-    if (['empty', undefined, null].includes(screenName)) {
+    if (["empty", undefined, null].includes(screenName)) {
       this.component = this.buildComponent(this.currentDefinition);
       return;
     }
@@ -54,27 +89,31 @@ export default {
     if (window.ProcessMaker.cachedScreens === undefined) {
       window.ProcessMaker.cachedScreens = [];
     }
-    let cachedScreen = window.ProcessMaker.cachedScreens.find(x => x.name === itemName);
+    let cachedScreen = window.ProcessMaker.cachedScreens.find(
+      (x) => x.name === itemName
+    );
     if (cachedScreen) {
       this.component = cachedScreen.component;
-    }
-    else {
+    } else {
       let component = this.buildComponent(this.currentDefinition);
       this.component = component;
-      window.ProcessMaker.cachedScreens.push({name: itemName, component: cloneDeep(component), definition: this.definition});
+      window.ProcessMaker.cachedScreens.push({
+        name: itemName,
+        component: cloneDeep(component),
+        definition: this.definition
+      });
     }
-
   },
   watch: {
     definition: {
       deep: true,
       handler(definition) {
         this.rebuildScreen(definition);
-      },
-    },
+      }
+    }
   },
   created() {
-    this.rebuildScreen =  debounce(function(definition) {
+    this.rebuildScreen = debounce(function (definition) {
       if (!isEqual(definition, this.currentDefinition)) {
         this.currentDefinition = cloneDeep(definition);
         this.component = this.buildComponent(this.currentDefinition);
@@ -83,12 +122,12 @@ export default {
   },
   methods: {
     hash(s) {
-      for (var i=0,h=9;i<s.length;)
-        h=Math.imul(h^s.charCodeAt(i++),9**9);
-      return h^h>>>9;
+      for (var i = 0, h = 9; i < s.length; )
+        h = Math.imul(h ^ s.charCodeAt(i++), 9 ** 9);
+      return h ^ (h >>> 9);
     },
     onAsyncWatcherOn() {
-      this.displayAsyncLoading = typeof this._parent === 'undefined';
+      this.displayAsyncLoading = typeof this._parent === "undefined";
     },
     onAsyncWatcherOff() {
       this.displayAsyncLoading = false;
@@ -98,8 +137,8 @@ export default {
     },
     setCurrentPage(page) {
       this.$refs.component.setCurrentPage(page);
-    },
-  },
+    }
+  }
 };
 </script>
 
@@ -109,19 +148,26 @@ export default {
 }
 @keyframes shakeError {
   0% {
-    transform: translateX(0); }
+    transform: translateX(0);
+  }
   15% {
-    transform: translateX(0.375rem); }
+    transform: translateX(0.375rem);
+  }
   30% {
-    transform: translateX(-0.375rem); }
+    transform: translateX(-0.375rem);
+  }
   45% {
-    transform: translateX(0.375rem); }
+    transform: translateX(0.375rem);
+  }
   60% {
-    transform: translateX(-0.375rem); }
+    transform: translateX(-0.375rem);
+  }
   75% {
-    transform: translateX(0.375rem); }
+    transform: translateX(0.375rem);
+  }
   90% {
-    transform: translateX(-0.375rem); }
+    transform: translateX(-0.375rem);
+  }
   100% {
     transform: none;
   }


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue is related to modeler elements that are cached because [this changes](https://github.com/ProcessMaker/screen-builder/pull/1240/commits/3e23eeb2303e96182d99dd2e52c0d22b559265d2). The purpose of the previous commit, is to improve performance in nested screens for screen builder, but modeler elements should not be cached.
The problem occurs because when you add an element in the modeler (for example a end event), the element is added to cached elements.

Reproduction steps:
- Add any element of modeler in the modeler (Except a start event, because start event is not cached because dows not have a name)
- Add again an element in the modeler

Expected behavior: 
Accordion should work as expected when you click in any element.

Actual behavior: 
Accordion is not loading the correct configuration for selected element.

## Solution
- Added **noCache** attribute for modeler elements, so we can skip modeler elements to be cached.

**Working video**

https://user-images.githubusercontent.com/90727999/188959669-c3b7ea1e-4cb0-48bd-8fab-3542b87731b8.mov

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6675](https://processmaker.atlassian.net/browse/FOUR-6675)
- Modeler PR

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
