### PR TITLE
FOUR-7564: Date picker does not validate the correct format

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -94,6 +94,7 @@ describe('Date Picker', () => {
     cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateBefore);
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
@@ -119,9 +120,11 @@ describe('Date Picker', () => {
     cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date);
+    cy.get('[data-cy=preview-content]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').type(dateSame);
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+    cy.get('[data-cy=preview-content]').click();
 
     cy.assertPreviewData({
       form_date_picker_1: moment(date).format('YYYY-MM-DD'),
@@ -147,6 +150,7 @@ describe('Date Picker', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').type(dateBefore);
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+    cy.get('[data-cy=preview-content]').click();
 
     cy.assertPreviewData({
       form_date_picker_1: moment(date).toISOString(),
@@ -169,13 +173,61 @@ describe('Date Picker', () => {
     cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date);
+    cy.get('[data-cy=preview-content]').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').type(dateSame);
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').click();
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
-
+    cy.get('[data-cy=preview-content]').click();
     cy.assertPreviewData({
       form_date_picker_1: moment(date).toISOString(),
       form_date_picker_2: moment(dateSame).toISOString(),
     });
   });
+  it('Date time picker validate when the user enter a string instead of a valid date', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateSame = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+   
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type('fooBarr{enter}');
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').click();
+    cy.assertPreviewData({
+      form_date_picker_1: null,
+      form_date_picker_2: null
+    });
+  });
+  it('Date time picker validate enter a valid date + string', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateSame = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Datetime');
+   
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date+"{enter}");
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date + "foo{enter}");
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').click();
+    cy.assertPreviewData({
+      form_date_picker_1:  moment(date).toISOString(),
+      form_date_picker_2: null
+    });
+  });
+
+
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
The date picker component is not validating if the usere enter invalid characters in the input field
 
1. Create screen 
2. Add line input 
3. Add date picker
4. Press preview button
5. Select a date from widget
6. edit and enter wrong dates to the input 

Expected behavior: 
The date picker component should validate the wrong entered characters .

Actual behavior: 
The date picker input allow none formatted date 

## Solution
- on Change handler was improved to catch and validate the input string and evaluate if is a valid date
## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7564

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
