### PR TITLE
FOUR-8509: Required fields in nested screens are lost 

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -85,8 +85,13 @@ class FormNestedScreenValidations extends Validations {
     }
     const definition = await this.loadScreen(this.element.config.screen);
     let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
-    if (definition && definition[0] && definition[0].items) {
-      await ValidationsFactory(definition[0].items, { screen: this.screen, data: this.data, parentVisibilityRule }).addValidations(validations);
+
+    if (Array.isArray(definition)) {
+      for(var i = 0; i < definition.length; i++) {
+        if (definition[i].items) {
+          await ValidationsFactory(definition[i].items, { screen: this.screen, data: this.data, parentVisibilityRule }).addValidations(validations);
+        }
+      }
     }
   }
 

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -83,16 +83,28 @@ class FormNestedScreenValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    const definition = await this.loadScreen(this.element.config.screen);
+    const nestedScreen = await this.loadNestedScreen(this.element.config.screen);
+    //const definition = await this.loadScreen(this.element.config.screen);
+    const definition = nestedScreen.config;
     let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
-
-    if (Array.isArray(definition)) {
-      for(var i = 0; i < definition.length; i++) {
-        if (definition[i].items) {
-          await ValidationsFactory(definition[i].items, { screen: this.screen, data: this.data, parentVisibilityRule }).addValidations(validations);
-        }
-      }
+    if (definition && definition[0] && definition[0].items) {
+      await ValidationsFactory(definition[0].items, { screen: nestedScreen, data: this.data, parentVisibilityRule }).addValidations(validations);
     }
+  }
+
+  async loadNestedScreen(id) {
+    if (!id) {
+      return null;
+    }
+    if (!globalObject['nestedScreens']) {
+      globalObject['nestedScreens'] = {};
+    }
+    if (globalObject.nestedScreens['id_' + id]) {
+      return {config: globalObject.nestedScreens['id_' + id]};
+    }
+    const response = await DataProvider.getScreen(id);
+    globalObject.nestedScreens['id_' + id] = response.data.config;
+    return {config: response.data};
   }
 
   async loadScreen(id) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -84,10 +84,12 @@ class FormNestedScreenValidations extends Validations {
       return;
     }
     const nestedScreen = await this.loadNestedScreen(this.element.config.screen);
-    const definition = nestedScreen.config;
-    let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
-    if (definition && definition[0] && definition[0].items) {
-      await ValidationsFactory(definition[0].items, { screen: nestedScreen, data: this.data, parentVisibilityRule }).addValidations(validations);
+    if (nestedScreen && nestedScreen.config) {
+      const definition = nestedScreen.config;
+      let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
+      if (definition && definition[0] && definition[0].items) {
+        await ValidationsFactory(definition[0].items, { screen: nestedScreen, data: this.data, parentVisibilityRule }).addValidations(validations);
+      }
     }
   }
 
@@ -210,9 +212,12 @@ class PageNavigateValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    if (pagesValidated.length > 0 && !pagesValidated.includes(parseInt(this.element.config.eventData))) {
-      pagesValidated.push(parseInt(this.element.config.eventData));
-      if (this.screen.config[this.element.config.eventData] && this.screen.config[this.element.config.eventData].items) {
+    const screenNumber = this.element.config.eventData;
+    const screenName = this.screen.config[screenNumber]?.name ?? 'Empty Screen';
+    const screenPageId = `${screenName}-${screenNumber}`;
+    if (pagesValidated.length > 0 && !pagesValidated.includes(screenPageId)) {
+      if (this.screen.config[screenNumber] && this.screen.config[screenNumber].items) {
+        pagesValidated.push(screenPageId);
         await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
       }
     }
@@ -253,7 +258,6 @@ class FormElementValidations extends Validations {
         let validationFn = validators[rule];
         if (!validationFn) {
           // eslint-disable-next-line no-console
-          console.error(`Undefined validation rule "${rule}"`);
           return;
         }
         if (validation.configs instanceof Array) {
@@ -301,7 +305,6 @@ class FormElementValidations extends Validations {
       let validationFn = validators[validationConfig];
       if (!validationFn) {
         // eslint-disable-next-line no-console
-        console.error(`Undefined validation rule "${validationConfig}"`);
         return;
       }
       fieldValidation[validationConfig] = function(...props) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -84,7 +84,6 @@ class FormNestedScreenValidations extends Validations {
       return;
     }
     const nestedScreen = await this.loadNestedScreen(this.element.config.screen);
-    //const definition = await this.loadScreen(this.element.config.screen);
     const definition = nestedScreen.config;
     let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
     if (definition && definition[0] && definition[0].items) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -213,7 +213,10 @@ class PageNavigateValidations extends Validations {
       return;
     }
     const screenNumber = this.element.config.eventData;
-    const screenName = this.screen.config[screenNumber]?.name ?? 'Empty Screen';
+    let screenName = 'Empty Screen';
+    if (this.screen.config[screenNumber] && this.screen.config[screenNumber].name) {
+      screenName = this.screen.config[screenNumber].name;
+    }
     const screenPageId = `${screenName}-${screenNumber}`;
     if (pagesValidated.length > 0 && !pagesValidated.includes(screenPageId)) {
       if (this.screen.config[screenNumber] && this.screen.config[screenNumber].items) {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a Form Screen with two pages at least
- Include on all pages the required fields
- Create other Form Screen
- Add a nested screen and assign the previous form.
- Add a Submit button
- Add a second nested screen with no screen assigned
- Go to Preview mode. All required fields are required on the first page, but on other pages lost all required fields.
- Create a process
- Add a Start Event, form task, and End Event.
- Connect one by one.
- Save all changes
- Start a new request for the process
- The task started and all required are required on the first page, but on other pages lost all required fields and it is possible to submit the task.

Expected behavior: 
In a nested screen that have more than 1 page, validation of all pages should be used.

Actual behavior: 
Validations of the only the first page are used.

## Solution
When  nested screen validations were added, the main screen definition was passed to the ValidationFactory. This was fixed, now the nested screen is passed, so that all the nested screen validations are added.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-8509](https://processmaker.atlassian.net/browse/FOUR-8509)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
