### PR TITLE
Verify Select Lists loaded by watchers

### DIFF
--- a/tests/e2e/fixtures/FOUR-6910_Watcher_Checkbox.json
+++ b/tests/e2e/fixtures/FOUR-6910_Watcher_Checkbox.json
@@ -1,0 +1,1207 @@
+{
+    "type": "screen_package",
+    "version": "2",
+    "screens": [
+        {
+            "id": 685,
+            "uuid": "97960bf8-237b-433e-95f1-443f2248d67e",
+            "screen_category_id": "6",
+            "title": "watcher - Radio",
+            "description": "watcher - Radio",
+            "type": "FORM",
+            "config": [
+                {
+                    "name": "watcher - Radio",
+                    "items": [
+                        {
+                            "items": [
+                                [
+                                    {
+                                        "label": "Checkbox",
+                                        "config": {
+                                            "icon": "fas fa-check-square",
+                                            "name": "enable",
+                                            "label": "enable",
+                                            "helper": null,
+                                            "toggle": false,
+                                            "disabled": false,
+                                            "validation": [],
+                                            "initiallyChecked": false
+                                        },
+                                        "component": "FormCheckbox",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "initiallyChecked",
+                                                "config": {
+                                                    "label": "Checked by default",
+                                                    "helper": "Should the checkbox be checked by default"
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "toggle",
+                                                "config": {
+                                                    "label": "Toggle Style",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "disabled",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormCheckbox",
+                                        "editor-component": "FormCheckbox"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "label": "Select List",
+                                        "config": {
+                                            "icon": "fas fa-angle-double-down",
+                                            "name": "form_select_list_2",
+                                            "label": "radio",
+                                            "helper": null,
+                                            "options": {
+                                                "key": "data.name",
+                                                "value": "data.name",
+                                                "dataName": "response1",
+                                                "jsonData": null,
+                                                "renderAs": "checkbox",
+                                                "editIndex": null,
+                                                "pmqlQuery": null,
+                                                "dataSource": "dataObject",
+                                                "optionsList": [],
+                                                "removeIndex": null,
+                                                "showRenderAs": true,
+                                                "showJsonEditor": false,
+                                                "showOptionCard": false,
+                                                "selectedOptions": [],
+                                                "allowMultiSelect": true,
+                                                "showRemoveWarning": false,
+                                                "valueTypeReturned": "single",
+                                                "selectedDataSource": null
+                                            },
+                                            "readonly": false,
+                                            "validation": [],
+                                            "placeholder": null,
+                                            "rootElement": "response",
+                                            "dataSourceUrl": null,
+                                            "dataSourceEndpoint": null
+                                        },
+                                        "component": "FormSelectList",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "placeholder",
+                                                "config": {
+                                                    "label": "Placeholder Text",
+                                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "OptionsList",
+                                                "field": "options",
+                                                "config": {
+                                                    "label": null,
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "default-value-editor",
+                                                "field": "defaultValue",
+                                                "config": {
+                                                    "label": "Default Value",
+                                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "readonly",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormSelectList",
+                                        "editor-component": "FormSelectList"
+                                    },
+                                    {
+                                        "label": "Select List",
+                                        "config": {
+                                            "icon": "fas fa-angle-double-down",
+                                            "name": "form_select_list_3",
+                                            "label": "dropdown",
+                                            "helper": null,
+                                            "options": {
+                                                "key": "data.name",
+                                                "value": "data.name",
+                                                "dataName": "response1",
+                                                "jsonData": null,
+                                                "renderAs": "dropdown",
+                                                "editIndex": null,
+                                                "pmqlQuery": null,
+                                                "dataSource": "dataObject",
+                                                "optionsList": [],
+                                                "removeIndex": null,
+                                                "showRenderAs": true,
+                                                "showJsonEditor": false,
+                                                "showOptionCard": false,
+                                                "selectedOptions": [],
+                                                "allowMultiSelect": true,
+                                                "showRemoveWarning": false,
+                                                "valueTypeReturned": "single",
+                                                "selectedDataSource": null
+                                            },
+                                            "readonly": false,
+                                            "validation": [],
+                                            "placeholder": null,
+                                            "rootElement": "response",
+                                            "dataSourceUrl": null,
+                                            "dataSourceEndpoint": null
+                                        },
+                                        "component": "FormSelectList",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "placeholder",
+                                                "config": {
+                                                    "label": "Placeholder Text",
+                                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "OptionsList",
+                                                "field": "options",
+                                                "config": {
+                                                    "label": null,
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "default-value-editor",
+                                                "field": "defaultValue",
+                                                "config": {
+                                                    "label": "Default Value",
+                                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "readonly",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormSelectList",
+                                        "editor-component": "FormSelectList"
+                                    }
+                                ]
+                            ],
+                            "label": "Multicolumn \/ Table",
+                            "config": {
+                                "icon": "fas fa-table",
+                                "label": null,
+                                "options": [
+                                    {
+                                        "value": "1",
+                                        "content": "6"
+                                    },
+                                    {
+                                        "value": "2",
+                                        "content": "6"
+                                    }
+                                ]
+                            },
+                            "component": "FormMultiColumn",
+                            "container": true,
+                            "inspector": [
+                                {
+                                    "type": "ContainerColumns",
+                                    "field": "options",
+                                    "config": {
+                                        "label": "Column Width",
+                                        "helper": null,
+                                        "validation": "columns-adds-to-12"
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "MultiColumn",
+                            "editor-component": "MultiColumn"
+                        },
+                        {
+                            "label": "Submit Button",
+                            "config": {
+                                "icon": "fas fa-share-square",
+                                "name": null,
+                                "event": "submit",
+                                "label": "New Submit",
+                                "tooltip": [],
+                                "variant": "primary",
+                                "fieldValue": null,
+                                "defaultSubmit": true
+                            },
+                            "component": "FormButton",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the button's text"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:\/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$\/|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "event",
+                                    "config": {
+                                        "label": "Type",
+                                        "helper": "Choose whether the button should submit the form",
+                                        "options": [
+                                            {
+                                                "value": "submit",
+                                                "content": "Submit Button"
+                                            },
+                                            {
+                                                "value": "script",
+                                                "content": "Regular Button"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "props": [
+                                            "label",
+                                            "value",
+                                            "helper"
+                                        ],
+                                        "watch": {
+                                            "value": {
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "inheritAttrs": false,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "tooltip",
+                                    "config": {
+                                        "label": "Tooltip"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "fieldValue",
+                                    "config": {
+                                        "label": "Value",
+                                        "helper": "The value being submitted"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "variant",
+                                    "config": {
+                                        "label": "Button Variant Style",
+                                        "helper": "The variant determines the appearance of the button",
+                                        "options": [
+                                            {
+                                                "value": "primary",
+                                                "content": "Primary"
+                                            },
+                                            {
+                                                "value": "secondary",
+                                                "content": "Secondary"
+                                            },
+                                            {
+                                                "value": "success",
+                                                "content": "Success"
+                                            },
+                                            {
+                                                "value": "danger",
+                                                "content": "Danger"
+                                            },
+                                            {
+                                                "value": "warning",
+                                                "content": "Warning"
+                                            },
+                                            {
+                                                "value": "info",
+                                                "content": "Info"
+                                            },
+                                            {
+                                                "value": "light",
+                                                "content": "Light"
+                                            },
+                                            {
+                                                "value": "dark",
+                                                "content": "Dark"
+                                            },
+                                            {
+                                                "value": "link",
+                                                "content": "Link"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormSubmit",
+                            "editor-component": "FormButton"
+                        }
+                    ]
+                }
+            ],
+            "computed": [],
+            "custom_css": null,
+            "created_at": "2022-10-25T14:10:17+00:00",
+            "updated_at": "2022-10-25T14:28:39+00:00",
+            "status": "ACTIVE",
+            "key": null,
+            "watchers": [
+                {
+                    "input_data": "{}",
+                    "script_configuration": "{\"dataSource\":\"2\",\"dataMapping\":[{\"key\":\"response1\",\"value\":\"data\"}],\"endpoint\":\"ListAll\"}",
+                    "synchronous": true,
+                    "show_async_loading": false,
+                    "run_onload": false,
+                    "name": "watcher  radio",
+                    "watching": "enable",
+                    "script": {
+                        "id": "data_source-2",
+                        "uuid": "9745caf6-4ceb-45f8-97d9-0316ee54948c",
+                        "name": "Students",
+                        "description": null,
+                        "endpoints": {
+                            "ListAll": {
+                                "url": "\/api\/1.0\/collections\/1\/records",
+                                "body": null,
+                                "method": "GET",
+                                "headers": [],
+                                "purpose": "ListAll",
+                                "testData": "{}",
+                                "description": "Collection list all records"
+                            },
+                            "GetRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": null,
+                                "method": "GET",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": "{{record}}",
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "GetRecord",
+                                "updated": "2022-10-10 15:31:16",
+                                "testData": "{}",
+                                "body_type": "json",
+                                "description": "Collection get record by record id"
+                            },
+                            "CreateRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records",
+                                "body": "{\n    \"data\": {\n        \"date\": \"{{date}}\",\n        \"CI\": \"{{CI}}\",\n        \"name\": \"{{name}}\",\n        \"lastName\": \"{{lastName}}\",\n        \"profession\": \"{{profession}}\",\n        \"telephone\": \"{{telephone}}\"\n    }\n}",
+                                "method": "POST",
+                                "headers": [],
+                                "purpose": "CreateRecord",
+                                "updated": "2022-10-21 20:12:03",
+                                "testData": "{\n    \"date\": \"2022-10-21 20:11:03\",\n    \"CI\": \"4545444\",\n    \"name\": \"nombre\",\n    \"lastName\": \"apellido\",\n    \"profession\": \"qa\",\n    \"telephone\": \"11111111\"\n}",
+                                "body_type": "json",
+                                "description": "Collection create record"
+                            },
+                            "DeleteRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": null,
+                                "method": "DELETE",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": null,
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "DeleteRecord",
+                                "testData": "{}",
+                                "description": "Collection delete record"
+                            },
+                            "UpdateRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": "{\"data\":[]}",
+                                "method": "PUT",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": null,
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "UpdateRecord",
+                                "testData": "{}",
+                                "description": "Collection update record"
+                            },
+                            "TruncateCollection": {
+                                "url": "\/api\/1.0\/collections\/1\/truncate",
+                                "body": null,
+                                "method": "DELETE",
+                                "headers": [],
+                                "purpose": "TruncateCollection",
+                                "testData": "{}",
+                                "description": "Delete all records in collection"
+                            }
+                        },
+                        "mappings": null,
+                        "type": "REST",
+                        "authtype": "OAUTH2_BEARER",
+                        "debug_mode": false,
+                        "credentials": "eyJpdiI6IlRKdUE5K2hXTFwvelhwWkc4RGFwdXdnPT0iLCJ2YWx1ZSI6IkpadlJUZzdCbmFqN1ZwcHlwYUFpUmNkRkkzZmJuU0l1VEYxMHRubTRld1c5OWlvamt0bytCZXBEN2pIOCt6UWtwcFFUVlNBV2VQK1FGMnFndUgwcDVQa1lMUTVHMVZXSEVcL09tNk5OcTlvNzU0T3dqQXJLaTZNSHBDZE5zdHpEa1gxeDdPXC9SbVRNZ1NGVHJmZWNCQmRHN3ZqbDFRaE41OFdoSnVTeWVNajFlSjlTRXc2eDlUdXZTK1k5SUhQaFFyVXJqTThqclVSQXROV3A5aUZQK2E3WVdrbUU3WExBOWtlUWR0VGFVM2MwYWhtSmtJczN2cE5OT3psUXErSENyaTJ4ZmhPczRpNGd1aUFpOFVCYzhFYlZma0RsQWc5M2NtVzJZMTltdk5FV21KUUxraHN5ek52bWo0bmxmTzVxUmFqN09oV3QzUzVIOHBPSTNUdGZ2NUZpcTJpaWcwa2ZGKzlPQ3BxazA4RjZQdWRMcUVLR0o2T0gxQTJtSGc5TUx2K3NHZ3pGaE51VkFXc25Sb2JzNmhad3FjSHJPUktVQ2FjM2cydERmcGNjOUJnOUJJeFhlbDY3YzNDSWpjT3dSdzNUWU9MQlYreFlKT1FlaGVwXC96Vkw1MzJ1d0ROK1RYRDdKZ1wvS1RYNkxsYnVFTktwT2lPU3hZMEVSTGxaZTRTZUdwaTR5N1wvanpBUmpQVmwrUG9hZFo5dlppSmR5dXNJeEhDVjNwUG9cL29oZFNOZTIzZjJBVEw3eEIwcW5kRGlwV2psSzlXbk9vMnBPXC9LWEF4KzBQSUJ5K1E0RmpWU2tWc0F3ZE45XC8zdVwvUWRLNWxCQTNIdzF6dFFGYjZrd2o5SVN5cGNRUytrWkUzdGVrdFpEcGxyTmxFR0N2SFRJNURLV2oyNDhtb0VFeVU4Ym5RZDNDK1NBUTFPQ1F1TWN3eWVhbHg5TnVDSUcrREswSjFhakdEYjdwSkJhaGgwSU9ZSThJaGV2SEQzd3hyd0R2b2UwOWtSWUlrYlwvVVE0QU9GNEpcL0M0Z3ZDOVowZXpLNE4wbjRzRFBxTjlKNFFyZGdadFlJMlwvd2tQMjlRXC9rZCtvUm9vT2g5aTh2R1J6SDUzSlZQUStLcWgyUiswNTkxa3JyNkxSQXNlQkJrU0pQZEljS1ZNK2VDWFBXMzdyUDdsY1wvS0ZcL1VyV1hrRG4wZzE4eXppOHVJOFNXd2x1MkI0M05kRHRoYVlOTCtKQjROY2lkSENTXC80dE8zWFVnVjM0QzV0QURTcEVScUJXVU9adFoycVJ3RnRac3JxUmZEcVwva2lFM1Bydjd6aWdmVytmOE5zendmb0ZrSjIweVMyN0VUanZUSDVcL0p6RWM2OVEzOUtENFpoWnJGcjA4VHpmYkREZHhlak8yQVBcL00yNjJwXC92VklvRzVadEJ4ejk1N0NUUjJBXC9vMURNN3lSVDA2Qk9KU1E0QTBySUVPK2xDdFJ4KzV0WUFWUXNyckRvRlpNMmxzWG1seXRxdEwxVHRIZFJyQ0ZreFh2dG0xYXEyck9QOUtuRXN5SjVKbDlibGFIWCt2YkR5QUFcL2F1dzQ1NjJHNWxEa0I4Mlh3QnhpNlJUVDB3U1l3WDdzV2Rja1Y0RzNtRE4zZXl1Wmd1UndMbmtYeks0SmVYZWRyZGhraVVqQ0UxYjhYaFJhTE0yRlFoTWI4aUsySHI3SFhGMktwSFZPMnJRRWU0dEIwQlFSV0dzTHBjOXRsQ0RUTnBGNWJKTmh3VXhGRDhZSW5WcHJ0QUU9IiwibWFjIjoiNWRiZTJmZWJjMTg2MDAxMDgyNjJlMWZhNWY4ZDFkMTQ1ZDIxN2ExMTEzNzM1NmRiOTg3ZTU3OGMxNzBkYWVkYSJ9",
+                        "status": "ACTIVE",
+                        "data_source_category_id": "2",
+                        "created_at": "2022-09-15T16:42:16+00:00",
+                        "updated_at": "2022-10-21T20:12:04+00:00",
+                        "operations": null,
+                        "validationStatus": [],
+                        "files": [],
+                        "localCertificateFile": null,
+                        "wsdlFile": null,
+                        "xsdFiles": [],
+                        "title": "Students",
+                        "key": "package-data-sources\/data-source-task-service"
+                    },
+                    "script_id": "2",
+                    "script_key": "package-data-sources\/data-source-task-service",
+                    "uid": "16667071052851"
+                }
+            ],
+            "categories": [
+                {
+                    "id": 6,
+                    "uuid": "97460483-4575-4032-94a2-dc23a7b4efea",
+                    "name": "catpaoScreen",
+                    "status": "ACTIVE",
+                    "is_system": 0,
+                    "created_at": "2022-02-09T15:19:37+00:00",
+                    "updated_at": "2022-09-15T19:23:12+00:00",
+                    "pivot": {
+                        "assignable_id": 685,
+                        "category_id": 6,
+                        "category_type": "ProcessMaker\\Models\\ScreenCategory"
+                    }
+                }
+            ]
+        }
+    ],
+    "screen_categories": [],
+    "scripts": [
+        {
+            "id": 1,
+            "uuid": "9745be69-db1b-4748-878e-c2147659730d",
+            "key": "connector-pdf-print\/processmaker-communication-pdf-print",
+            "title": "Render PDF",
+            "description": "Renders PDF from HTML",
+            "language": "PHP",
+            "code": "<?php\n\nuse GuzzleHttp\\Client;\nuse GuzzleHttp\\Psr7\\Request;\n\n$api_token = getenv('API_TOKEN');\n$client = new Client([\n    'base_uri' => getenv('HOST_URL'),\n    'verify' => false,\n    'defaults' => [\n        'verify' => false,\n        'headers' => [\n            'Content-Type' => 'application\/json',\n            'Accept' => 'application\/json',\n            'Authorization' => 'Bearer ' . getenv('API_TOKEN'),\n        ],\n    ],\n]);\n\n\/\/ Get the selected screen to render\n$screen_id = $config['screenRef'];\n\n\/\/ POST the screen to generate PDF\n$postData = [\n    'config' => $config,\n    'data' => $data,\n];\n\n$response = $client->post('\/api\/1.0\/connector-pdf-print\/generatePdf\/' . $screen_id . '\/' . $data['_request']['id'],\n    [\n        GuzzleHttp\\RequestOptions::JSON => $postData,\n    ]\n);\n\nif ($response->getStatusCode() != 200) {\n    throw new \\Exception('Error posting message: ' . $response->getBody());\n}\n\n$data = json_decode($response->getBody()->getContents());\n\nreturn $data->data;\n",
+            "timeout": 300,
+            "run_as_user_id": 2,
+            "created_at": "2022-09-15T16:07:11+00:00",
+            "updated_at": "2022-09-15T16:07:11+00:00",
+            "status": "ACTIVE",
+            "script_category_id": "2",
+            "script_executor_id": 1,
+            "categories": [
+                {
+                    "id": 2,
+                    "uuid": "9745be69-d5ac-406c-b5db-02bb47ffc2dc",
+                    "name": "System",
+                    "status": "ACTIVE",
+                    "is_system": 1,
+                    "created_at": "2022-09-15T16:07:11+00:00",
+                    "updated_at": "2022-09-15T16:07:11+00:00",
+                    "pivot": {
+                        "assignable_id": 1,
+                        "category_id": 2,
+                        "category_type": "ProcessMaker\\Models\\ScriptCategory"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/e2e/fixtures/FOUR-6910_Watcher_Radio.json
+++ b/tests/e2e/fixtures/FOUR-6910_Watcher_Radio.json
@@ -1,0 +1,1207 @@
+{
+    "type": "screen_package",
+    "version": "2",
+    "screens": [
+        {
+            "id": 685,
+            "uuid": "97960bf8-237b-433e-95f1-443f2248d67e",
+            "screen_category_id": "6",
+            "title": "watcher - Radio",
+            "description": "watcher - Radio",
+            "type": "FORM",
+            "config": [
+                {
+                    "name": "watcher - Radio",
+                    "items": [
+                        {
+                            "items": [
+                                [
+                                    {
+                                        "label": "Checkbox",
+                                        "config": {
+                                            "icon": "fas fa-check-square",
+                                            "name": "enable",
+                                            "label": "enable",
+                                            "helper": null,
+                                            "toggle": false,
+                                            "disabled": false,
+                                            "validation": [],
+                                            "initiallyChecked": false
+                                        },
+                                        "component": "FormCheckbox",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "initiallyChecked",
+                                                "config": {
+                                                    "label": "Checked by default",
+                                                    "helper": "Should the checkbox be checked by default"
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "toggle",
+                                                "config": {
+                                                    "label": "Toggle Style",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "disabled",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormCheckbox",
+                                        "editor-component": "FormCheckbox"
+                                    }
+                                ],
+                                [
+                                    {
+                                        "label": "Select List",
+                                        "config": {
+                                            "icon": "fas fa-angle-double-down",
+                                            "name": "form_select_list_2",
+                                            "label": "radio",
+                                            "helper": null,
+                                            "options": {
+                                                "key": "data.name",
+                                                "value": "data.name",
+                                                "dataName": "response1",
+                                                "jsonData": null,
+                                                "renderAs": "checkbox",
+                                                "editIndex": null,
+                                                "pmqlQuery": null,
+                                                "dataSource": "dataObject",
+                                                "optionsList": [],
+                                                "removeIndex": null,
+                                                "showRenderAs": true,
+                                                "showJsonEditor": false,
+                                                "showOptionCard": false,
+                                                "selectedOptions": [],
+                                                "allowMultiSelect": false,
+                                                "showRemoveWarning": false,
+                                                "valueTypeReturned": "single",
+                                                "selectedDataSource": null
+                                            },
+                                            "readonly": false,
+                                            "validation": [],
+                                            "placeholder": null,
+                                            "rootElement": "response",
+                                            "dataSourceUrl": null,
+                                            "dataSourceEndpoint": null
+                                        },
+                                        "component": "FormSelectList",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "placeholder",
+                                                "config": {
+                                                    "label": "Placeholder Text",
+                                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "OptionsList",
+                                                "field": "options",
+                                                "config": {
+                                                    "label": null,
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "default-value-editor",
+                                                "field": "defaultValue",
+                                                "config": {
+                                                    "label": "Default Value",
+                                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "readonly",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormSelectList",
+                                        "editor-component": "FormSelectList"
+                                    },
+                                    {
+                                        "label": "Select List",
+                                        "config": {
+                                            "icon": "fas fa-angle-double-down",
+                                            "name": "form_select_list_3",
+                                            "label": "dropdown",
+                                            "helper": null,
+                                            "options": {
+                                                "key": "data.name",
+                                                "value": "data.name",
+                                                "dataName": "response1",
+                                                "jsonData": null,
+                                                "renderAs": "dropdown",
+                                                "editIndex": null,
+                                                "pmqlQuery": null,
+                                                "dataSource": "dataObject",
+                                                "optionsList": [],
+                                                "removeIndex": null,
+                                                "showRenderAs": true,
+                                                "showJsonEditor": false,
+                                                "showOptionCard": false,
+                                                "selectedOptions": [],
+                                                "allowMultiSelect": false,
+                                                "showRemoveWarning": false,
+                                                "valueTypeReturned": "single",
+                                                "selectedDataSource": null
+                                            },
+                                            "readonly": false,
+                                            "validation": [],
+                                            "placeholder": null,
+                                            "rootElement": "response",
+                                            "dataSourceUrl": null,
+                                            "dataSourceEndpoint": null
+                                        },
+                                        "component": "FormSelectList",
+                                        "inspector": [
+                                            {
+                                                "type": "FormInput",
+                                                "field": "name",
+                                                "config": {
+                                                    "name": "Variable Name",
+                                                    "label": "Variable Name",
+                                                    "helper": "A variable name is a symbolic name to reference information.",
+                                                    "validation": "regex:\/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$\/|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "label",
+                                                "config": {
+                                                    "label": "Label",
+                                                    "helper": "The label describes the field's name"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "placeholder",
+                                                "config": {
+                                                    "label": "Placeholder Text",
+                                                    "helper": "The placeholder is what is shown in the field when no value is provided yet"
+                                                }
+                                            },
+                                            {
+                                                "type": "ValidationSelect",
+                                                "field": "validation",
+                                                "config": {
+                                                    "label": "Validation Rules",
+                                                    "helper": "The validation rules needed for this field"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "helper",
+                                                "config": {
+                                                    "label": "Helper Text",
+                                                    "helper": "Help text is meant to provide additional guidance on the field's value"
+                                                }
+                                            },
+                                            {
+                                                "type": "OptionsList",
+                                                "field": "options",
+                                                "config": {
+                                                    "label": null,
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "color",
+                                                "config": {
+                                                    "label": "Text Color",
+                                                    "helper": "Set the element's text color",
+                                                    "options": [
+                                                        {
+                                                            "value": "text-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "text-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "text-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "text-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "text-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "text-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "text-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "text-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "ColorSelect",
+                                                "field": "bgcolor",
+                                                "config": {
+                                                    "label": "Background Color",
+                                                    "helper": "Set the element's background color",
+                                                    "options": [
+                                                        {
+                                                            "value": "alert alert-primary",
+                                                            "content": "primary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-secondary",
+                                                            "content": "secondary"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-success",
+                                                            "content": "success"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-danger",
+                                                            "content": "danger"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-warning",
+                                                            "content": "warning"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-info",
+                                                            "content": "info"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-light",
+                                                            "content": "light"
+                                                        },
+                                                        {
+                                                            "value": "alert alert-dark",
+                                                            "content": "dark"
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            {
+                                                "type": "default-value-editor",
+                                                "field": "defaultValue",
+                                                "config": {
+                                                    "label": "Default Value",
+                                                    "helper": "The default value is pre populated using the existing request data. This feature will allow you to modify the value displayed on screen load if needed."
+                                                }
+                                            },
+                                            {
+                                                "type": "FormCheckbox",
+                                                "field": "readonly",
+                                                "config": {
+                                                    "label": "Read Only",
+                                                    "helper": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "conditionalHide",
+                                                "config": {
+                                                    "label": "Visibility Rule",
+                                                    "helper": "This control is hidden until this expression is true"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customFormatter",
+                                                "config": {
+                                                    "label": "Custom Format String",
+                                                    "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                                    "validation": null
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "customCssSelector",
+                                                "config": {
+                                                    "label": "CSS Selector Name",
+                                                    "helper": "Use this in your custom css rules",
+                                                    "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "ariaLabel",
+                                                "config": {
+                                                    "label": "Aria Label",
+                                                    "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                                }
+                                            },
+                                            {
+                                                "type": "FormInput",
+                                                "field": "tabindex",
+                                                "config": {
+                                                    "label": "Tab Order",
+                                                    "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                                    "validation": "regex: [0-9]*"
+                                                }
+                                            }
+                                        ],
+                                        "editor-control": "FormSelectList",
+                                        "editor-component": "FormSelectList"
+                                    }
+                                ]
+                            ],
+                            "label": "Multicolumn \/ Table",
+                            "config": {
+                                "icon": "fas fa-table",
+                                "label": null,
+                                "options": [
+                                    {
+                                        "value": "1",
+                                        "content": "6"
+                                    },
+                                    {
+                                        "value": "2",
+                                        "content": "6"
+                                    }
+                                ]
+                            },
+                            "component": "FormMultiColumn",
+                            "container": true,
+                            "inspector": [
+                                {
+                                    "type": "ContainerColumns",
+                                    "field": "options",
+                                    "config": {
+                                        "label": "Column Width",
+                                        "helper": null,
+                                        "validation": "columns-adds-to-12"
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "color",
+                                    "config": {
+                                        "label": "Text Color",
+                                        "helper": "Set the element's text color",
+                                        "options": [
+                                            {
+                                                "value": "text-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "text-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "text-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "text-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "text-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "text-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "text-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "text-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "ColorSelect",
+                                    "field": "bgcolor",
+                                    "config": {
+                                        "label": "Background Color",
+                                        "helper": "Set the element's background color",
+                                        "options": [
+                                            {
+                                                "value": "alert alert-primary",
+                                                "content": "primary"
+                                            },
+                                            {
+                                                "value": "alert alert-secondary",
+                                                "content": "secondary"
+                                            },
+                                            {
+                                                "value": "alert alert-success",
+                                                "content": "success"
+                                            },
+                                            {
+                                                "value": "alert alert-danger",
+                                                "content": "danger"
+                                            },
+                                            {
+                                                "value": "alert alert-warning",
+                                                "content": "warning"
+                                            },
+                                            {
+                                                "value": "alert alert-info",
+                                                "content": "info"
+                                            },
+                                            {
+                                                "value": "alert alert-light",
+                                                "content": "light"
+                                            },
+                                            {
+                                                "value": "alert alert-dark",
+                                                "content": "dark"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "MultiColumn",
+                            "editor-component": "MultiColumn"
+                        },
+                        {
+                            "label": "Submit Button",
+                            "config": {
+                                "icon": "fas fa-share-square",
+                                "name": null,
+                                "event": "submit",
+                                "label": "New Submit",
+                                "tooltip": [],
+                                "variant": "primary",
+                                "fieldValue": null,
+                                "defaultSubmit": true
+                            },
+                            "component": "FormButton",
+                            "inspector": [
+                                {
+                                    "type": "FormInput",
+                                    "field": "label",
+                                    "config": {
+                                        "label": "Label",
+                                        "helper": "The label describes the button's text"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "name",
+                                    "config": {
+                                        "name": "Variable Name",
+                                        "label": "Variable Name",
+                                        "helper": "A variable name is a symbolic name to reference information.",
+                                        "validation": "regex:\/^(?:[A-Za-z])(?:[0-9A-Z_.a-z])*(?<![.])$\/|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "event",
+                                    "config": {
+                                        "label": "Type",
+                                        "helper": "Choose whether the button should submit the form",
+                                        "options": [
+                                            {
+                                                "value": "submit",
+                                                "content": "Submit Button"
+                                            },
+                                            {
+                                                "value": "script",
+                                                "content": "Regular Button"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": {
+                                        "props": [
+                                            "label",
+                                            "value",
+                                            "helper"
+                                        ],
+                                        "watch": {
+                                            "value": {
+                                                "immediate": true
+                                            }
+                                        },
+                                        "methods": [],
+                                        "computed": [],
+                                        "_compiled": true,
+                                        "inheritAttrs": false,
+                                        "staticRenderFns": []
+                                    },
+                                    "field": "tooltip",
+                                    "config": {
+                                        "label": "Tooltip"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "fieldValue",
+                                    "config": {
+                                        "label": "Value",
+                                        "helper": "The value being submitted"
+                                    }
+                                },
+                                {
+                                    "type": "FormMultiselect",
+                                    "field": "variant",
+                                    "config": {
+                                        "label": "Button Variant Style",
+                                        "helper": "The variant determines the appearance of the button",
+                                        "options": [
+                                            {
+                                                "value": "primary",
+                                                "content": "Primary"
+                                            },
+                                            {
+                                                "value": "secondary",
+                                                "content": "Secondary"
+                                            },
+                                            {
+                                                "value": "success",
+                                                "content": "Success"
+                                            },
+                                            {
+                                                "value": "danger",
+                                                "content": "Danger"
+                                            },
+                                            {
+                                                "value": "warning",
+                                                "content": "Warning"
+                                            },
+                                            {
+                                                "value": "info",
+                                                "content": "Info"
+                                            },
+                                            {
+                                                "value": "light",
+                                                "content": "Light"
+                                            },
+                                            {
+                                                "value": "dark",
+                                                "content": "Dark"
+                                            },
+                                            {
+                                                "value": "link",
+                                                "content": "Link"
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "conditionalHide",
+                                    "config": {
+                                        "label": "Visibility Rule",
+                                        "helper": "This control is hidden until this expression is true"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customFormatter",
+                                    "config": {
+                                        "label": "Custom Format String",
+                                        "helper": "Use the Mask Pattern format <br> Date ##\/##\/#### <br> SSN ###-##-#### <br> Phone (###) ###-####",
+                                        "validation": null
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "customCssSelector",
+                                    "config": {
+                                        "label": "CSS Selector Name",
+                                        "helper": "Use this in your custom css rules",
+                                        "validation": "regex: [-?[_a-zA-Z]+[_-a-zA-Z0-9]*]"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "ariaLabel",
+                                    "config": {
+                                        "label": "Aria Label",
+                                        "helper": "Attribute designed to help assistive technology (e.g. screen readers) attach a label"
+                                    }
+                                },
+                                {
+                                    "type": "FormInput",
+                                    "field": "tabindex",
+                                    "config": {
+                                        "label": "Tab Order",
+                                        "helper": "Order in which a user will move focus from one control to another by pressing the Tab key",
+                                        "validation": "regex: [0-9]*"
+                                    }
+                                }
+                            ],
+                            "editor-control": "FormSubmit",
+                            "editor-component": "FormButton"
+                        }
+                    ]
+                }
+            ],
+            "computed": [],
+            "custom_css": null,
+            "created_at": "2022-10-25T14:10:17+00:00",
+            "updated_at": "2022-10-25T14:28:39+00:00",
+            "status": "ACTIVE",
+            "key": null,
+            "watchers": [
+                {
+                    "input_data": "{}",
+                    "script_configuration": "{\"dataSource\":\"2\",\"dataMapping\":[{\"key\":\"response1\",\"value\":\"data\"}],\"endpoint\":\"ListAll\"}",
+                    "synchronous": true,
+                    "show_async_loading": false,
+                    "run_onload": false,
+                    "name": "watcher  radio",
+                    "watching": "enable",
+                    "script": {
+                        "id": "data_source-2",
+                        "uuid": "9745caf6-4ceb-45f8-97d9-0316ee54948c",
+                        "name": "Students",
+                        "description": null,
+                        "endpoints": {
+                            "ListAll": {
+                                "url": "\/api\/1.0\/collections\/1\/records",
+                                "body": null,
+                                "method": "GET",
+                                "headers": [],
+                                "purpose": "ListAll",
+                                "testData": "{}",
+                                "description": "Collection list all records"
+                            },
+                            "GetRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": null,
+                                "method": "GET",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": "{{record}}",
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "GetRecord",
+                                "updated": "2022-10-10 15:31:16",
+                                "testData": "{}",
+                                "body_type": "json",
+                                "description": "Collection get record by record id"
+                            },
+                            "CreateRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records",
+                                "body": "{\n    \"data\": {\n        \"date\": \"{{date}}\",\n        \"CI\": \"{{CI}}\",\n        \"name\": \"{{name}}\",\n        \"lastName\": \"{{lastName}}\",\n        \"profession\": \"{{profession}}\",\n        \"telephone\": \"{{telephone}}\"\n    }\n}",
+                                "method": "POST",
+                                "headers": [],
+                                "purpose": "CreateRecord",
+                                "updated": "2022-10-21 20:12:03",
+                                "testData": "{\n    \"date\": \"2022-10-21 20:11:03\",\n    \"CI\": \"4545444\",\n    \"name\": \"nombre\",\n    \"lastName\": \"apellido\",\n    \"profession\": \"qa\",\n    \"telephone\": \"11111111\"\n}",
+                                "body_type": "json",
+                                "description": "Collection create record"
+                            },
+                            "DeleteRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": null,
+                                "method": "DELETE",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": null,
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "DeleteRecord",
+                                "testData": "{}",
+                                "description": "Collection delete record"
+                            },
+                            "UpdateRecord": {
+                                "url": "\/api\/1.0\/collections\/1\/records\/{{record_id}}",
+                                "body": "{\"data\":[]}",
+                                "method": "PUT",
+                                "params": [
+                                    {
+                                        "id": 0,
+                                        "key": "record_id",
+                                        "value": null,
+                                        "required": true
+                                    }
+                                ],
+                                "headers": [],
+                                "purpose": "UpdateRecord",
+                                "testData": "{}",
+                                "description": "Collection update record"
+                            },
+                            "TruncateCollection": {
+                                "url": "\/api\/1.0\/collections\/1\/truncate",
+                                "body": null,
+                                "method": "DELETE",
+                                "headers": [],
+                                "purpose": "TruncateCollection",
+                                "testData": "{}",
+                                "description": "Delete all records in collection"
+                            }
+                        },
+                        "mappings": null,
+                        "type": "REST",
+                        "authtype": "OAUTH2_BEARER",
+                        "debug_mode": false,
+                        "credentials": "eyJpdiI6IlRKdUE5K2hXTFwvelhwWkc4RGFwdXdnPT0iLCJ2YWx1ZSI6IkpadlJUZzdCbmFqN1ZwcHlwYUFpUmNkRkkzZmJuU0l1VEYxMHRubTRld1c5OWlvamt0bytCZXBEN2pIOCt6UWtwcFFUVlNBV2VQK1FGMnFndUgwcDVQa1lMUTVHMVZXSEVcL09tNk5OcTlvNzU0T3dqQXJLaTZNSHBDZE5zdHpEa1gxeDdPXC9SbVRNZ1NGVHJmZWNCQmRHN3ZqbDFRaE41OFdoSnVTeWVNajFlSjlTRXc2eDlUdXZTK1k5SUhQaFFyVXJqTThqclVSQXROV3A5aUZQK2E3WVdrbUU3WExBOWtlUWR0VGFVM2MwYWhtSmtJczN2cE5OT3psUXErSENyaTJ4ZmhPczRpNGd1aUFpOFVCYzhFYlZma0RsQWc5M2NtVzJZMTltdk5FV21KUUxraHN5ek52bWo0bmxmTzVxUmFqN09oV3QzUzVIOHBPSTNUdGZ2NUZpcTJpaWcwa2ZGKzlPQ3BxazA4RjZQdWRMcUVLR0o2T0gxQTJtSGc5TUx2K3NHZ3pGaE51VkFXc25Sb2JzNmhad3FjSHJPUktVQ2FjM2cydERmcGNjOUJnOUJJeFhlbDY3YzNDSWpjT3dSdzNUWU9MQlYreFlKT1FlaGVwXC96Vkw1MzJ1d0ROK1RYRDdKZ1wvS1RYNkxsYnVFTktwT2lPU3hZMEVSTGxaZTRTZUdwaTR5N1wvanpBUmpQVmwrUG9hZFo5dlppSmR5dXNJeEhDVjNwUG9cL29oZFNOZTIzZjJBVEw3eEIwcW5kRGlwV2psSzlXbk9vMnBPXC9LWEF4KzBQSUJ5K1E0RmpWU2tWc0F3ZE45XC8zdVwvUWRLNWxCQTNIdzF6dFFGYjZrd2o5SVN5cGNRUytrWkUzdGVrdFpEcGxyTmxFR0N2SFRJNURLV2oyNDhtb0VFeVU4Ym5RZDNDK1NBUTFPQ1F1TWN3eWVhbHg5TnVDSUcrREswSjFhakdEYjdwSkJhaGgwSU9ZSThJaGV2SEQzd3hyd0R2b2UwOWtSWUlrYlwvVVE0QU9GNEpcL0M0Z3ZDOVowZXpLNE4wbjRzRFBxTjlKNFFyZGdadFlJMlwvd2tQMjlRXC9rZCtvUm9vT2g5aTh2R1J6SDUzSlZQUStLcWgyUiswNTkxa3JyNkxSQXNlQkJrU0pQZEljS1ZNK2VDWFBXMzdyUDdsY1wvS0ZcL1VyV1hrRG4wZzE4eXppOHVJOFNXd2x1MkI0M05kRHRoYVlOTCtKQjROY2lkSENTXC80dE8zWFVnVjM0QzV0QURTcEVScUJXVU9adFoycVJ3RnRac3JxUmZEcVwva2lFM1Bydjd6aWdmVytmOE5zendmb0ZrSjIweVMyN0VUanZUSDVcL0p6RWM2OVEzOUtENFpoWnJGcjA4VHpmYkREZHhlak8yQVBcL00yNjJwXC92VklvRzVadEJ4ejk1N0NUUjJBXC9vMURNN3lSVDA2Qk9KU1E0QTBySUVPK2xDdFJ4KzV0WUFWUXNyckRvRlpNMmxzWG1seXRxdEwxVHRIZFJyQ0ZreFh2dG0xYXEyck9QOUtuRXN5SjVKbDlibGFIWCt2YkR5QUFcL2F1dzQ1NjJHNWxEa0I4Mlh3QnhpNlJUVDB3U1l3WDdzV2Rja1Y0RzNtRE4zZXl1Wmd1UndMbmtYeks0SmVYZWRyZGhraVVqQ0UxYjhYaFJhTE0yRlFoTWI4aUsySHI3SFhGMktwSFZPMnJRRWU0dEIwQlFSV0dzTHBjOXRsQ0RUTnBGNWJKTmh3VXhGRDhZSW5WcHJ0QUU9IiwibWFjIjoiNWRiZTJmZWJjMTg2MDAxMDgyNjJlMWZhNWY4ZDFkMTQ1ZDIxN2ExMTEzNzM1NmRiOTg3ZTU3OGMxNzBkYWVkYSJ9",
+                        "status": "ACTIVE",
+                        "data_source_category_id": "2",
+                        "created_at": "2022-09-15T16:42:16+00:00",
+                        "updated_at": "2022-10-21T20:12:04+00:00",
+                        "operations": null,
+                        "validationStatus": [],
+                        "files": [],
+                        "localCertificateFile": null,
+                        "wsdlFile": null,
+                        "xsdFiles": [],
+                        "title": "Students",
+                        "key": "package-data-sources\/data-source-task-service"
+                    },
+                    "script_id": "2",
+                    "script_key": "package-data-sources\/data-source-task-service",
+                    "uid": "16667071052851"
+                }
+            ],
+            "categories": [
+                {
+                    "id": 6,
+                    "uuid": "97460483-4575-4032-94a2-dc23a7b4efea",
+                    "name": "catpaoScreen",
+                    "status": "ACTIVE",
+                    "is_system": 0,
+                    "created_at": "2022-02-09T15:19:37+00:00",
+                    "updated_at": "2022-09-15T19:23:12+00:00",
+                    "pivot": {
+                        "assignable_id": 685,
+                        "category_id": 6,
+                        "category_type": "ProcessMaker\\Models\\ScreenCategory"
+                    }
+                }
+            ]
+        }
+    ],
+    "screen_categories": [],
+    "scripts": [
+        {
+            "id": 1,
+            "uuid": "9745be69-db1b-4748-878e-c2147659730d",
+            "key": "connector-pdf-print\/processmaker-communication-pdf-print",
+            "title": "Render PDF",
+            "description": "Renders PDF from HTML",
+            "language": "PHP",
+            "code": "<?php\n\nuse GuzzleHttp\\Client;\nuse GuzzleHttp\\Psr7\\Request;\n\n$api_token = getenv('API_TOKEN');\n$client = new Client([\n    'base_uri' => getenv('HOST_URL'),\n    'verify' => false,\n    'defaults' => [\n        'verify' => false,\n        'headers' => [\n            'Content-Type' => 'application\/json',\n            'Accept' => 'application\/json',\n            'Authorization' => 'Bearer ' . getenv('API_TOKEN'),\n        ],\n    ],\n]);\n\n\/\/ Get the selected screen to render\n$screen_id = $config['screenRef'];\n\n\/\/ POST the screen to generate PDF\n$postData = [\n    'config' => $config,\n    'data' => $data,\n];\n\n$response = $client->post('\/api\/1.0\/connector-pdf-print\/generatePdf\/' . $screen_id . '\/' . $data['_request']['id'],\n    [\n        GuzzleHttp\\RequestOptions::JSON => $postData,\n    ]\n);\n\nif ($response->getStatusCode() != 200) {\n    throw new \\Exception('Error posting message: ' . $response->getBody());\n}\n\n$data = json_decode($response->getBody()->getContents());\n\nreturn $data->data;\n",
+            "timeout": 300,
+            "run_as_user_id": 2,
+            "created_at": "2022-09-15T16:07:11+00:00",
+            "updated_at": "2022-09-15T16:07:11+00:00",
+            "status": "ACTIVE",
+            "script_category_id": "2",
+            "script_executor_id": 1,
+            "categories": [
+                {
+                    "id": 2,
+                    "uuid": "9745be69-d5ac-406c-b5db-02bb47ffc2dc",
+                    "name": "System",
+                    "status": "ACTIVE",
+                    "is_system": 1,
+                    "created_at": "2022-09-15T16:07:11+00:00",
+                    "updated_at": "2022-09-15T16:07:11+00:00",
+                    "pivot": {
+                        "assignable_id": 1,
+                        "category_id": 2,
+                        "category_type": "ProcessMaker\\Models\\ScriptCategory"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/e2e/specs/SelectListWatcher.spec.js
+++ b/tests/e2e/specs/SelectListWatcher.spec.js
@@ -1,0 +1,98 @@
+describe("SelectList - Watcher", () => {
+  const watcherResponse = [
+    {
+      id: 1,
+      created_by_id: 2,
+      updated_by_id: 2,
+      created_at: "2021-11-08 10:29:56",
+      updated_at: "2021-11-08 10:29:56",
+      data: {
+        id: 1,
+        name: "John"
+      },
+      collection_id: 2,
+      title: "1"
+    },
+    {
+      id: 2,
+      created_by_id: 2,
+      updated_by_id: 2,
+      created_at: "2021-11-08 10:29:56",
+      updated_at: "2021-11-08 10:29:56",
+      data: {
+        id: 2,
+        name: "Mary"
+      },
+      collection_id: 2,
+      title: "2"
+    }
+  ];
+
+  beforeEach(() => {
+    cy.server();
+    // Mock the response from the data source
+    cy.route(
+      "POST",
+      "/api/1.0/requests/data_sources/2",
+      JSON.stringify({
+        // Note: Mapping is done by the endpoint, not by the watcher
+        response1: watcherResponse
+      })
+    ).as("getWatcherResponse");
+    cy.visit("/");
+  });
+
+  it("Verify Radio select list loaded by watcher", () => {
+    cy.loadFromJson("FOUR-6910_Watcher_Radio.json", 0);
+    // set init screen test data
+    // cy.setPreviewDataInput({person: []});
+    cy.get("[data-cy=mode-preview]").click();
+
+    cy.get("[data-cy=preview-content] [name=enable]").click();
+
+    // Select "John" option in radio buttons "form_select_list_2"
+    cy.get(
+      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+    ).click();
+
+    // Select "Mary" option in select list "form_select_list_3"
+    cy.get(
+      "[data-cy=preview-content] [data-cy=screen-field-form_select_list_3]"
+    ).selectOption("Mary");
+
+    // Check the data of the screen
+    cy.assertPreviewData({
+      enable: true,
+      form_select_list_2: "John",
+      form_select_list_3: "Mary",
+      response1: watcherResponse
+    });
+  });
+
+  it("Verify Checkbox select list loaded by watcher", () => {
+    cy.loadFromJson("FOUR-6910_Watcher_Checkbox.json", 0);
+    // set init screen test data
+    // cy.setPreviewDataInput({person: []});
+    cy.get("[data-cy=mode-preview]").click();
+
+    cy.get("[data-cy=preview-content] [name=enable]").click();
+
+    // Select "John" option in radio buttons "form_select_list_2"
+    cy.get(
+      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+    ).click();
+
+    // Select "Mary" option in select list "form_select_list_3"
+    cy.get(
+      "[data-cy=preview-content] [data-cy=screen-field-form_select_list_3]"
+    ).selectOption("Mary");
+
+    // Check the data of the screen
+    cy.assertPreviewData({
+      enable: true,
+      form_select_list_2: ["John"],
+      form_select_list_3: ["Mary"],
+      response1: watcherResponse
+    });
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List of type Radio (and also Checkbox) does not refresh its options after a watcher execution.

Expected behavior: 
After the watcher load the values for the select list options, these options should be updated in the select list control.

Actual behavior: 
Select List of type Radio (and also Checkbox) does not refresh its options after a watcher execution.

## Solution
- Add missing reactivity to refresh the Radio and Checkbox options.

## How to Test
1. Import the screen attached in the ticket
2. Setup the required collection and data source
3. Update the screen watcher to point the prepared data source in step 2
4. Preview the screen
5. Enable the checkbox to trigger the watcher

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6910

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
