### PR TITLE
FOUR-9096: e2e Test(s) that validate that media queries are applied to controls of a screen

### DIFF
--- a/tests/e2e/specs/MediaQuery.spec.js
+++ b/tests/e2e/specs/MediaQuery.spec.js
@@ -1,0 +1,32 @@
+describe('Media Query CSS', () => {
+  it('Adds media query and styling the element', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-customCssSelector]').type('new_input_css');
+    cy.get('[data-cy=topbar-css]').click();
+    // write the media query in the custom css panel
+    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}', {parseSpecialCharSequences: false} );
+    cy.get('[data-cy=save-button]').click();
+    //preview
+    cy.get('[data-cy=mode-preview]').click();
+    //if the resilt contains the custom css name selector
+    cy.get('.page').should('contain.html', '<div selector="new_input_css">');
+    // backround color blue
+    cy.wait(400);
+    // update the viewport size
+    cy.viewport(700, 800);
+    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
+    // backround color red
+    cy.wait(100);
+    // update the viewport size
+    cy.viewport(1000, 800);
+    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
+    // backround color green
+    cy.wait(100);
+    // update the viewport size
+    cy.viewport(1500, 800);
+    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
have a e2e test  to validate media query
Actual behavior: 
n/a
## Solution
- created MediaQuery.spec.js to validate if the media query rules was applied

## How to Test
Test the steps above
- run the command npm run seve, port 8080
- run the command npm run open-cypress
- find the test MediaQuery.spec.js and run it

![Screenshot from 2023-06-28 11-54-25](https://github.com/ProcessMaker/screen-builder/assets/1401911/5ff0dfeb-e751-44bf-9090-2c5ae09b7d81)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9096

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
