### PR TITLE
Fix debounce of updateDataInputNow and updateDataPreview methods

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -400,6 +400,9 @@ export default {
       return warnings;
     },
   },
+  created() {
+    this.updateDataInput = debounce(this.updateDataInput, 1000);
+  },
   mounted() {
     this.countElements = debounce(this.countElements, 2000);
     if (globalObject.ProcessMaker && globalObject.ProcessMaker.user && globalObject.ProcessMaker.user.lang) {
@@ -422,10 +425,9 @@ export default {
   },
   methods: {
     ...mapMutations("globalErrorsModule", { setStoreMode: "setMode" }),
-    // eslint-disable-next-line func-names
-    updateDataInput: debounce(function () {
+    updateDataInput() {
       this.updateDataInputNow();
-    }, 1000),
+    },
     updateDataInputNow() {
       if (this.previewInputValid) {
         // Copy data over

--- a/src/App.vue
+++ b/src/App.vue
@@ -402,6 +402,7 @@ export default {
   },
   created() {
     this.updateDataInput = debounce(this.updateDataInput, 1000);
+    this.updateDataPreview = debounce(this.updateDataPreview, 1000);
   },
   mounted() {
     this.countElements = debounce(this.countElements, 2000);
@@ -435,10 +436,9 @@ export default {
         this.updateDataPreview();
       }
     },
-    // eslint-disable-next-line func-names
-    updateDataPreview: debounce(function () {
+    updateDataPreview() {
       this.previewDataStringify = JSON.stringify(this.previewData, null, 2);
-    }, 1000),
+    },
     monacoMounted(editor) {
       this.editor = editor;
       this.editor.updateOptions({ readOnly: true });

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -145,7 +145,6 @@ export default {
     },
     async submitForm() {
       await this.validateNow(findRootScreen(this));
-      console.log(this.valid__, this.message__);
       if (!this.valid__) {
         window.ProcessMaker.alert(this.message__, "danger");
         // if the form is not valid the data is not emitted


### PR DESCRIPTION
## Issue & Reproduction Steps
Incorrect debounce declaration of updateDataInputNow and updateDataPreview methods.

Expected behavior: 
Debounce the methods during the creation of the component.

Actual behavior: 
Incorrect debounce declaration of updateDataInputNow and updateDataPreview methods.

## Solution
- Fix debounce initialization following the guide: https://forum.vuejs.org/t/lodash-debounce-not-working-when-placed-inside-a-method/86334/5

## How to Test
- Create a simple screen with some fields like: input text, currency, select list
- Go to preview
- Input and change information
- Submit the form

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6888

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
