### PR TITLE
FOUR-9720 Added a wait in the DatePickerTimezone.spec.js

### DIFF
--- a/tests/e2e/specs/DatePickerTimezone.spec.js
+++ b/tests/e2e/specs/DatePickerTimezone.spec.js
@@ -39,6 +39,8 @@ describe("Date Picker", () => {
       }
     });
 
+    cy.wait(500);
+
     const todayDateChanged = `${moment().format("YYYY-MM-DD")}T20:15:00`;
     const today = moment.tz(todayDateChanged, timezoneTest);
 


### PR DESCRIPTION
## Issue & Reproduction Steps

## Solution
- Added an extra wait for Vue queue to pick up the changes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9720

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
