### PR TITLE
Four 6957 detect circular references 4 2

### DIFF
--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -3,7 +3,7 @@ import { Parser } from 'expr-eval';
 
 export default {
   methods: {
-    evaluateExpression(expression, type) {
+    evaluateExpression(expression, type, selfName) {
       const self = this;
       let value = null;
 
@@ -14,6 +14,11 @@ export default {
 
         const data = new Proxy({}, {
           get(data, name) {
+            // Detect circular reference
+            if (name === selfName) {
+              console.warn(`Circular reference detected in calculated property ${name}`);
+              return;
+            }
             if (self[name] === undefined || !isEqual(self[name], self.vdata[name])) {
               return self.vdata[name];
             } else {

--- a/src/mixins/extensions/ComputedFields.js
+++ b/src/mixins/extensions/ComputedFields.js
@@ -11,8 +11,9 @@ export default {
           get: (() => {
             const formula = JSON.stringify(computed.formula);
             const type = JSON.stringify(computed.type);
+            const property = JSON.stringify(computed.property);
 
-            return new Function(`return this.evaluateExpression(${formula}, ${type});`);
+            return new Function(`return this.evaluateExpression(${formula}, ${type}, ${property});`);
           })(),
           set() {
             // Do nothing (as it's not allowed)


### PR DESCRIPTION
## Issue & Reproduction Steps
A circular reference triggers the calculated properties multiple times during screen render and execution.

Expected behavior: 
Prevent circular references in calculated properties.

Actual behavior: 
A circular reference triggers the calculated properties multiple times during screen render and execution.

## Solution
- Detect and cancel circular references.

## How to Test
- Run the process attached in the ticket.
- https://processmaker.atlassian.net/browse/FOUR-6957?focusedCommentId=291444
[testNestedScreen.zip](https://github.com/ProcessMaker/screen-builder/files/9914272/testNestedScreen.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6957?focusedCommentId=291444

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
