### PR TITLE
Adding a query per file - FOUR-7233

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -121,6 +121,9 @@ export default {
     }
   },
   computed: {
+    hasVariableName () {
+      return this.name && typeof this.$parent[this.name] !== 'undefined';
+    },
     filesFromGlobalRequestFiles() {
       if (!this.value) {
         return [];
@@ -222,33 +225,33 @@ export default {
     },
     name: {
       handler() {
-        this.options.query.data_name = this.fileDataName;
+        this.staticQuery.data_name = this.fileDataName;
       },
       immediate: true,
     },
     parent: {
       handler() {
-        this.options.query.parent = this.parent;
+        this.staticQuery.parent = this.parent;
       },
       immediate: true,
     },
     prefix: {
       handler() {
-        this.options.query.data_name = this.fileDataName;
+        this.staticQuery.data_name = this.fileDataName;
       },
       immediate: true,
     },
     row_id: {
       handler() {
-        this.options.query.row_id = this.row_id;
-        this.options.query.data_name = this.prefix + this.name + (this.row_id ? '.' + this.row_id : '');
+        this.staticQuery.row_id = this.row_id;
+        this.staticQuery.data_name = this.prefix + this.name + (this.row_id ? '.' + this.row_id : '');
       },
       immediate: true,
     },
     multipleUpload: {
       handler() {
         // Add the multiple parameter for the endpoint call that will be executed by vue-simple-uploader
-        this.options.query.multiple = this.multipleUpload;
+        this.staticQuery.multiple = this.multipleUpload;
       },
       immediate: true,
     },
@@ -263,16 +266,23 @@ export default {
       },
       prefix: '',
       row_id: null,
+      staticQuery: {
+        chunk: true,
+        data_name: this.name,
+        parent: null,
+        row_id: null,
+      },
       options: {
+        query: (file) => {
+          const query = Object.assign({}, this.staticQuery);
+          if (!this.hasVariableName) {
+            query.data_name = file.name;
+          }
+          return query;
+        },
         target: this.getTargetUrl,
         // We cannot increase this until laravel chunk uploader handles this gracefully
         simultaneousUploads: 1,
-        query: {
-          chunk: true,
-          data_name: this.name,
-          parent: null,
-          row_id: null,
-        },
         testChunks: false,
         // Setup our headers to deal with API calls
         headers: {
@@ -462,9 +472,6 @@ export default {
         }
       }
       file.ignored = false;
-      if (!this.name) {
-        this.options.query.data_name = file.name;
-      }
       return true;
     },
     removeDefaultClasses() {


### PR DESCRIPTION
## Issue & Reproduction Steps

The wrong `data_name` was being sent when sending multiple files.

### Expected behavior: 
Submit the correct `data_name`.

### Actual behavior: 
The wrong `data_name` was being sent.

## Solution
- The data sent `query` with the upload must be one per file, not static as it was previously

## How to Test
- Go to file manager page
- Send multiple images (3)
- Try to open all images

[Multiple-Upload-Issue.webm](https://user-images.githubusercontent.com/16992680/209140712-9d1a1bec-3ab1-4964-ba02-da34d4d6522d.webm)

## Related Tickets & Packages
- [FOUR-7233](https://processmaker.atlassian.net/browse/FOUR-7233)
- [simple-uploader.js](https://github.com/simple-uploader/Uploader#configuration)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
