### PR TITLE
Save pagesValidated outside definition

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -11,6 +11,7 @@ class Validations {
   firstPage = 0;
   data = {};
   insideLoop = false;
+  pagesValidated = [];
   constructor(element, options) {
     this.element = element;
     Object.assign(this, options);
@@ -64,10 +65,10 @@ class ScreenValidations extends Validations {
   async addValidations(validations) {
     // add validations for page 1
     if (this.element.config[this.firstPage]) {
-      this.element.pagesValidated = [this.firstPage];
+      this.pagesValidated = [this.firstPage];
       const screenValidations = ValidationsFactory(this.element.config[this.firstPage].items, { screen: this.element, data: this.data });
       await screenValidations.addValidations(validations);
-      delete this.element.pagesValidated;
+      this.pagesValidated = [];
     }
   }
 }
@@ -192,8 +193,8 @@ class PageNavigateValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    if (this.screen.pagesValidated && !this.screen.pagesValidated.includes(parseInt(this.element.config.eventData))) {
-      this.screen.pagesValidated.push(parseInt(this.element.config.eventData));
+    if (this.pagesValidated.length > 0 && !this.pagesValidated.includes(parseInt(this.element.config.eventData))) {
+      this.pagesValidated.push(parseInt(this.element.config.eventData));
       if (this.screen.config[this.element.config.eventData] && this.screen.config[this.element.config.eventData].items) {
         await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
       }

--- a/tests/e2e/specs/SelectListDependentCollection.spec.js
+++ b/tests/e2e/specs/SelectListDependentCollection.spec.js
@@ -92,7 +92,7 @@ describe('select list dependent collection', () => {
 
     // Assert value is set correctly
     cy.assertPreviewData({
-      'form_select_list_1': 456
+      'form_select_list_1': '456'
     });
   });
 
@@ -103,7 +103,7 @@ describe('select list dependent collection', () => {
     cy.get('[data-cy="screen-field-city"]').selectOption('Henderson');
     cy.assertPreviewData({
       state: 'NV',
-      city: 789,
+      city: '789',
       id_gt_than: '33',
       form_select_list_2: null
     });
@@ -123,7 +123,7 @@ describe('select list dependent collection', () => {
     const setup = () => {
       cy.loadFromJson('select_list_dependent_collection.json', 0);
       cy.setPreviewDataInput({
-        'city': 789,
+        'city': '789',
         'state': 'NV',
       });
       
@@ -134,7 +134,7 @@ describe('select list dependent collection', () => {
       cy.get('[data-cy="screen-field-city"] .multiselect__single').should('have.text', 'Henderson');
       cy.assertPreviewData({
         state: 'NV',
-        city: 789,
+        city: '789',
         id_gt_than: '33',
         form_select_list_2: null
       });


### PR DESCRIPTION
## Issue & Reproduction Steps
Nested screens in record lists are causing the page continually re-render every second
- Create a screen with a record list
- Create a new page for the record list item
- In the record list row page, add a nested screen
- In the nested screen, add a checkbox, multicolumn, and a select list that calls a data source
- Preview and add an item to the record list
- Look at the network panel and notice it's calling the data source every few seconds
- Also, notice the input box gets unfocused
- Notice on the Vue tab of devtools, events are firing every second without any interaction

Expected behavior: 
Should not re-render

Actual behavior: 
Screen is re-rendering every second

## Solution
- In ValidationsFactory, make the `pagesValidated` a non-reactive property as to not-trigger `rebuildScreen`

## How to Test
Test the steps above

## Related Tickets & Packages
Solves both these issues:
- https://processmaker.atlassian.net/browse/FOUR-8413
- https://processmaker.atlassian.net/browse/FOUR-8335

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
