### PR TITLE
Bugfix/FOUR-7111: Previewing a screen that contains a nested screen and another control causes two 404 error calls

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -99,6 +99,10 @@ export default {
     });
   },
   getScreen(id, query = "") {
+    if (!id) {
+      return null;
+    }
+
     const cachedPromise = this.cachedScreenPromises.find(
       (item) => item.id === id && item.query === query
     );
@@ -117,10 +121,6 @@ export default {
     );
     if (screensCacheHit) {
       return Promise.resolve({ data: screensCacheHit });
-    }
-
-    if (!id) {
-      return null;
     }
 
     const screenPromise = new Promise((resolve, reject) => {

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -119,6 +119,10 @@ export default {
       return Promise.resolve({ data: screensCacheHit });
     }
 
+    if (!id) {
+      return null;
+    }
+
     const screenPromise = new Promise((resolve, reject) => {
       this.get(`${endpoint}/${id}${query}`)
         .then((response) => {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -95,6 +95,9 @@ class FormNestedScreenValidations extends Validations {
     if (globalObject.nestedScreens['id_' + id]) {
       return globalObject.nestedScreens['id_' + id];
     }
+    if (!id) {
+      return null;
+    }
     const response = await DataProvider.getScreen(id);
     globalObject.nestedScreens['id_' + id] = response.data.config;
     return response.data.config;

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -89,20 +89,19 @@ class FormNestedScreenValidations extends Validations {
   }
 
   async loadScreen(id) {
+    if (!id) {
+      return null;
+    }
     if (!globalObject['nestedScreens']) {
       globalObject['nestedScreens'] = {};
     }
     if (globalObject.nestedScreens['id_' + id]) {
       return globalObject.nestedScreens['id_' + id];
     }
-    if (!id) {
-      return null;
-    }
     const response = await DataProvider.getScreen(id);
     globalObject.nestedScreens['id_' + id] = response.data.config;
     return response.data.config;
   }
-
 }
 
 /**


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to Reproduce:**

- Go to https://release-testing-qa.processmaker.net/ (PM 4.3.0-RC4)
- Go to Designer tab
- Go to screen option in sidebar menu
- Create a Form type screen
- Click on Add screen
- Fill a name and description
- In the type option, select “Form“
- Click on Save button
- Drag and drop a Nested Screen control.
- Drag a control of the following: Checkbox, Date Picker, File Upload, Google Places, Line Input, Loop, Record List, Select 
- List or Text Area (In the attached video I tested with a Text Area control)
- Open Devtools and go the network tab
- Click on Preview button


**Expected behavior:** 
A single call should be generated by the nested Screen.

**Actual behavior:** 
Two pop-ups with 404 error appear and two calls are generated.

## Solution
- Check if id exists before send the api request to retrieve the screen

**Working video**

https://user-images.githubusercontent.com/90727999/202778996-e4583dee-a14c-4c4a-a59d-6c15b49d3864.mov



## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-7111](https://processmaker.atlassian.net/browse/FOUR-7111)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
