### PR TITLE
FOUR-9420 visibility rules show the controls, when the variable does not exist

### DIFF
--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -1,23 +1,26 @@
-import { Parser } from "expr-eval";
+import { Parser } from 'expr-eval';
 
 export default {
   methods: {
     visibilityRuleIsVisible(rule, name, deviceVisibility) {
-      const visibility = deviceVisibility || {showForDesktop: true, showForMobile: true, isMobile: false};
+      const visibility = deviceVisibility || { showForDesktop: true, showForMobile: true, isMobile: false };
       const visibleInDevice =
-        (visibility.isMobile && visibility.showForMobile) ||
-        (!visibility.isMobile && visibility.showForDesktop);
+        (visibility.isMobile && visibility.showForMobile) || (!visibility.isMobile && visibility.showForDesktop);
 
       try {
         if (rule && rule.trim().length > 0) {
           const dataWithParent = this.getDataReference();
           const isVisible = Boolean(Parser.evaluate(rule, dataWithParent));
+
           return isVisible && visibleInDevice;
         }
+
         return visibleInDevice;
       } catch (e) {
-        return visibleInDevice;
+        // empty.
       }
+
+      return false;
     }
   }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a screen
2. Add line input control inside the screen
3. Configure the  line input with a variable non-existent in visibility
4. Press Preview button

Expected behavior:
If the variable does not exist the validation rules should not show the control configured. like PM 4.7.0 Alpha 1

Actual behavior:
Controls that are configured with a variable non-existent in visibility rules are showed 

## Solution
Validate the variable in visibility rule mixin

## How to Test
1. Switch to bugfix/FOUR-9420 branch
2. Configure the line input with a variable non-existent in visibility
3. Press Preview button
4. The control must not be displayed

## Related Tickets & Packages
[FOUR-9420](https://processmaker.atlassian.net/browse/FOUR-9420)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9420]: https://processmaker.atlassian.net/browse/FOUR-9420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ