### PR TITLE
Bugfix/four 8320

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -6,12 +6,13 @@ import { Parser } from 'expr-eval';
 let globalObject = typeof window === 'undefined'
   ? global
   : window;
+
+let pagesValidated = [];
 class Validations {
   screen = null;
   firstPage = 0;
   data = {};
   insideLoop = false;
-  pagesValidated = [];
   constructor(element, options) {
     this.element = element;
     Object.assign(this, options);
@@ -65,10 +66,10 @@ class ScreenValidations extends Validations {
   async addValidations(validations) {
     // add validations for page 1
     if (this.element.config[this.firstPage]) {
-      this.pagesValidated = [this.firstPage];
+      pagesValidated = [this.firstPage];
       const screenValidations = ValidationsFactory(this.element.config[this.firstPage].items, { screen: this.element, data: this.data });
       await screenValidations.addValidations(validations);
-      this.pagesValidated = [];
+      pagesValidated = [];
     }
   }
 }
@@ -193,8 +194,8 @@ class PageNavigateValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    if (this.pagesValidated.length > 0 && !this.pagesValidated.includes(parseInt(this.element.config.eventData))) {
-      this.pagesValidated.push(parseInt(this.element.config.eventData));
+    if (pagesValidated.length > 0 && !pagesValidated.includes(parseInt(this.element.config.eventData))) {
+      pagesValidated.push(parseInt(this.element.config.eventData));
       if (this.screen.config[this.element.config.eventData] && this.screen.config[this.element.config.eventData].items) {
         await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
       }

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -425,12 +425,13 @@ export default {
             try {
               if (screenComponent.$v) {
                 screenComponent.$v.$touch();
-                resolve();
               }
             } catch (error) {
               if (this.getMode() === "preview") {
                 console.warn("There was a problem rendering the screen", error);
               }
+            } finally {
+              resolve();
             }
           });
         });


### PR DESCRIPTION
Ticket [FOUR-8320](https://processmaker.atlassian.net/browse/FOUR-8320) 
## Issue & Reproduction Steps
Submit button does not validate when using multiple pages and nested screens.

- Create a Screen 1 (As a nested screen)
- Add line input with the required option
- Create a Screen 2 (As a nested screen)
- Add any image or rich text
- Create a Screen Main
- Add multiple pages-navigations
- In one of the navigation pages, Adding  the two nested screens created
- Create a process with WE
- Add the Screen Main in the WE
- Create a request 
- Complete the field required

Or add any of the Processes attached.

## Actual behavior: ##
The submit button is shown as disabled at the end of the process.

## Expected behavior: ##
Submit button should be disabled if any of the validations are missing and enable when all the required fields are completed.

## Solution
- Implement proper validation for screens with multiple pages.

## How to Test
- Import the following processes for testing
-- https://processmaker.atlassian.net/browse/FOUR-8320
- Complete all the fields and make sure the button shows as enabled at the end.
- Leave some required fields empty and check that the submit button shows as disabled.


https://www.loom.com/share/ece2f90d8556462590e91afefa7b43c2


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8320]: https://processmaker.atlassian.net/browse/FOUR-8320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy