### PR TITLE
FOUR-8416 Added test to support read only attributes

### DIFF
--- a/tests/e2e/specs/DatePicker.spec.js
+++ b/tests/e2e/specs/DatePicker.spec.js
@@ -55,6 +55,20 @@ describe('Date Picker', () => {
       form_date_picker_1: moment().format('YYYY-MM-DD'),
     });
   });
+  it("Date type with readOnly as true shouldn't be able to clear the date" , () => {
+    cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
+    cy.get('[data-cy=screen-element-container]').click();
+    cy.setMultiselect('[data-cy=inspector-dataFormat]', 'Date');
+    cy.get('[data-cy=inspector-disabled]').click();
+    cy.get('[data-cy=accordion-Advanced]').click();
+    cy.get('[data-cy=inspector-defaultValue-js]').click();
+    cy.setVueComponentValue('[data-cy=inspector-defaultValue-jsValue]', 'return new Date();');
+    cy.get('[data-cy=mode-preview]').click();
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] vdpClearInput').should('not.exist');
+    cy.assertPreviewData({
+      form_date_picker_1: moment().format('YYYY-MM-DD'),
+    });
+  });
   it('DateTime type', () => {
     cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The user shouldn't be able to clear the date if the datepicker is in `readonly` mode

Actual behavior: 
The user is able to clear the date when in `readonly` mode

## Solution
- `isReadOnly` coming from the mixin `validation.js` and we weren't getting a prop from `readonly`. Removed the prop since it wasn't needed and added the test to cover this scenario

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8416
- https://github.com/ProcessMaker/vue-form-elements/pull/407

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:vue-form-elements:bugfix/FOUR-8416
