### PR TITLE
Bugfix/FOUR-8132: Default Value not working dynamically in Dropdowns

### DIFF
--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -154,7 +154,7 @@ export default {
     },
     resetValue(safeDotName, variableName) {
       this.setValue(safeDotName, null);
-      this.updateScreenDataNow(safeDotName, variableName);
+      this.updateScreenDataNow(safeDotName, variableName, false);
     },
     getValidationData() {
       return this.vdata;
@@ -194,8 +194,10 @@ export default {
       this.blockUpdate(safeDotName, 210);
       this.setValueDebounced(variable, this[safeDotName], this.vdata);
     },
-    updateScreenDataNow(safeDotName, variable) {
-      this[`${safeDotName}_was_filled__`] = true;
+    updateScreenDataNow(safeDotName, variable, setWasFilled = true) {
+      if (setWasFilled) {
+        this[`${safeDotName}_was_filled__`] = true;
+      }
       this.setValue(variable, this[safeDotName], this.vdata);
       this.unblockUpdate(safeDotName);
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce**
- Add two Select List controls on the screen with variable name sex and sexResp
- On both controls, select data source as “Provide Values” and enter the JSON below

```
[
    {
        "content": "Male",
        "value": "M"
    },
    {
        "content": "Female",
        "value": "F"
    }
]
```

- On the select list with variable name sexResp, on the advanced tab, enter the JavaScript code below  enter the 
`return this.sex;`


Expected behavior: 
On select of the options on the sex control, the sexRespvalues is not dynamically updated to match the choice in the sex variable, since the default value has been set to the sex value

Actual behavior: 
On select of the options on the sex control, the sexRespvalues should dynamically be updated to match the choice in the sex variable

## Solution
- Do not set to true the was_filled attr when reseting value

**Working video**

https://user-images.githubusercontent.com/90727999/234987851-881729b9-cf24-4b07-a7ac-da7db0b7a0fd.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-8132](https://processmaker.atlassian.net/browse/FOUR-8132)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8132]: https://processmaker.atlassian.net/browse/FOUR-8132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ