### PR TITLE
FOUR-6704:Update Task.view with shouldRedirectToParentRequest()

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -209,12 +209,11 @@ export default {
     },
     parentRequest() {
       if (!_.get(this.task, 'can_view_parent_request', false)) {
-        console.log('Returning');
         return null;
       } else {
-        console.log('Get');
         return _.get(this.task, 'process_request.parent_request_id', null);
       }
+
     },
   },
   methods: {
@@ -291,7 +290,6 @@ export default {
       this.prepareTask();
     },
     closeTask(parentRequestId = null) {
-      console.log(parentRequestId, 'parentRequestId')
       if (this.hasErrors) {
         this.$emit('error', this.requestId);
         return;
@@ -316,9 +314,6 @@ export default {
       const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
-         
-          console.log(this.task);
-
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
             if (task.process_request_id !== this.requestId) {
@@ -335,6 +330,7 @@ export default {
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;
+          
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
           }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -208,7 +208,13 @@ export default {
       return screenType.toLowerCase() + '-screen';
     },
     parentRequest() {
-      return _.get(this.task, 'process_request.parent_request_id', null);
+      if (!_.get(this.task, 'can_view_parent_request', false)) {
+        console.log('Returning');
+        return null;
+      } else {
+        console.log('Get');
+        return _.get(this.task, 'process_request.parent_request_id', null);
+      }
     },
   },
   methods: {
@@ -285,6 +291,7 @@ export default {
       this.prepareTask();
     },
     closeTask(parentRequestId = null) {
+      console.log(parentRequestId, 'parentRequestId')
       if (this.hasErrors) {
         this.$emit('error', this.requestId);
         return;
@@ -309,6 +316,9 @@ export default {
       const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
+         
+          console.log(this.task);
+
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
             if (task.process_request_id !== this.requestId) {

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -724,7 +724,7 @@ describe('Task component', () => {
 
     cy.visit('/?scenario=TaskRedirect', {});
 
-    // cy.wait(2000);
+    
     cy.get('.form-group').find('button').click();
 
     cy.route('PUT', 'http://localhost:8080/api/1.0/tasks/1').then(function() {
@@ -744,7 +744,7 @@ describe('Task component', () => {
       );
       
       getTasks('http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1');
-      // cy.wait(2000);
+      
       cy.reload();
     });
 

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -29,7 +29,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -85,7 +85,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -145,7 +145,7 @@ describe('Task component', () => {
         .then(function() {
           cy.route(
             'GET',
-            'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+            'http://localhost:8080/api/1.0/tasks/1?include=*',
             {
               id: 1,
               advanceStatus: 'completed',
@@ -162,7 +162,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -220,7 +220,7 @@ describe('Task component', () => {
         .then(function() {
           cy.route(
             'GET',
-            'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+            'http://localhost:8080/api/1.0/tasks/1?include=*',
             {
               id: 1,
               advanceStatus: 'completed',
@@ -264,7 +264,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -329,7 +329,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -358,7 +358,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -384,7 +384,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=*',
         responseDataTask2
       );
 
@@ -404,7 +404,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -434,7 +434,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -453,7 +453,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=*',
         responseDataTask2
       );
 
@@ -474,7 +474,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -503,7 +503,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -528,7 +528,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask2['taskId']+'?include=*',
         responseDataTask2
       );
 
@@ -548,7 +548,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -577,7 +577,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -597,7 +597,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -626,7 +626,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -652,7 +652,7 @@ describe('Task component', () => {
     cy.server();
     cy.route(
       'GET',
-      'http://localhost:8080/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
         advanceStatus: 'open',
@@ -685,7 +685,7 @@ describe('Task component', () => {
       };
 
       getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=data,user,requestor,processRequest,component,screen,requestData,bpmnTagName,interstitial,definition,nested,userRequestPermission',
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
         responseDataTask1
       );
 
@@ -697,6 +697,60 @@ describe('Task component', () => {
 
     cy.url().should('eq', 'http://localhost:8080/requests/3');
   });
+
+  /* DNAT = Subprocess Next Assigned Task
+   parentTask1                           ParentTask2
+              \_______childTask1_______/
+                       (DNAT)
+   After childTask1 and not pending tasks should redirect to parent Request
+  */
+   it('When subprocess finishes but parent has not finished, redirect to sub-process request page.', () => {
+    cy.server();
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
+      {
+        id: 1,
+        advanceStatus: 'open',
+        component: 'task-screen',
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 2,
+          status: 'ACTIVE',
+          parent_request_id: 1,
+        },
+      }
+    );
+
+    cy.visit('/?scenario=TaskRedirect', {});
+
+    // cy.wait(2000);
+    cy.get('.form-group').find('button').click();
+
+    cy.route('PUT', 'http://localhost:8080/api/1.0/tasks/1').then(function() {
+      let responseDataTask1 = {
+        'status': 'CLOSED',
+        'process_request_id': 2,
+        'parent_request_id': 3,
+        'id': 1,
+        'screen': SingleScreen.screens[0],
+        'allow_interstitial': true,
+        'interstitial_screen': InterstitialScreen.screens[0],
+        'process_request_parent': {'status': 'CLOSED'},
+      };
+      getTask(
+        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
+        responseDataTask1
+      );
+      
+      getTasks('http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1');
+      // cy.wait(2000);
+      cy.reload();
+    });
+
+    cy.url().should('eq', 'http://localhost:8080/requests/3');
+  });
+
 });
 
 function getTask(url, responseData) {

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -698,59 +698,67 @@ describe('Task component', () => {
     cy.url().should('eq', 'http://localhost:8080/requests/3');
   });
 
-  /* DNAT = Subprocess Next Assigned Task
-   parentTask1                           ParentTask2
-              \_______childTask1_______/
-                       (DNAT)
-   After childTask1 and not pending tasks should redirect to parent Request
-  */
-   it('When subprocess finishes but parent has not finished, redirect to sub-process request page.', () => {
+
+  it('When user can view parent, redirect to parent request page.', () => {
     cy.server();
     cy.route(
       'GET',
       'http://localhost:8080/api/1.0/tasks/1?include=*',
       {
         id: 1,
-        advanceStatus: 'open',
+        status: 'COMPLETED',
         component: 'task-screen',
         screen: SingleScreen.screens[0],
         process_request: {
-          id: 2,
-          status: 'ACTIVE',
-          parent_request_id: 1,
+          id: 3,
+          status: 'COMPLETED',
+          parent_request_id: 2,
         },
+        can_view_parent_request: true,
       }
     );
 
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1',
+        {
+          data: []
+        }
+    );
+
     cy.visit('/?scenario=TaskRedirect', {});
-
-    
-    cy.get('.form-group').find('button').click();
-
-    cy.route('PUT', 'http://localhost:8080/api/1.0/tasks/1').then(function() {
-      let responseDataTask1 = {
-        'status': 'CLOSED',
-        'process_request_id': 2,
-        'parent_request_id': 3,
-        'id': 1,
-        'screen': SingleScreen.screens[0],
-        'allow_interstitial': true,
-        'interstitial_screen': InterstitialScreen.screens[0],
-        'process_request_parent': {'status': 'CLOSED'},
-      };
-      getTask(
-        'http://localhost:8080/api/1.0/tasks/'+responseDataTask1['id']+'?include=*',
-        responseDataTask1
-      );
-      
-      getTasks('http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1');
-      
-      cy.reload();
-    });
-
-    cy.url().should('eq', 'http://localhost:8080/requests/3');
+    cy.url().should('eq', 'http://localhost:8080/requests/2');
   });
 
+  it('When user can NOT view parent, redirect to subprocess request page.', () => {
+    cy.server();
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks/1?include=*',
+      {
+        id: 1,
+        status: 'COMPLETED',
+        component: 'task-screen',
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 3,
+          status: 'COMPLETED',
+          parent_request_id: 2,
+        },
+        can_view_parent_request: false,
+      }
+    );
+
+    cy.route(
+      'GET',
+      'http://localhost:8080/api/1.0/tasks?user_id=1&status=ACTIVE&process_request_id=1&include_sub_tasks=1',
+        {
+          data: []
+        }
+    );
+    cy.visit('/?scenario=TaskRedirect', {});
+    cy.url().should('eq', 'http://localhost:8080/requests/2');
+  });
 });
 
 function getTask(url, responseData) {
@@ -769,8 +777,10 @@ function getTask(url, responseData) {
         id: 1,
         parent_request_id: responseData['parent_request_id'],
         status: responseData['status'],
+        process_request_parent: responseData['status'],
+        process_request_parent: responseData['status']
       },
-      user_request_permission: responseData['user_request_permission']
+      process_request_parent: {'status': 'CLOSED'},
     }
   );
 }


### PR DESCRIPTION
Based on original by @estebangallego 

Ticket [FOUR-6704](https://processmaker.atlassian.net/browse/FOUR-6704)

## Issue & Reproduction Steps
In a subprocess after completing a task assigned to a user "By user ID" the message "Not Authorized" is displayed.

Current behavior: 
After completing the task with the assigned user, the message "Not Authorized" is displayed.

Expected behavior: 
After the thread's task completes, the summary of the completed task should be displayed, as in previous versions.

## Solution
- Updated processCompleted() with a processRequestParent() in the Task.view file.

## How to Test
- Import the process and sub-process using the files from the ticket.
- Create a new user.
- Create a new request `test_subprocess_bsa`.
- https://www.loom.com/share/f9a3ef8c56284c968085a0762d04190b

**Cypress test at Task.spect.js -> Subprocess Next Assigned Task**

## Related Tickets & Packages
This PR is linked to a ProcessMaker [PR](https://github.com/ProcessMaker/processmaker/pull/4596) and it should be run together.

ci:processmaker:bugfix/FOUR-6704

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-6704]: https://processmaker.atlassian.net/browse/FOUR-6704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ