### PR TITLE
FOUR-8548 | Photo/Video Variable Name Is Not Created Correlatively

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1007,9 +1007,8 @@ export default {
 
       // Generate Variable Name
       if (
-        control.inspector.indexOf(keyNameProperty) !== -1 ||
-        control.component === "FormLoop"
-      ) {
+        _.findIndex(control.inspector, keyNameProperty) !== -1 ||
+        control.component === "FormLoop") {
         [this.variables, copy.config.name] = this.generator.generate(
           this.config,
           copy["editor-control"] ? copy["editor-control"] : copy.component


### PR DESCRIPTION
# Issue
Ticket: [FOUR-8548](https://processmaker.atlassian.net/browse/FOUR-8548)

The name of the Photo/Video control does not iterate when other Photo/Video controls are present on the screen.
If you have three Photo/Video controls on the screen, they all have the Variable Name "photo_video_1".

# Steps to Reproduce
1. Log in to ProcessMaker.
2. Go to the Designer tab.
3. Create a new Screen.
4. Add three Photo/Video controls to the screen.

# How to Test
1. Go to branch `observation/FOUR-8548` in `package-photo-video`. Install the package.
2. Go to branch `observation/FOUR-8548` in `screen-builder`. Link screen-builder to core.
3. Follow the Steps to Reproduce.
4. The name of the Photo/Video control should update sequentially when multiple controls are added.

# Related Tickets & Packages
- [FOUR-8179](https://processmaker.atlassian.net/browse/FOUR-8179) | Photo/Video Capture Control

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-8548]: https://processmaker.atlassian.net/browse/FOUR-8548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8179]: https://processmaker.atlassian.net/browse/FOUR-8179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ