### PR TITLE
FOUR-9477: Added alphabetical sort to control list

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -555,7 +555,14 @@ export default {
         return this.collator.compare(a.label, b.label);
       });
 
-      return [...sorted, ...excluded];
+      return [...sorted, ...excluded].sort((a, b) => {
+        const textA = a.label.toLowerCase();
+        const textB = b.label.toLowerCase();
+        if (textA < textB) {
+          return -1;
+        }
+        return textA > textB ? 1 : 0;
+      });
     },
     isCurrentPageEmpty() {
       return this.config[this.currentPage].items.length === 0;

--- a/tests/e2e/specs/Loop.spec.js
+++ b/tests/e2e/specs/Loop.spec.js
@@ -78,7 +78,7 @@ describe('Loop control', () => {
     cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
 
     // Add submit button
-    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormButton]').contains('Submit Button').drag('[data-cy=screen-element-container]', 'bottom');
 
     cy.setPreviewDataInput('{"loop_1":[{"name": "foo"}]}');
 
@@ -148,7 +148,7 @@ describe('Loop control', () => {
     cy.get('[data-cy=save-rule]').click();
 
     // Add submit button
-    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormButton]').contains('Submit Button').drag('[data-cy=screen-element-container]', 'bottom');
 
     // Set preview data
     cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');
@@ -165,7 +165,7 @@ describe('Loop control', () => {
     cy.get(':nth-child(1) > .container-fluid > :nth-child(1) > .page > :nth-child(1) > .row > :nth-child(1) > :nth-child(1) > .form-group > [data-cy=screen-field-form_input_1]').clear().type('foobar').blur();
 
     // Ensure form can be submitted
-    cy.get('[name="Default"] > :nth-child(1) > .form-group > .btn')
+    cy.get('.form-group > .btn')
       .click()
       .then(() => expect(alert).to.equal('Preview Form was Submitted'));
   });
@@ -200,7 +200,7 @@ describe('Loop control', () => {
     cy.get('[data-cy=save-rule]').click();
 
     // Add submit button
-    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormButton]').contains('Submit Button').drag('[data-cy=screen-element-container]', 'bottom');
 
     // Set preview data
     cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');
@@ -284,7 +284,7 @@ describe('Loop control', () => {
     cy.get('[data-cy=inspector-conditionalHide]').clear().type('name != "foo"');
 
     // Add submit button
-    cy.get('[data-cy=controls] > :nth-child(14)').drag('[data-cy=screen-element-container]', 'bottom');
+    cy.get('[data-cy=controls-FormButton]').contains('Submit Button').drag('[data-cy=screen-element-container]', 'bottom');
 
     // Set preview data
     cy.setPreviewDataInput('{"loop_1":[{"name": "bar"}, {"name": "foo"}]}');


### PR DESCRIPTION
## Issue & Reproduction Steps
The Bootstrap controls in Screen Builder are not listed in alphabetical order. They are presently the last ones in this list. They should be listed as the first controls to be alphabetical.

Expected behavior: 
Bootstrap controls should fall in alphabetical order along with all other controls.

Actual behavior: 
Bootstrap controls are out of order and appear at the bottom of other controls.

## Solution
- Added a sort to the filtered controls.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9477

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
