### PR TITLE
FOUR-9300: Device Visibility is not working inside a loop

### DIFF
--- a/src/mixins/extensions/LoopContainer.js
+++ b/src/mixins/extensions/LoopContainer.js
@@ -28,7 +28,7 @@ export default {
             items: element.items
           }
         ],
-        watchers: definition.watchersa,
+        watchers: definition.watchers,
         isMobile: definition.isMobile
       };
 

--- a/src/mixins/extensions/LoopContainer.js
+++ b/src/mixins/extensions/LoopContainer.js
@@ -28,7 +28,8 @@ export default {
             items: element.items
           }
         ],
-        watchers: definition.watchers
+        watchers: definition.watchersa,
+        isMobile: definition.isMobile
       };
 
       let loopContext = "";


### PR DESCRIPTION
## Issue & Reproduction Steps

-     Create screen 
-     Add a loop
-     Add line input control inside the loop
-     Disable “Show for Desktop“ option in line input
-     Press Preview option
-     Go to Web and mobile

Expected behavior: 
The line input inside the loop should be visible according to configuration 

Actual behavior: 
The line input is not visible in Web or mobile design

## Solution
- The isMobile attribute of the main screen definition was not passed to loops

## How to Test
Test the steps above

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-9300](https://processmaker.atlassian.net/browse/FOUR-9300)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
