### PR TITLE
Improve refresh validation event triggering to perform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "@processmaker/screen-builder",
       "version": "2.50.0",
       "dependencies": {
-        "is-proxy": "^1.0.6",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.27",
@@ -13785,11 +13784,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
-    },
-    "node_modules/is-proxy": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-proxy/-/is-proxy-1.0.6.tgz",
-      "integrity": "sha512-RzUROKx085vc7tpo9zCinKAmsD7ihAnXJ7HvKdcsc3m0XW/vpJDFSvZgutqMam0aBxpYBmDVYv48+T/+AMYl1g=="
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -35039,11 +35033,6 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "dev": true
-    },
-    "is-proxy": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/is-proxy/-/is-proxy-1.0.6.tgz",
-      "integrity": "sha512-RzUROKx085vc7tpo9zCinKAmsD7ihAnXJ7HvKdcsc3m0XW/vpJDFSvZgutqMam0aBxpYBmDVYv48+T/+AMYl1g=="
     },
     "is-regex": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "*.js"
   ],
   "dependencies": {
-    "is-proxy": "^1.0.6",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.27",

--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -9,19 +9,18 @@
 <script>
 import Mustache from 'mustache';
 import { getValidPath } from '@/mixins';
+import { mapState } from 'vuex';
 
 export default {
   mixins: [getValidPath],
   props: ['variant', 'label', 'event', 'eventData', 'name', 'fieldValue', 'value', 'tooltip', 'transientData'],
   watch: {
-    "$store.state.globalErrorsModule": {
-      deep: true,
-      handler(validate) {
-        this.isInvalid = !validate.valid;
-      },
-    },
+    valid(valid) {
+      this.isInvalid = !valid;
+    }
   },
   computed: {
+    ...mapState('globalErrorsModule', ['valid']),
     classList() {
       let variant = this.variant || 'primary';
       return {

--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -9,40 +9,25 @@
 <script>
 import Mustache from 'mustache';
 import { getValidPath } from '@/mixins';
-import { isProxy } from 'is-proxy';
 
 export default {
   mixins: [getValidPath],
   props: ['variant', 'label', 'event', 'eventData', 'name', 'fieldValue', 'value', 'tooltip', 'transientData'],
   watch: {
-    '$attrs.validate': {
+    "$store.state.globalErrorsModule": {
       deep: true,
       handler(validate) {
-        if (validate && !isProxy(validate.vdata.$model)) {
-          this.errors = 0;
-          let message = '';
-          if (validate.$invalid) {
-            this.countErrors(validate.vdata);
-            this.countErrors(validate.schema);
-            message = this.errors === 1
-              ? 'There is a validation error in your form.'
-              : 'There are {{items}} validation errors in your form.';
-            message = this.$t(message, {items: this.errors});
-          }
-          this.$store.commit('globalErrorsModule/basic', {key: 'valid', value: !validate.$invalid});
-          this.$store.commit('globalErrorsModule/basic', {key: 'message', value: message});
-        }
+        this.isInvalid = !validate.valid;
       },
     },
   },
   computed: {
     classList() {
       let variant = this.variant || 'primary';
-      let isInvalid = this.$store.getters['globalErrorsModule/isValidScreen'] === false;
       return {
         btn: true,
         ['btn-' + variant]: true,
-        disabled: this.event === 'submit' && isInvalid,
+        disabled: this.event === 'submit' && this.isInvalid,
       };
     },
     options() {
@@ -67,29 +52,10 @@ export default {
   },
   data() {
     return {
-      errors: 0,
+      isInvalid: false,
     };
   },
   methods: {
-    countErrors(obj) {
-      if (typeof obj !== 'object') {
-        return;
-      }
-      Object.entries(obj).forEach(([key, value]) => {
-        if (value) {
-          if (typeof value === 'object' && '$each' in value) {
-            this.countErrors(value.$each);
-            return;
-          }
-          if (typeof value === 'object' && '$invalid' in value && value.$invalid && isNaN(key)) {
-            this.errors++;
-          }
-          if (key !== '$iter' && value) {
-            this.countErrors(value);
-          }
-        }
-      });
-    },
     setValue(parent, name, value) {
       if (parent) {
         if (parent.items) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -356,6 +356,7 @@ import {
   FormHtmlEditor,
   FormHtmlViewer,
 } from '@processmaker/vue-form-elements';
+import defaultValueEditor from "./inspector/default-value-editor";
 
 import RequiredCheckbox from './utils/required-checkbox';
 import MultipleUploadsCheckbox from './utils/multiple-uploads-checkbox';
@@ -400,6 +401,7 @@ export default {
     FormHtmlViewer,
     RequiredCheckbox,
     MultipleUploadsCheckbox,
+    defaultValueEditor,
     ...inspector,
     ...renderer,
   },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script>
+import globalErrorsModule from "@/store/modules/global-errors";
 import { mapActions } from "vuex";
 import _ from 'lodash';
 import CustomCssOutput from './custom-css-output';
@@ -113,6 +114,7 @@ export default {
   },
   created() {
     this.parseCss = _.debounce(this.parseCss, 500, {leading: true});
+    this.registerStoreModule("globalErrorsModule", globalErrorsModule);
   },
   mounted() {
     this.parseCss();
@@ -124,6 +126,13 @@ export default {
   },
   methods: {
     ...mapActions("globalErrorsModule", ["validate"]),
+    registerStoreModule(moduleName, storeModule) {
+      const store = this.$store;
+
+      if (store && store.state && !store.state[moduleName]) {
+        store.registerModule(moduleName, storeModule);
+      }
+    },
     getMainScreen() {
       return this.$refs.renderer && this.$refs.renderer.$refs.component;
     },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -6,6 +6,7 @@
 </template>
 
 <script>
+import { mapActions } from "vuex";
 import _ from 'lodash';
 import CustomCssOutput from './custom-css-output';
 import currencies from '../currency.json';
@@ -13,7 +14,6 @@ import Inputmask from 'inputmask';
 import { getItemsFromConfig } from '../itemProcessingUtils';
 import { ValidatorFactory } from '../factories/ValidatorFactory';
 import CurrentPageProperty from '../mixins/CurrentPageProperty';
-import globalErrorsModule from '@/store/modules/global-errors';
 
 const csstree = require('css-tree');
 const Scrollparent = require('scrollparent');
@@ -94,10 +94,7 @@ export default {
         this.$emit('update', this.data);
         const mainScreen = this.getMainScreen();
         if (mainScreen) {
-          this.$store.dispatch(
-            "globalErrorsModule/updateValidation",
-            mainScreen
-          );
+          this.validate(mainScreen);
         }
       },
     },
@@ -115,7 +112,6 @@ export default {
     },
   },
   created() {
-    this.registerStoreModule('globalErrorsModule', globalErrorsModule);
     this.parseCss = _.debounce(this.parseCss, 500, {leading: true});
   },
   mounted() {
@@ -127,6 +123,7 @@ export default {
     this.scrollable = Scrollparent(this.$el);
   },
   methods: {
+    ...mapActions("globalErrorsModule", ["validate"]),
     getMainScreen() {
       return this.$refs.renderer && this.$refs.renderer.$refs.component;
     },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -92,6 +92,13 @@ export default {
       deep: true,
       handler() {
         this.$emit('update', this.data);
+        const mainScreen = this.getMainScreen();
+        if (mainScreen) {
+          this.$store.dispatch(
+            "globalErrorsModule/updateValidation",
+            mainScreen
+          );
+        }
       },
     },
     computed: {
@@ -120,6 +127,9 @@ export default {
     this.scrollable = Scrollparent(this.$el);
   },
   methods: {
+    getMainScreen() {
+      return this.$refs.renderer && this.$refs.renderer.$refs.component
+    },
     registerStoreModule(moduleName, storeModule) {
       const store = this.$store;
 

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -128,7 +128,7 @@ export default {
   },
   methods: {
     getMainScreen() {
-      return this.$refs.renderer && this.$refs.renderer.$refs.component
+      return this.$refs.renderer && this.$refs.renderer.$refs.component;
     },
     registerStoreModule(moduleName, storeModule) {
       const store = this.$store;

--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -1,4 +1,3 @@
-import defaultValueEditor from './components/inspector/default-value-editor';
 import Tooltip from './components/inspector/tooltip';
 
 export const bgcolorProperty = {
@@ -221,7 +220,7 @@ export const buttonVariantStyleProperty = {
 };
 
 export const defaultValueProperty = {
-  type: defaultValueEditor,
+  type: "default-value-editor",
   field: 'defaultValue',
   config: {
     label: 'Default Value',

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -1,5 +1,6 @@
 import { get, isEqual, set } from 'lodash';
 import Mustache from 'mustache';
+import { mapActions, mapState } from 'vuex';
 import { ValidationMsg } from './ValidationRules';
 
 const stringFormats = ['string', 'datetime', 'date', 'password'];
@@ -38,11 +39,16 @@ export default {
     },
   },
   computed: {
+    ...mapState("globalErrorsModule", {
+      valid__: "valid",
+      message__: "message"
+    }),
     references__() {
       return this.$parent && this.$parent.references__;
     },
   },
   methods: {
+    ...mapActions("globalErrorsModule", ["validateNow"]),
     getDataAccordingToFieldLevel(dataWithParent, level) {
       if (level === 0 || !dataWithParent) {
         return dataWithParent;
@@ -109,11 +115,11 @@ export default {
         return 'MUSTACHE: ' + e.message;
       }
     },
-    submitForm() {
-      if (this.$v.$invalid) {
-        let msgError = this.$store.getters['globalErrorsModule/getErrorMessage'];
-        window.ProcessMaker.alert(msgError, 'danger');
-        //if the form is not valid the data is not emitted
+    async submitForm() {
+      await this.validateNow(this);
+      if (!this.valid__) {
+        window.ProcessMaker.alert(this.message__, "danger");
+        // if the form is not valid the data is not emitted
         return;
       }
       this.$emit('submit', this.vdata);

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -1,36 +1,11 @@
 import { Parser } from 'expr-eval';
-import { debounce } from 'lodash';
 
 export default {
-  mounted() {
-    this.refreshValidationRulesByName = debounce(this.refreshValidationRulesByName, 500);
-
-    this.$root.$on('refresh-validation-rules', () => {
-      this.loadValidationRules();
-    });
-  },
   methods: {
-    refreshValidationRulesByName(fieldName, isVisible) {
-      if (fieldName) {
-        // Update the array of hidden fields
-        const fieldExists = this.hiddenFields__.indexOf(fieldName) !== -1;
-        if (isVisible && fieldExists) {
-          this.hiddenFields__ = this.hiddenFields__.filter((f) => f !== fieldName);
-        } else if (!isVisible && !fieldExists) {
-          this.hiddenFields__.push(fieldName);
-        }
-      }
-      this.$root.$emit('refresh-validation-rules');
-    },
-
-    visibilityRuleIsVisible(rule, fieldName) {
+    visibilityRuleIsVisible(rule) {
       try {
         const data = Object.assign({ _parent: this._parent }, this.vdata);
         const isVisible = !!Parser.evaluate(rule, Object.assign({}, data));
-
-        window.setTimeout(() => {
-          this.refreshValidationRulesByName(fieldName, isVisible);
-        }, 250);
         return isVisible;
       } catch (e) {
         return false;

--- a/src/store/modules/global-errors.js
+++ b/src/store/modules/global-errors.js
@@ -31,7 +31,6 @@ function countErrors(obj) {
 }
 
 let updateValidationRules = async (mainScreen, commit) => {
-  console.log("updateValidation");
   await mainScreen.loadValidationRules(true);
   const validate = mainScreen.$v;
   // update the global error state used by submit buttons
@@ -55,7 +54,6 @@ let updateValidationRules = async (mainScreen, commit) => {
       key: "message",
       value: message
     });
-    console.log("valid?", !validate.$invalid);
   }
 };
 updateValidationRules = debounce(updateValidationRules, 1000);

--- a/src/store/modules/global-errors.js
+++ b/src/store/modules/global-errors.js
@@ -30,8 +30,8 @@ function countErrors(obj) {
   return errors;
 }
 
-let updateValidationRules = async (mainScreen, commit) => {
-  await mainScreen.loadValidationRules(true);
+const updateValidationRules = async (mainScreen, commit) => {
+  await mainScreen.loadValidationRules();
   const validate = mainScreen.$v;
   // update the global error state used by submit buttons
   if (validate) {
@@ -56,7 +56,7 @@ let updateValidationRules = async (mainScreen, commit) => {
     });
   }
 };
-updateValidationRules = debounce(updateValidationRules, 1000);
+const updateValidationRulesDebounced = debounce(updateValidationRules, 1000);
 
 const globalErrorsModule = {
   namespaced,
@@ -80,8 +80,11 @@ const globalErrorsModule = {
     }
   },
   actions: {
-    updateValidation({ commit }, mainScreen) {
-      updateValidationRules(mainScreen, commit);
+    validate({ commit }, mainScreen) {
+      updateValidationRulesDebounced(mainScreen, commit);
+    },
+    async validateNow({ commit }, mainScreen) {
+      await updateValidationRules(mainScreen, commit);
     },
     close({ commit }) {
       commit("basic", { key: "valid", value: true });

--- a/src/store/modules/global-errors.js
+++ b/src/store/modules/global-errors.js
@@ -1,10 +1,71 @@
+import { debounce } from "lodash";
+
 const namespaced = true;
+
+function countErrors(obj) {
+  let errors = 0;
+  if (typeof obj !== "object") {
+    return errors;
+  }
+  Object.entries(obj).forEach(([key, value]) => {
+    if (value) {
+      if (typeof value === "object" && "$each" in value) {
+        errors += countErrors(value.$each.$iter);
+        return;
+      }
+      if (
+        key !== "$iter" &&
+        typeof value === "object" &&
+        "$invalid" in value &&
+        value.$invalid &&
+        Number.isNaN(Number(key))
+      ) {
+        errors++;
+      }
+      if (key !== "$iter" && value) {
+        errors += countErrors(value);
+      }
+    }
+  });
+  return errors;
+}
+
+let updateValidationRules = async (mainScreen, commit) => {
+  console.log("updateValidation");
+  await mainScreen.loadValidationRules(true);
+  const validate = mainScreen.$v;
+  // update the global error state used by submit buttons
+  if (validate) {
+    let errors = 0;
+    let message = "";
+    if (validate.$invalid) {
+      errors += countErrors(validate.vdata);
+      errors += countErrors(validate.schema);
+      message =
+        errors === 1
+          ? "There is a validation error in your form."
+          : "There are {{items}} validation errors in your form.";
+      message = mainScreen.$t(message, { items: errors });
+    }
+    commit("basic", {
+      key: "valid",
+      value: !validate.$invalid
+    });
+    commit("basic", {
+      key: "message",
+      value: message
+    });
+    console.log("valid?", !validate.$invalid);
+  }
+};
+updateValidationRules = debounce(updateValidationRules, 1000);
+
 const globalErrorsModule = {
   namespaced,
   state: () => {
     return {
       valid: true,
-      message: '',
+      message: ""
     };
   },
   getters: {
@@ -13,18 +74,21 @@ const globalErrorsModule = {
     },
     getErrorMessage(state) {
       return state.message;
-    },
+    }
   },
   mutations: {
     basic(state, payload) {
       state[payload.key] = payload.value;
-    },
+    }
   },
   actions: {
-    close({ commit }) {
-      commit('basic', { key: 'valid', value: true });
+    updateValidation({ commit }, mainScreen) {
+      updateValidationRules(mainScreen, commit);
     },
-  },
+    close({ commit }) {
+      commit("basic", { key: "valid", value: true });
+    }
+  }
 };
 
 export default globalErrorsModule;

--- a/tests/e2e/specs/RecordList.spec.js
+++ b/tests/e2e/specs/RecordList.spec.js
@@ -68,7 +68,7 @@ describe('Record list', () => {
 
     //Delete record 7
     cy.get('[aria-rowindex="7"] > .text-right > .actions > .btn-group > [data-cy=remove-row]').click();
-    cy.get('#__BVID__95___BV_modal_footer_ > .btn-primary').click();
+    cy.get("[data-cy='modal-remove'] button.btn.btn-primary").click();
 
     cy.get('.table-column')
       .should('contain.text', '6');
@@ -78,7 +78,7 @@ describe('Record list', () => {
 
     //Delete record 6
     cy.get('[data-cy=remove-row]').click();
-    cy.get('#__BVID__95___BV_modal_footer_ > .btn-primary').click();
+    cy.get("[data-cy='modal-remove'] button.btn.btn-primary").click();
 
     //Assert we see page 1
     cy.get('[data-cy=table-pagination]')


### PR DESCRIPTION
## Issue & Reproduction Steps
For a form with validation rules and visibility rules combined, when an input text changes it triggers multiple times the `refresh-validation-rules` event causing performance problems.

## Expected behavior: 
The refresh of validation rules should be "debounced" to prevent it triggers multiple times on an input change.

## Actual behavior: 
The refresh of validation rules is triggered multiple times, it increases when the screen has many nested screens and loops.

## Solution
- Move the refresh validation rules logic to $store so this way it will be unique for the screen.
- Add refresh validation rules logic to submit button to make sure all the validations are updated before submit.
- Debounce the refresh validation rules function.

## How to Test
- In a Screen with visibility rules combined with validation rules
- Fill the values
- Check the validation is working as expected.

[Test Screen.zip](https://github.com/ProcessMaker/screen-builder/files/9585360/Test.Screen.zip)

https://user-images.githubusercontent.com/8028650/190676175-5516eaa7-a747-469c-ab5d-0a7dba97c11c.mp4

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6719

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
