### PR TITLE
FOUR-9094: e2e Tests for configuring a screen with controls that show/hide for desktop/mobile devices

### DIFF
--- a/tests/e2e/specs/DeviceVisivilityInspector.spec.js
+++ b/tests/e2e/specs/DeviceVisivilityInspector.spec.js
@@ -1,0 +1,245 @@
+describe('Device Visiblility Inspector', () => {
+  it('Verify if an input has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a checkbox has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormCheckbox]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a datePicker has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FileDownload has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FileDownload]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FileUpload has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FileUpload]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormImage has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormImage]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormLoop has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormLoop]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormMultiColumn has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormMultiColumn]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormNestedScreen has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormNestedScreen]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormButton has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormButton]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormRecordList has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormRecordList]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormHtmlViewer has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormHtmlViewer]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormSelectList has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormSelectList]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Verify if a FormTextArea has device visiblility settings', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormTextArea]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Enabled device visiblility', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        expect(control.children('input')).to.have.length(1);
+        // get label
+        expect(control.children('label')).to.have.length(1);
+        // get Window reference from element
+        const win = control.children('label')[0].ownerDocument.defaultView;
+        // use getComputedStyle to read the pseudo selector
+        console.log(control.children('label')[0]);
+        const before = win.getComputedStyle(control.children('label')[0], 'before');
+        // read the value of the `content` CSS property
+        const contentValue = before.getPropertyValue('background-color');
+        // the returned value will have double quotes around it, but this is correct
+        expect(contentValue).to.eq('rgb(0, 123, 255)');
+        // if have a label
+        expect(control.children('label')).to.have.length(1);
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+  it('Disabled device visiblility', () => {
+    cy.visit('/');
+    cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        // forced click over the control
+        control.children('input').trigger("click");
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+    cy.wait(200);
+    cy.get('[data-cy=inspector-deviceVisibility]').children().children('.custom-control')
+      .each((control) => {
+        //GET INPUT
+        expect(control.children('input')).to.have.length(1);
+        // get label
+        expect(control.children('label')).to.have.length(1);
+        // get Window reference from element
+        const win = control.children('label')[0].ownerDocument.defaultView;
+        // use getComputedStyle to read the pseudo selector
+        console.log(control.children('label')[0]);
+        const before = win.getComputedStyle(control.children('label')[0], 'before');
+        // read the value of the `content` CSS property
+        const contentValue = before.getPropertyValue('background-color');
+        // the returned value will have double quotes around it, but this is correct
+        debugger;
+        expect(contentValue).to.eq('rgb(255, 255, 255)');
+      })
+      .then(($lis) => {
+        expect($lis).to.have.length(2); // true
+      });
+  });
+});

--- a/tests/e2e/specs/DeviceVisivilityInspector.spec.js
+++ b/tests/e2e/specs/DeviceVisivilityInspector.spec.js
@@ -194,7 +194,6 @@ describe('Device Visiblility Inspector', () => {
         // get Window reference from element
         const win = control.children('label')[0].ownerDocument.defaultView;
         // use getComputedStyle to read the pseudo selector
-        console.log(control.children('label')[0]);
         const before = win.getComputedStyle(control.children('label')[0], 'before');
         // read the value of the `content` CSS property
         const contentValue = before.getPropertyValue('background-color');
@@ -230,7 +229,6 @@ describe('Device Visiblility Inspector', () => {
         // get Window reference from element
         const win = control.children('label')[0].ownerDocument.defaultView;
         // use getComputedStyle to read the pseudo selector
-        console.log(control.children('label')[0]);
         const before = win.getComputedStyle(control.children('label')[0], 'before');
         // read the value of the `content` CSS property
         const contentValue = before.getPropertyValue('background-color');

--- a/tests/e2e/specs/DeviceVisivilityInspector.spec.js
+++ b/tests/e2e/specs/DeviceVisivilityInspector.spec.js
@@ -233,7 +233,6 @@ describe('Device Visiblility Inspector', () => {
         // read the value of the `content` CSS property
         const contentValue = before.getPropertyValue('background-color');
         // the returned value will have double quotes around it, but this is correct
-        debugger;
         expect(contentValue).to.eq('rgb(255, 255, 255)');
       })
       .then(($lis) => {


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
have a e2e test to validate device visibility in the inspector panel
Actual behavior: 
n/a
## Solution
- created tests/e2e/specs/DeviceVisivilityInspector.spec.js to validate device visibility for all controls
## How to Test
Test the steps above

-     run the command npm run seve, port 8080
-     run the command npm run open-cypress
-     find the test DeviceVisivilityInspector.spec.js and run it.

![Screenshot from 2023-06-28 16-26-06](https://github.com/ProcessMaker/screen-builder/assets/1401911/f7bb7862-87b2-4761-88c5-2c0e2cce7c41)

## Related Tickets & Packages

-  https://processmaker.atlassian.net/browse/FOUR-9094

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
