### PR TITLE
Add retry to get task endpoint

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -316,7 +316,8 @@ export default {
       if (!requestId) {
         requestId = this.requestId;
       }
-      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1&t=${Date.now()}`;
+      const timestamp = !window.Cypress ? `&t=${Date.now()}` : "";
+      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${timestamp}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
           if (response.data.data.length > 0) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -316,7 +316,7 @@ export default {
       if (!requestId) {
         requestId = this.requestId;
       }
-      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1`;
+      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1&t=${Date.now()}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
           if (response.data.data.length > 0) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Sometimes when a ActivatedActivity is triggered and the get tasks function is executed immediatly it gets an empty result. It needs a retry capacity to retry to get the next task.

Expected behavior: 

A retry feature to get the last assigned task.

Actual behavior: 
Does not have a retry feature.

## Solution
- Implement a retry feature to `getTasks()` function.

## How to Test
Run the attached process as a webentry.
- Upload a file
- Submit the form
- See the interstitial get properly the next screen.

[webentry.zip](https://github.com/ProcessMaker/screen-builder/files/12501628/webentry.zip)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10271


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

.
