### PR TITLE
FOUR-9247: adding toolip for desktop and mobile preview buttons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -27,6 +27,8 @@
                 :variant="deviceScreen === 'desktop' ? 'secondary' : 'outline-secondary'"
                 data-cy="device-screen-desktop-button"
                 @click="changeDeviceScreen('desktop')"
+                v-b-tooltip.hover
+                :title="$t('Desktop')"
               >
                 <i class="fas fa-desktop" />
               </b-button>
@@ -34,6 +36,8 @@
                 :variant="deviceScreen === 'mobile' ? 'secondary' : 'outline-secondary'"
                 data-cy="device-screen-mobile-button"
                 @click="changeDeviceScreen('mobile')"
+                v-b-tooltip.hover
+                :title="$t('Mobile')"
               >
                 <i class="fas fa-mobile" />
               </b-button>

--- a/tests/e2e/specs/MediaQuery.spec.js
+++ b/tests/e2e/specs/MediaQuery.spec.js
@@ -1,4 +1,4 @@
-describe('Media Query CSS', () => {
+describe.skip('Media Query CSS', () => {
   it('Adds media query and styling the element', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
@@ -7,7 +7,7 @@ describe('Media Query CSS', () => {
     cy.get('[data-cy=inspector-customCssSelector]').type('new_input_css');
     cy.get('[data-cy=topbar-css]').click();
     // write the media query in the custom css panel
-    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}');
+    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}', {parseSpecialCharSequences: false} );
     cy.get('[data-cy=save-button]').click();
     //preview
     cy.get('[data-cy=mode-preview]').click();
@@ -16,23 +16,17 @@ describe('Media Query CSS', () => {
     // backround color blue
     cy.wait(400);
     // update the viewport size
-    // cy.viewport(700, 800);
-    // Cypress.config('viewportWidth', 700);
-    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
-    Cypress.config('viewportWidth', 100)
     cy.viewport(700, 800);
-    cy.wrap(Cypress.config('viewportWidth')).should('eq', 700)   // passing
-    // console.log(cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
     cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
-    // // backround color red
-    // cy.wait(100);
-    // // update the viewport size
-    // cy.viewport(1000, 800);
-    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
-    // // backround color green
-    // cy.wait(100);
-    // // update the viewport size
-    // cy.viewport(1500, 800);
-    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
+    // backround color red
+    cy.wait(100);
+    // update the viewport size
+    cy.viewport(1000, 800);
+    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
+    // backround color green
+    cy.wait(100);
+    // update the viewport size
+    cy.viewport(1500, 800);
+    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
   });
 });

--- a/tests/e2e/specs/MediaQuery.spec.js
+++ b/tests/e2e/specs/MediaQuery.spec.js
@@ -1,4 +1,4 @@
-describe.skip('Media Query CSS', () => {
+describe('Media Query CSS', () => {
   it('Adds media query and styling the element', () => {
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
@@ -7,7 +7,7 @@ describe.skip('Media Query CSS', () => {
     cy.get('[data-cy=inspector-customCssSelector]').type('new_input_css');
     cy.get('[data-cy=topbar-css]').click();
     // write the media query in the custom css panel
-    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}', {parseSpecialCharSequences: false} );
+    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}');
     cy.get('[data-cy=save-button]').click();
     //preview
     cy.get('[data-cy=mode-preview]').click();
@@ -16,17 +16,23 @@ describe.skip('Media Query CSS', () => {
     // backround color blue
     cy.wait(400);
     // update the viewport size
+    // cy.viewport(700, 800);
+    // Cypress.config('viewportWidth', 700);
+    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
+    Cypress.config('viewportWidth', 100)
     cy.viewport(700, 800);
+    cy.wrap(Cypress.config('viewportWidth')).should('eq', 700)   // passing
+    // console.log(cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
     cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
-    // backround color red
-    cy.wait(100);
-    // update the viewport size
-    cy.viewport(1000, 800);
-    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
-    // backround color green
-    cy.wait(100);
-    // update the viewport size
-    cy.viewport(1500, 800);
-    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
+    // // backround color red
+    // cy.wait(100);
+    // // update the viewport size
+    // cy.viewport(1000, 800);
+    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
+    // // backround color green
+    // cy.wait(100);
+    // // update the viewport size
+    // cy.viewport(1500, 800);
+    // cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
   });
 });

--- a/tests/e2e/specs/ResponsivePreview.spec.js
+++ b/tests/e2e/specs/ResponsivePreview.spec.js
@@ -23,7 +23,13 @@ describe('Responsive Preview test', () => {
     cy.get(desktopButtonSelector).should('not.be.visible');
     cy.get(mobileButtonSelector).should('not.be.visible');
   });
-
+  it('Buttons should have title attributes', () => {
+    // Preview button
+    cy.get(modePreviewSelector).click();
+    // Device buttons 
+    cy.get(desktopButtonSelector).should('be.visible').should('have.attr', 'title');
+    cy.get(mobileButtonSelector).should('be.visible').should('have.attr', 'title');
+  });
   it('should render the device screen buttons when clicking on mode preview', () => {
     // Preview button
     cy.get(modePreviewSelector).click();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Web and mobile preview icons should have pop up to identify them 

Actual behavior: 
Web and mobile preview icons do not have pop up

## Solution
- Add tool-tip labels

## How to Test
Test the steps above
1. Go to screen 
2. Press preview button
3. Check the icons for web and mobile 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9247

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
