### PR TITLE
FOUR-7559: Fixed datepicker input not being responsive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@cypress/code-coverage": "^3.8.1",
         "@fortawesome/fontawesome-free": "^5.6.1",
         "@panter/vue-i18next": "^0.15.2",
-        "@processmaker/vue-form-elements": "0.43.0",
+        "@processmaker/vue-form-elements": "0.43.1",
         "@processmaker/vue-multiselect": "^2.2.0",
         "@vue/cli-plugin-babel": "^3.6.0",
         "@vue/cli-plugin-e2e-cypress": "^4.0.3",
@@ -79,7 +79,7 @@
       },
       "peerDependencies": {
         "@panter/vue-i18next": "^0.15.0",
-        "@processmaker/vue-form-elements": "0.43.0",
+        "@processmaker/vue-form-elements": "0.43.1",
         "i18next": "^15.0.8",
         "vue": "^2.6.12",
         "vuex": "^3.1.1"
@@ -2804,9 +2804,9 @@
       }
     },
     "node_modules/@processmaker/vue-form-elements": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.43.0.tgz",
-      "integrity": "sha512-yKzN1E6ptBzkwfeMu4J5Lpy00CEX7VJd1MExLBVFeMtP8m5OXk9Td9Se0R1GjtXL3ZDqF9UsCuLdumzkK9yghA==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.43.1.tgz",
+      "integrity": "sha512-3ZV41WfbfwiVJ+iTtFqsikB1vClvpcNJEpc3rZXoS6SwbIhEt/cDsLEpmZHc3qAcLCAH8BRIIaToxVQVoB9Y3w==",
       "dev": true,
       "dependencies": {
         "@tinymce/tinymce-vue": "2.0.0",
@@ -27855,9 +27855,9 @@
       }
     },
     "@processmaker/vue-form-elements": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.43.0.tgz",
-      "integrity": "sha512-yKzN1E6ptBzkwfeMu4J5Lpy00CEX7VJd1MExLBVFeMtP8m5OXk9Td9Se0R1GjtXL3ZDqF9UsCuLdumzkK9yghA==",
+      "version": "0.43.1",
+      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.43.1.tgz",
+      "integrity": "sha512-3ZV41WfbfwiVJ+iTtFqsikB1vClvpcNJEpc3rZXoS6SwbIhEt/cDsLEpmZHc3qAcLCAH8BRIIaToxVQVoB9Y3w==",
       "dev": true,
       "requires": {
         "@tinymce/tinymce-vue": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@cypress/code-coverage": "^3.8.1",
     "@fortawesome/fontawesome-free": "^5.6.1",
     "@panter/vue-i18next": "^0.15.2",
-    "@processmaker/vue-form-elements": "0.43.0",
+    "@processmaker/vue-form-elements": "0.43.1",
     "@processmaker/vue-multiselect": "^2.2.0",
     "@vue/cli-plugin-babel": "^3.6.0",
     "@vue/cli-plugin-e2e-cypress": "^4.0.3",
@@ -88,7 +88,7 @@
   },
   "peerDependencies": {
     "@panter/vue-i18next": "^0.15.0",
-    "@processmaker/vue-form-elements": "0.43.0",
+    "@processmaker/vue-form-elements": "0.43.1",
     "i18next": "^15.0.8",
     "vue": "^2.6.12",
     "vuex": "^3.1.1"

--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -178,4 +178,19 @@ describe('Date Picker', () => {
       form_date_picker_2: moment(dateSame).toISOString(),
     });
   });
+
+  it('Date Time Picker should have the class .datePicker applied in design mode', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container] .vdpComponent')
+      .should('have.class', 'datePicker');
+  });
+
+  it('Date Time Picker should have the class .datePicker applied in preview mode', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] .vdpComponent')
+      .should('have.class', 'datePicker');
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
The date picker component is not responsive as other controls and it doesn't look good on the design the screen.
 
1. Create screen 
2. Add line input 
3. Add date picker
4. Press preview button

Expected behavior: 
The date picker component should be responsive, the same with others controls, the label should be at the top.

Actual behavior: 
The date picker input is displayed next to its' label either in design mode or in preview mode.

## Solution
- A new class (`.datePicker`) on the FormDatePicker.vue file was added to the date-picker input. This was done to change the css property: `display: inline-block` that was causing the issue. The display mode was changed to `block` to match the other inputs.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7559
- https://github.com/ProcessMaker/vue-form-elements

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

## QA Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] Verify that date picker will be responsive like other controls
- [x] Verify that date picker will be responsive with CSS
- [x] Verify that date picker will be responsive if its properties were changes like: (design: Text Color, Background Color)
- [ ] Verify properties of date picker 