### PR TITLE
FOUR-8992: Media Queries - Enable Media Queries for custom css in the screen builder

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -209,9 +209,6 @@ export default {
         });
         let i = 0;
         csstree.walk(ast, function(node, item, list) {
-          if (node.type === 'Atrule' && list) {
-            throw 'CSS \'At-Rules\' (starting with @) are not allowed.';
-          }
           if (
             node.type.match(/^.+Selector$/) &&
               node.name !== containerSelector &&


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The user must able to write media query in the custom css

Actual behavior: 
n/a
## Solution
- media query was enabled for the user

## How to Test
Test the steps above
- npm run serve
- add a input field
- for this input add a CSS Selector Name
- add media query
- preview the screen


https://github.com/ProcessMaker/screen-builder/assets/1401911/a15a3dce-bf04-4ed8-972b-d7c7fc071a66


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8992

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
