### PR TITLE
FOUR-7610 Added test coverage for Helper Text

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -78,6 +78,26 @@ describe('Date Picker', () => {
       form_date_picker_1: today.toISOString(),
     });
   });
+  it('Date time picker should update the helper text', () => {
+    const helperTextFirstChange = 'Testing helper text';
+    const helperTextSecondChange = 'Testing helper text 2';
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-helper]').type(helperTextFirstChange);
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=screen-field-form_date_picker_1]').should('contain.text', helperTextFirstChange);
+    cy.get('[data-cy=mode-editor]').click();
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-helper]').clear().type(helperTextSecondChange);
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=screen-field-form_date_picker_1]').should('contain.text', helperTextSecondChange);
+  });
 
   it('Date picker with minDate less than first datepicker should return null data', () => {
     const date = moment(new Date()).format('MM/DD/YYYY');


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Having a test case scenario to cover helper text changes

Actual behavior: 
No test case covering this scenario

## Solution
- Added a test case scenario

## How to Test
Test the steps above
- Run SB with the branch in VFE `FOUR-7610`
- Run Cypress, Datepicker spec file

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7610

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
