### PR TITLE
FOUR-7931 Added e2e to cover DatePicker with Validation Rules and cle…

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -332,6 +332,36 @@ describe('Date Picker', () => {
       form_date_picker_2: null
     });
   });
+  it.only("Date picker with Required validation shouldn't allow the user to submit the date if empty", () => {
+    const date = moment(new Date()).format('MM/DD/YYYY');
+
+    cy.visit('/');
+
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=add-rule]').click();
+    cy.setMultiselect('[data-cy=select-rule]', 'Required');
+    cy.get('[data-cy=save-rule]').click();
+    cy.get('[data-cy=controls-FormButton]').last().drag('[data-cy=screen-element-container]', 'bottom');
+
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('.invalid-feedback').contains('Field is required');
+    cy.get('.vdpComponent input').should('have.class', 'is-invalid');
+    cy.get('.btn-primary').should('have.class', 'disabled');
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').type(date+"{enter}");
+    cy.get('[data-cy=preview-content]').click();
+    cy.wait(500);
+    cy.get('.btn-primary').should('not.have.class', 'disabled');
+    cy.get('.vdpClearInput').click();
+    cy.wait(500);
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] .vdpComponent').should('not.contain.value', date);
+    cy.get('.vdpComponent input').should('have.class', 'is-invalid');
+    cy.get('.btn-primary').should('have.class', 'disabled');
+    cy.assertPreviewData({
+      form_date_picker_1:  "",
+    });
+  })
   it('Date Time Picker should have the class .datePicker applied in design mode', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');


### PR DESCRIPTION
…ar functionality

## Issue & Reproduction Steps

Expected behavior: 
The user shouldn't be able to submit the form if the date is invalid

Actual behavior: 
The user is able to move on if the date is invalid

## Solution
- If the user clicks on the clear button, emit an empty string to tell SB that the input was clear and the validation rules should trigger the DatePicker invalid class

## How to Test
Test the steps above
* Add a datepicker
* Set it to Date
* Add validation rules to be required
* Add a submit button into the screen
* Click Preview
* "Field is required" should be shown in the validation errors below the datepicker
* Button shouldn't be clickable
* User sets the date
* Invalid error message should be removed
* Button should be clickable
* User clicks the clear button in the datepicker
* "Field is required" should be shown in the validation errors below the datepicker *again*
* Button shouldn't be clickable

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7931
- https://github.com/ProcessMaker/vue-form-elements/pull/395

ci:deploy
ci:vue-form-elements:bugfix/FOUR-7931

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
