### PR TITLE
FOUR-7663 Added test to check minDate and MaxDates and other scenario…

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -141,8 +141,33 @@ describe('Date Picker', () => {
       form_date_picker_2: null,
     });
   });
+  it('Date picker with maxDate greater than first datepicker should return null data', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateAfter = moment(new Date()).add(1, 'days').format('MM/DD/YYYY');
 
-  it('Date picker with minDate equal than first datepicker should return the current date', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"]').type(date);
+    cy.get('[data-cy=preview-content]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').type(dateAfter);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] input').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).format('YYYY-MM-DD'),
+      form_date_picker_2: null,
+    });
+  });
+
+  it('Date picker with minDate equal or less than first datepicker should return the current date', () => {
     const date = moment(new Date()).format('MM/DD/YYYY');
     const dateSame = moment(new Date()).format('MM/DD/YYYY');
 
@@ -164,6 +189,52 @@ describe('Date Picker', () => {
     cy.assertPreviewData({
       form_date_picker_1: moment(date).format('YYYY-MM-DD'),
       form_date_picker_2: moment(dateSame).format('YYYY-MM-DD'),
+    });
+  });
+  it('Date picker with maxDate equal or greater than first datepicker should return the current date', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const dateSame = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type('{{}{{}form_date_picker_1{}}{}}');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date);
+    cy.get('[data-cy=preview-content]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_2"] .vdpComponent').type(dateSame);
+    cy.get('[data-cy=preview-content]').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).format('YYYY-MM-DD'),
+      form_date_picker_2: moment(dateSame).format('YYYY-MM-DD'),
+    });
+  });
+
+  it('Date picker with minDate and maxDate should show the value in Data Preview', () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+    const minDate = moment(new Date()).subtract('5', 'days').format('MM/DD/YYYY');
+    const maxDate = moment(new Date()).add('5', 'days').format('MM/DD/YYYY');
+
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=screen-element-container]').first().click();
+    cy.get('[data-cy=accordion-Configuration]').click();
+    cy.get('[data-cy=inspector-minDate]').clear().type(minDate);
+    cy.get('[data-cy=inspector-maxDate]').clear().type(maxDate);
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date);
+    cy.get('[data-cy=preview-content]').click();
+
+    cy.assertPreviewData({
+      form_date_picker_1: moment(date).format('YYYY-MM-DD')
     });
   });
 


### PR DESCRIPTION
…s related to it

## Issue & Reproduction Steps

Expected behavior: 
Added tests to cover minDates and maxDates at the same time. Also expanded the maxDate tests only

Actual behavior: 
We weren't testing for minDates and MaxDates at the same time. Also, not testing for maxDate

## Solution
- Added way more tests to cover minDates and maxDates, individual and both at the same time

## How to Test
Test the steps above

## Related Tickets & Packages
- https://github.com/ProcessMaker/vue-form-elements/pull/389
- https://processmaker.atlassian.net/browse/FOUR-7663

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
