### PR TITLE
FOUR-8770: Watcher script configuration strips line breaks

### DIFF
--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -328,7 +328,7 @@ export default {
       try {
         const currentConf = JSON.parse(this.config.script_configuration);
         const newConf = JSON.parse(value);
-        this.config.script_configuration = JSON.stringify({...currentConf, ...newConf});
+        this.config.script_configuration = JSON.stringify({...currentConf, ...newConf}, null, '\t');
       } catch {
         // Invalid json will get caught by the validator
       }

--- a/tests/e2e/specs/ComputedFieldsReadOnly.spec.js
+++ b/tests/e2e/specs/ComputedFieldsReadOnly.spec.js
@@ -1,3 +1,5 @@
+import {waitUntilElementIsVisible} from '../support/utils';
+
 describe('Computed fields', () => {
 
   it('The user should not be able to change a FormInput assigned to a computed property', () => {
@@ -135,7 +137,7 @@ describe('Computed fields', () => {
     });
   });
 
-  it('The user should not be able to change a FormDatePicker assigned to a computed property', () => {
+  it.only('The user should not be able to change a FormDatePicker assigned to a computed property', () => {
     cy.visit('/');
     // Add an input field
     cy.get('[data-cy=controls-FormDatePicker]').drag('[data-cy=screen-drop-zone]', 'bottom'); 
@@ -153,11 +155,13 @@ describe('Computed fields', () => {
     cy.get('[data-cy=mode-preview]').click();
 
     // Assertion: Check the form_date_picker_1 is read only
-    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').should('have.attr', 'readonly');
+    cy.get('[data-cy=preview-content] [data-cy="screen-field-form_date_picker_1"] input').should('have.attr', 'disabled');
+
     // Assertion: Check the form_date_picker_1 is always 1
     cy.assertPreviewData({
       form_date_picker_1: '1',
     });
+
   });
 
   it('The user should not be able to change a FormSelectList assigned to a computed property', () => {


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a Watcher 
- Go to the Source configuration - 
-  Add a script on the source list
-  Go to the Script configuration part
-  Add a JSON to the Script configuration
-  Save the Watcher 
-  Re-open the Watcher
-  Look for the Script Configuration again 
-  At this point, all the JSON lines breaks are gone upon 


Expected behavior: 
When we save the script configuration, all line breaks should not go upon reopening the editor.

Actual behavior: 
When saving the Script Configuration for a Watcher, all line breaks are gone upon reopening the editor.
## Solution
The problem is that internally, a new JSON object is created (a merge of 2 objects), causing any "customization" in the JSON string to be lost.

The proposed solution involves adding carriage returns and spaces to the created JSON.


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-8770](https://processmaker.atlassian.net/browse/FOUR-8770)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
