### PR TITLE
FOUR-9117: Use the size of the rendered screen to hide/show controls according to the Device Visibility Configuration

### DIFF
--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -3,10 +3,6 @@ import { Parser } from "expr-eval";
 export default {
   methods: {
     visibilityRuleIsVisible(rule, name, deviceVisibility) {
-      // const isMobile = window.ProcessMaker && window.ProcessMaker.isMobile
-      //   ? window.Processmaker.isMobile
-      //   : false;
-
       const visibility = deviceVisibility || {showForDesktop: true, showForMobile: true, isMobile: false};
       const visibleInDevice =
         (visibility.isMobile && visibility.showForMobile) ||

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -2,13 +2,25 @@ import { Parser } from "expr-eval";
 
 export default {
   methods: {
-    visibilityRuleIsVisible(rule) {
+    visibilityRuleIsVisible(rule, name, deviceVisibility) {
+      // const isMobile = window.ProcessMaker && window.ProcessMaker.isMobile
+      //   ? window.Processmaker.isMobile
+      //   : false;
+
+      const visibility = deviceVisibility || {showForDesktop: true, showForMobile: true, isMobile: false};
+      const visibleInDevice =
+        (visibility.isMobile && visibility.showForMobile) ||
+        (!visibility.isMobile && visibility.showForDesktop);
+
       try {
-        const dataWithParent = this.getDataReference();
-        const isVisible = Boolean(Parser.evaluate(rule, dataWithParent));
-        return isVisible;
+        if (rule && rule.trim().length > 0) {
+          const dataWithParent = this.getDataReference();
+          const isVisible = Boolean(Parser.evaluate(rule, dataWithParent));
+          return isVisible && visibleInDevice;
+        }
+        return visibleInDevice;
       } catch (e) {
-        return false;
+        return true;
       }
     }
   }

--- a/src/mixins/extensions/VisibilityRule.js
+++ b/src/mixins/extensions/VisibilityRule.js
@@ -4,8 +4,6 @@ export default {
   mounted() {
     this.extensions.push({
       onloaditems({ element, wrapper, definition }) {
-        console.log('element:', element, definition.isMobile);
-
         const visibility = element.config.deviceVisibility || { showForDesktop: true, showForMobile: true }
         const restrictDeviceVisibility = !visibility.showForDesktop || !visibility.showForMobile;
 

--- a/src/mixins/extensions/VisibilityRule.js
+++ b/src/mixins/extensions/VisibilityRule.js
@@ -3,12 +3,18 @@ import VisibilityRule from '../VisibilityRule';
 export default {
   mounted() {
     this.extensions.push({
-      onloaditems({ element, wrapper }) {
-        if (element.config.conditionalHide) {
+      onloaditems({ element, wrapper, definition }) {
+        console.log('element:', element, definition.isMobile);
+
+        const visibility = element.config.deviceVisibility || { showForDesktop: true, showForMobile: true }
+        const restrictDeviceVisibility = !visibility.showForDesktop || !visibility.showForMobile;
+
+        if (element.config.conditionalHide || restrictDeviceVisibility) {
+          const deviceVisibility = JSON.stringify( { ...visibility, isMobile: definition.isMobile } );
           wrapper.setAttribute(
             'v-show',
             `visibilityRuleIsVisible(${JSON.stringify(element.config.conditionalHide)}, 
-            ${JSON.stringify(element.config.name)})`
+            ${JSON.stringify(element.config.name)}, ${deviceVisibility})`
           );
         }
       },


### PR DESCRIPTION
## Issue & Reproduction Steps

Create a screen with 2 input lines and configure them like this:
Line1-> Select Show For Desktop = true, Show For Desktop = false
Line2-> Select Show For Desktop = false, Show For Desktop = true


Change the browser screen size. When the screen width is less than 480px Line 2 will be displayed and Line 1 will be hidden.


## Solution
- Added an additional condition when displaying/hiding a control


## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-9117](https://processmaker.atlassian.net/browse/FOUR-9117)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
