### PR TITLE
Four 6732/change vuejsonpretty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "validatorjs": "^3.14.2",
         "vue": "^2.6.12",
         "vue-deepset": "^0.6.3",
-        "vue-json-pretty": "^1.4.0",
         "vue-monaco": "^0.3.1",
         "vue-template-compiler": "^2.6.14",
         "vue-uniq-ids": "^1.0.0",
@@ -22914,16 +22913,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/vue-json-pretty": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.8.3.tgz",
-      "integrity": "sha512-rpsop8LMy6EybkjmlT8a2fB2mHe0EMvxoCuw6lXcNBDsVkRuD4+eDwzqjshfe5qEki8EVLqr1o6n+lSLkR/tgQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 5.0.0"
-      }
-    },
     "node_modules/vue-loader": {
       "version": "15.10.0",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.0.tgz",
@@ -42397,12 +42386,6 @@
           "dev": true
         }
       }
-    },
-    "vue-json-pretty": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/vue-json-pretty/-/vue-json-pretty-1.8.3.tgz",
-      "integrity": "sha512-rpsop8LMy6EybkjmlT8a2fB2mHe0EMvxoCuw6lXcNBDsVkRuD4+eDwzqjshfe5qEki8EVLqr1o6n+lSLkR/tgQ==",
-      "dev": true
     },
     "vue-loader": {
       "version": "15.10.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "validatorjs": "^3.14.2",
     "vue": "^2.6.12",
     "vue-deepset": "^0.6.3",
-    "vue-json-pretty": "^1.4.0",
     "vue-monaco": "^0.3.1",
     "vue-template-compiler": "^2.6.14",
     "vue-uniq-ids": "^1.0.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,7 +90,7 @@
 
           <b-col class="overflow-hidden h-100 preview-inspector p-0">
             <b-card no-body class="p-0 h-100 rounded-0 border-top-0 border-right-0 border-bottom-0">
-              <b-card-body class="p-0 overflow-auto">
+              <b-card-body class="p-0">
                 <b-button variant="outline"
                   class="text-left card-header d-flex align-items-center w-100 shadow-none"
                   @click="showDataInput = !showDataInput"
@@ -115,7 +115,13 @@
                 </b-button>
 
                 <b-collapse v-model="showDataPreview" id="showDataPreview" data-cy="preview-data-content" class="mt-2">
-                  <vue-json-pretty :data="previewData" class="p-2 data-collapse"/>
+                  <monaco-editor
+                    v-model="previewDataStringify"
+                    :options="monacoOptions"
+                    class="editor"
+                    language="json"
+                    @editorDidMount="monacoMounted"
+                  />
                 </b-collapse>
 
               </b-card-body>
@@ -255,6 +261,7 @@ export default {
   mixins: [canOpenJsonFile],
   data() {
     return {
+      previewDataStringify: "",
       numberOfElements: 0,
       preview: {
         config: [
@@ -301,7 +308,9 @@ export default {
       monacoOptions: {
         automaticLayout: true,
         lineNumbers: 'off',
-        minimap: false,
+        minimap: {
+          enabled: false
+        }
       },
     };
   },
@@ -315,6 +324,12 @@ export default {
     WatchersPopup,
   },
   watch: {
+    previewData: {
+      deep: true,
+      handler() {
+        this.updateDataPreview();
+      }
+    },
     previewInput() {
       if (this.previewInputValid) {
         // Copy data over
@@ -391,6 +406,9 @@ export default {
       return warnings;
     },
   },
+  created() {
+    this.updateDataPreview = debounce(this.updateDataPreview, 1000);
+  },
   mounted() {
     this.countElements = debounce(this.countElements, 2000);
     if (globalObject.ProcessMaker && globalObject.ProcessMaker.user && globalObject.ProcessMaker.user.lang) {
@@ -412,6 +430,13 @@ export default {
     this.loadFromLocalStorage();
   },
   methods: {
+    updateDataPreview() {
+      this.previewDataStringify = JSON.stringify(this.previewData, null, 2);
+    },
+    monacoMounted(editor) {
+      this.editor = editor;
+      this.editor.updateOptions({ readOnly: true });
+    },
     countElements() {
       this.$refs.renderer.countElements(this.config).then(allElements => {
         this.numberOfElements = allElements.length;
@@ -607,5 +632,8 @@ export default {
 
     .form-group--error {
       animation: none;
+    }
+    .editor {
+      height: 30em;
     }
 </style>

--- a/tests/e2e/specs/NestedScreen.spec.js
+++ b/tests/e2e/specs/NestedScreen.spec.js
@@ -88,9 +88,9 @@ describe('Nested screen', () => {
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=preview] input[name="firstname"]').type('Alan');
     cy.get('[data-cy=preview] input[name="lastname"]').type('Turing');
-    cy.get('[data-cy=preview-data-content]').should((a) => {
-      const person = JSON.parse(a.text().split('{...}').join(''));
-      expect(person).to.eql({ firstname: 'Alan', lastname: 'Turing' });
+    cy.assertPreviewData({
+      firstname: "Alan",
+      lastname: "Turing"
     });
     cy.get('[data-cy=mode-editor]').click();
   });

--- a/tests/e2e/specs/RichText.spec.js
+++ b/tests/e2e/specs/RichText.spec.js
@@ -3,7 +3,7 @@ describe('Rich Text control', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormHtmlViewer]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();
-    cy.get('[data-cy=inspector-content]').clear().type('<p>Hello {{ name }}</p>', {parseSpecialCharSequences: false});
+    cy.get('[data-cy=inspector-content]').focus().clear().type('<p>Hello {{ name }}</p>', {parseSpecialCharSequences: false});
     cy.get('[data-cy=mode-preview]').click();
     cy.setPreviewDataInput('{"name":"World"}');
     cy.get('[data-cy=preview-content]').should('contain.html', '<p>Hello World</p>');
@@ -13,7 +13,7 @@ describe('Rich Text control', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormHtmlViewer]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();
-    cy.get('[data-cy=inspector-content]').clear().type('{{ name }}', {parseSpecialCharSequences: false});
+    cy.get('[data-cy=inspector-content]').focus().clear().type('{{ name }}', {parseSpecialCharSequences: false});
     cy.get('[data-cy=inspector-renderVarHtml]').click();
     cy.get('[data-cy=mode-preview]').click();
     cy.setPreviewDataInput('{"name":"<p>Hello <b>World</b></p>"}');

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -5,6 +5,7 @@ import 'cypress-wait-until';
 Cypress.Commands.add('setPreviewDataInput', (input) => {
   cy.get('#screen-builder-container').then((div) => {
     div[0].__vue__.previewInput = typeof input === 'string' ? input : JSON.stringify(input);
+    div[0].__vue__.updateDataInput();
   });
 });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Preview Data in Screen Builder is refreshing many times when a input changes.

## Solution
Delay and debounce the refresh of data preview

## How to Test
- Create a form with some inputs and other controls
- Go to Preview
- Focus on a input text
- Type
- Note in the Preview Data panel VueJosnPretty was changed by Monaco
- Note the Preview Data is devounced (refresh after user complete to type)


https://user-images.githubusercontent.com/8028650/191998125-ad117d9a-bb43-4801-953c-15a6a32266a3.mp4


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6732

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
