### PR TITLE
FOUR-7405 Watchers E2E file was only running 1 test of 10

### DIFF
--- a/tests/e2e/specs/Watchers.spec.js
+++ b/tests/e2e/specs/Watchers.spec.js
@@ -176,7 +176,7 @@ describe('Watchers', () => {
     cy.get('[data-cy="watchers-watcher-variable"] input').clear().type('form_input_1');
     cy.get('[data-cy="watchers-watcher-variable"]').should('contain.text', 'No elements found.');
     cy.get('[data-cy="watchers-button-save"]').click();
-    cy.get('#watcherConfig').should('contain.text', 'The Variable to Watch field is required');
+    cy.get('#watcherConfig').should('contain.text', 'The Variable to Watch * field is required');
   });
   it('Test synchronous watcher', () => {
     // Mock script response

--- a/tests/e2e/specs/Watchers.spec.js
+++ b/tests/e2e/specs/Watchers.spec.js
@@ -405,7 +405,7 @@ describe('Watchers', () => {
       ],
     });
   });
-  it.only('Focuses the first field that has an error', () => {
+  it('Focuses the first field that has an error', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy="topbar-watchers"]').click();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
We should run all the tests from the Watchers spec file

Actual behavior: 
Only one test of 10 were running

## Solution
- Removed the `.only` from the last test. Now all test should be running

## How to Test
Test the steps above
* Run `npm run open-cypress` after spinning up `npm run serve` and run the Watchers.spec.js file

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7405

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
