### PR TITLE
Bugfix/FOUR-7175: Border added automatically to the bottom of short WEB ENTRY screens

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -6,7 +6,7 @@
     class="tab-pane active show h-100"
   >
     <template v-if="screen">
-      <div class="card card-body border-top-0 h-100" :class="screenTypeClass">
+      <div class="card card-body border-top-0 h-100" :class="[screenTypeClass, webEntryClass]">
         <div v-if="renderComponent === 'task-screen'">
           <vue-form-renderer
             ref="renderer"
@@ -70,6 +70,7 @@ export default {
     initialRequestId: { type: Number, default: null },
     initialProcessId: { type: Number, default: null },
     initialNodeId: { type: String, default: null },
+    isWebEntry: { type: Boolean, default: false },
     userId: { type: Number, default: null },
     csrfToken: { type: String, default: null },
     value: { type: Object, default: () => {} },
@@ -206,6 +207,9 @@ export default {
       }
       const screenType = this.screen.type;
       return screenType.toLowerCase() + '-screen';
+    },
+    webEntryClass() {
+      return this.isWebEntry ? 'border-0' : '';
     },
     parentRequest() {
       return _.get(this.task, 'process_request.parent_request_id', null);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a web-entry screen with a single row of text
- View the web entry in the browser
- Notice the border on the bottom of the screen that is automatically added

Expected behavior: 
There should be no border at the bottom of the web-entry

Actual behavior: 
There is a border added to the bottom of short web-entry screens as a result of default Bootstrap Card styling

## Solution
- Add bootstrap class to remove border when is a webentry

**Working video**

https://user-images.githubusercontent.com/90727999/211328075-2fb5e5bb-6ccf-4dd1-8fce-61d60e704057.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-7175](https://processmaker.atlassian.net/browse/FOUR-7175)
- [WebEntry PR](https://github.com/ProcessMaker/package-webentry/pull/180)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7175]: https://processmaker.atlassian.net/browse/FOUR-7175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ