### PR TITLE
Use correct URL for file download in web entry

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -114,6 +114,9 @@ export default {
 
       if (_.has(window, 'PM4ConfigOverrides.useDefaultUrlDownload') && window.PM4ConfigOverrides.useDefaultUrlDownload) {
         // Use default endpoint when coming from a package.
+        if (this.requestId) {
+          return `requests/${this.requestId}/files/${file.id}/contents`;
+        }
         return `../files/${file.id}/contents`;
       }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

See https://processmaker.atlassian.net/browse/FOUR-6836

## Solution
- Use the correct URL when files are read from webentry

## How to Test
Follow reproduction steps in https://processmaker.atlassian.net/browse/FOUR-6836

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6836

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
