### PR TITLE
Fix svg icon height for controls

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1055,7 +1055,6 @@ export default {
 }
 
 .svg-icon > svg {
-  height: 14px;
 }
 </style>
 


### PR DESCRIPTION
Fixed svg icon height for control icons.

Related PR:
[Package Plaid](https://github.com/ProcessMaker/package-plaid/pull/5)