### PR TITLE
Refactor media query spec because the previous spec was failing

### DIFF
--- a/tests/e2e/specs/MediaQuery.spec.js
+++ b/tests/e2e/specs/MediaQuery.spec.js
@@ -1,33 +1,35 @@
+
+const sizes = [[700, 800], [1000, 800], [1500, 768]];
+const backgroundColor = ['rgb(0, 0, 255)', 'rgb(255, 0, 0)', 'rgb(0, 128, 0)'];
+
 describe('Media Query CSS', () => {
-  it('Adds media query and styling the element', () => {
+  before(() => {
+    // run these tests as if in a desktop
     cy.visit('/');
     cy.get('[data-cy=controls-FormInput]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();
     cy.get('[data-cy=accordion-Advanced]').click();
     cy.get('[data-cy=inspector-customCssSelector]').type('new_input_css');
     cy.get('[data-cy=topbar-css]').click();
+    cy.wait(500);
     // write the media query in the custom css panel
-    cy.get('#custom-css').type('@media (max-width: 800px) { [selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) { [selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) { [selector=\'new_input_css\'] {background-color: green;}}', {parseSpecialCharSequences: false} );
+    cy.get('#custom-css').type('@media (max-width: 800px) {div[selector=\'new_input_css\'] {background-color: blue;}} @media (min-width: 800px) and (max-width: 1280px) {div[selector=\'new_input_css\'] {background-color: red;}} @media (min-width: 1280px) {div[selector=\'new_input_css\'] {background-color: green;}}', {parseSpecialCharSequences: false} );
+    cy.wait(500);
     cy.get('[data-cy=save-button]').click();
     //preview
     cy.get('[data-cy=mode-preview]').click();
-    cy.wait(1000);
-    //if the resilt contains the custom css name selector
-    cy.get('.page').should('contain.html', '<div selector="new_input_css">');
-    // background color blue
-    cy.wait(400);
-    // update the viewport size
-    cy.viewport(700, 800);
-    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 0, 255)');
-    // background color red
-    cy.wait(100);
-    // update the viewport size
-    cy.viewport(1000, 800);
-    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(255, 0, 0)');
-    // background color green
-    cy.wait(100);
-    // update the viewport size
-    cy.viewport(1500, 800);
-    cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq','rgb(0, 128, 0)');
+  });
+
+  sizes.forEach((size, index) => {
+    // make assertions on the screen using
+    // an array of different viewports
+    it(`Should display screen on ${size} screen`, () => {
+      if (Cypress._.isArray(size)) {
+        cy.viewport(size[0], size[1]);
+      } else {
+        cy.viewport(size);
+      }
+      cy.get('[selector=new_input_css]').should('have.css', 'background-color').and('eq',backgroundColor[index]);
+    });
   });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
media query spec must work
Actual behavior: 
media query spec is failing in the Circle CI enviroment
## Solution
- refactor the cypress media query tests
![tests](https://github.com/ProcessMaker/screen-builder/assets/1401911/65551462-a1e0-43d5-a346-3e787babafc3)


## How to Test
Test the steps above
1. run npm run serve
2. run npx cypress run --spec tests/e2e/specs/MediaQuery.spec.js
3. test result fails

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9485

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
