### PR TITLE
Fix pickTomorrow command to correctly select tomorrow on the last day of the week

### DIFF
--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -177,9 +177,30 @@ Cypress.Commands.add('pickYesterday', { prevSubject: true }, (subject) => {
   cy.get(subject).find('.day.today').prev().click();
 });
 
-Cypress.Commands.add('pickTomorrow', { prevSubject: true }, (subject) => {
-  cy.get(subject).find('input').click();
-  cy.get(subject).find('.day.today').next().click();
+Cypress.Commands.add("pickTomorrow", { prevSubject: true }, (subject) => {
+  // Click the input element to open the calendar
+  cy.get(subject).find("input").click();
+
+  // Find the "today" element and get its index
+  cy.get(subject)
+    .find(".day.today")
+    .should("exist")
+    .invoke("index")
+    .then((index) => {
+      // If today is the last day of the week, select the first day of the next week
+      if (index === 6) {
+        cy.get(subject)
+          .find(".day.today")
+          .parent()
+          .next()
+          .find(".day")
+          .first()
+          .click();
+      } else {
+        // Otherwise, select the next day
+        cy.get(subject).find(".day.today").next().click();
+      }
+    });
 });
 
 Cypress.Commands.add('pickTodayWithTime', { prevSubject: true }, (subject, hour, minute, period='AM') => {


### PR DESCRIPTION
The following test fails when it run the last day of the week (Feb 11, in the image).

![image](https://user-images.githubusercontent.com/8028650/218879564-fe74d8f2-1112-4cc8-b74a-8f40872c2c98.png)

### Expected behavior:

Fix pickTomorrow command should correctly select tomorrow on the last day of the week

## Solution
- Fix pickTomorrow command 

## How to Test

1. Run Screen Builder in development mode
2. Open the Cypress tests
3. Run the test ValidationRulesAdvanced.spec.js
4. The pick tomorrow step will fail (When executed the last day of the week)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7416

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
