### PR TITLE
FOUR-9213:Device Visibility is not working with Visibility Rule

### DIFF
--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -3,6 +3,7 @@ import { Parser } from "expr-eval";
 export default {
   methods: {
     visibilityRuleIsVisible(rule, name, deviceVisibility) {
+      debugger;
       const visibility = deviceVisibility || {showForDesktop: true, showForMobile: true, isMobile: false};
       const visibleInDevice =
         (visibility.isMobile && visibility.showForMobile) ||
@@ -16,7 +17,7 @@ export default {
         }
         return visibleInDevice;
       } catch (e) {
-        return true;
+        return visibleInDevice;
       }
     }
   }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Texarea should be visible only in mobile according to the configuration 
Actual behavior: 
Textarea is visible both on web and mobile, but “Show for mobile“ is enabled
## Solution
- the the visibility rules trow an error the device visibility rule will be applied

## How to Test
Test the steps above
1. Go to modeler
3. Add any control on the screen, like a textarea
5. Select only “Show for Mobile“
7. Type any variable in Visibility Rule
9. Press preview


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-9213

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
