### PR TITLE
FOUR-6996: e2e test for Text Area

### DIFF
--- a/tests/e2e/specs/FormTextArea.spec.js
+++ b/tests/e2e/specs/FormTextArea.spec.js
@@ -1,0 +1,116 @@
+describe('Form Text Area Field', () => {
+  it('Default properties', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').type('Hello World');
+    cy.assertPreviewData({
+      form_text_area_1: 'Hello World',
+    });
+  });
+  it('Variable properties', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]').clear().type('comments');
+    cy.get('[data-cy=inspector-label]').clear().type('Comments');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content]').should('contain.html', 'Comments');
+    cy.get('[data-cy=preview-content] [name=comments]').type('Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockup.');
+    cy.assertPreviewData({
+      comments: 'Lorem ipsum is placeholder text commonly used in the graphic, print, and publishing industries for previewing layouts and visual mockup.',
+    });
+  });
+  it('Read Only', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=inspector-name]').clear().type('comments');
+    cy.get('[data-cy=inspector-label]').clear().type('Comments');
+
+    cy.get('[data-cy=inspector-readonly').check()
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=screen-field-comments').should('have.attr', 'readonly', 'readonly');
+  });
+
+  //Configuration
+  it('Placeholder', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-placeholder]').clear().type('enter text here');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').should('have.attr', 'placeholder', 'enter text here');
+  });
+  it('Helper Text', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-helper]').clear().type('helper text test');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content]').should('contain.html', 'helper text test');
+  });
+  it('Rich Text', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-richtext').check(); // Check checkbox element
+    cy.get('[data-cy=mode-preview]').click();
+    cy.setPreviewDataInput('{"form_text_area_1":"<p>Hello <b>World</b></p>"}');
+    cy.assertPreviewData({
+      form_text_area_1: '<p>Hello <b>World</b></p>',
+    });
+  });
+  it('Rows', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-rows]').clear().type('4');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').should('have.attr', 'rows', '4');
+  });
+  it('Default Value', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-basicValue]').clear().type('default value test');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.assertPreviewData({
+      form_text_area_1: 'default value test',
+    });
+  });
+  it('CSS Selector Name', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-customCssSelector]').clear().type('customSelector');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').parent().parent().should('have.attr', 'selector', 'customSelector');
+  });
+  it('Aria Label', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-ariaLabel]').clear().type('Aria label test');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').should('have.attr', 'aria-label', 'Aria label test');
+  });
+  it('Tab Order', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-tabindex]').clear().type('5');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [name=form_text_area_1]').should('have.attr', 'tabindex', '5');
+  });
+
+});


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The E2E test for the text Area field 

Actual behavior: 
Text area need some improvements

## Solution
- [x] Remove all the watch declarations if possible. Manly the ones that could use the deep: true flag
- [x] Remove all the computed properties if possible. Only the ones that really need to be reactive could be kept. It is better to evaluate then on data() create() * or mount()
- [x] Remove the v-bind="$attrs" if possible, it is better to define all the properties that the control can use including testing ones like data-cy
- [x] Avoid the use of transientData if possible.
- [x] v-if can reduce the reactivity (more than v-show) if it contains multiple reactive elements inside
- [x] Make sure v-for also includes a proper :key
- [X] Avoid the use of code like {... this.reactiveObject }e.g. { ...this.transientData } because it triggers the reactivity from all the properties of reactiveObject.


## How to Test
run the cypress tests

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6996
- https://github.com/ProcessMaker/vue-form-elements/pull/380

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
