### PR TITLE
FOUR-7158: Class submit is not disabled with field required 

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -14,11 +14,6 @@ import { mapState } from 'vuex';
 export default {
   mixins: [getValidPath],
   props: ['variant', 'label', 'event', 'eventData', 'name', 'fieldValue', 'value', 'tooltip', 'transientData'],
-  watch: {
-    valid(valid) {
-      this.isInvalid = !valid;
-    }
-  },
   computed: {
     ...mapState('globalErrorsModule', ['valid']),
     classList() {
@@ -26,7 +21,7 @@ export default {
       return {
         btn: true,
         ['btn-' + variant]: true,
-        disabled: this.event === 'submit' && this.isInvalid,
+        disabled: this.event === 'submit' && !this.valid
       };
     },
     options() {
@@ -48,11 +43,6 @@ export default {
         boundary: 'window',
       };
     },
-  },
-  data() {
-    return {
-      isInvalid: false,
-    };
   },
   methods: {
     setValue(parent, name, value) {


### PR DESCRIPTION
## Issue & Reproduction Steps

    Create a Screen with 2 pages
        On the first page
        Add any control like line input
        Add page navigator to second page
    On the Second page
        Add check box with required filed
        Add submit button
    Save the changes
    Go to the page where is the submit button
    Press preview button
    Go to until submit button
Button’s class is not disabled , when there are fields required 
## Solution
The property used to determine if the button was enabled/disabled was a Vue watcher that was not updated when expected. The problem is resolved when the Vuex store value is used directly.


## How to Test
Test the steps above

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-7158](https://processmaker.atlassian.net/browse/FOUR-7158)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
