### PR TITLE
Bugfix/FOUR-10072: Address issue related to the icon in screen builder controls list

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1055,6 +1055,7 @@ export default {
 }
 
 .svg-icon > svg {
+  margin-bottom: 3px;
 }
 </style>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Address issue related to the icon in screen builder controls list for Plaid package.

## Solution
- Fix width and height in plaid package
- fix margin bottom for svg icons

## How to Test
- install package-plaid and go to screen builder. Verify the icon for plaid is correctly displayed

## Related Tickets & Packages
- [FOUR-10072](https://processmaker.atlassian.net/browse/FOUR-10072)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10072]: https://processmaker.atlassian.net/browse/FOUR-10072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ