### PR TITLE
FOUR-6760: Fix the multiple refresh with RichText Control

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -125,13 +125,7 @@ export default {
       this.$emit('submit', this.vdata);
     },
     getValidationData() {
-      const screen = this;
-      return new Proxy(this.vdata || {}, {
-        get(target, name) {
-          if (name in target) return target[name];
-          if (name === '_parent') return screen._parent === undefined ? this._parent : screen._parent;
-        },
-      });
+      return this.vdata;
     },
     initialValue(component, dataFormat, config) {
       let value = null;


### PR DESCRIPTION
## Issue & Reproduction Steps
The control Rich text is refreshed  as a result of some action on other controls that are not directly dependent

## Solution
- getValidationData was improved in order to avoid multiple proxy calls

## How to Test
 - create rich text field
 - add other fields non dependents
 - update the other fields

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-6760

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
