### PR TITLE
Four 7147

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -43,6 +43,22 @@ export {
   Task,
 };
 
+/**
+ * Gets the screen parent or null if don't have
+ * @returns {object|null}
+ */
+ function findScreenOwner(control) {
+  let owner = control.$parent;
+  while (owner) {
+    const isScreen = owner.$options.name === "ScreenContent";
+    if (isScreen) {
+      return owner;
+    }
+    owner = owner.$parent;
+  }
+  return null;
+}
+
 // Export our Vue plugin as our default
 export default {
   install(Vue) {
@@ -87,6 +103,13 @@ export default {
       }
     });
     Vue.mixin({ store });
+
+    //Helper to access data reference.
+    Vue.mixin({ methods:{ getScreenDataReference(customProperties = null, setter = null) {
+      const control = this;
+      const screen = findScreenOwner(control);
+      return screen.getDataReference(customProperties, setter);
+    }}});
   }
 };
 

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -4,25 +4,7 @@ export default {
   methods: {
     visibilityRuleIsVisible(rule) {
       try {
-        const that = this;
-        const dataWithParent = new Proxy(
-          {},
-          {
-            get: (target, name) => {
-              if (name === "_parent") {
-                return that._parent;
-              }
-              return that.vdata[name];
-            },
-            has: (target, name) => {
-              if (name === "_parent") {
-                return that._parent !== undefined;
-              }
-              return that.vdata[name] !== undefined;
-            }
-          }
-        );
-        const isVisible = Boolean(Parser.evaluate(rule, dataWithParent));
+        const isVisible = Boolean(Parser.evaluate(rule, this.getDataReference()));
         return isVisible;
       } catch (e) {
         return false;


### PR DESCRIPTION
## Issue & Reproduction Steps
create screen
create the component with visibility rule with variable "_parent"
go to the preview screen 
add data in DataInput with value "_parent"
the component isn't visible.


Expected behavior: 
The visibility rule should be evaluated with the value "_parent".
Actual behavior: 
the visibility rule isn't evaluated with the value "_parent"
## Solution
- Change method to load data of screen.

## How to Test
Test the steps above

https://user-images.githubusercontent.com/1747025/204346027-76db6632-961c-4cf9-b3bc-7513ebda3e4f.mp4



## Related Tickets & Packages
- [FOUR-7147](https://processmaker.atlassian.net/browse/FOUR-7147)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
