### PR TITLE
FOUR-8066 Restart screens to be validated when a task resets screen state

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -127,7 +127,7 @@ export default {
 
       if (_.has(window, 'PM4ConfigOverrides.getFileEndpoint')) {
         endpoint = window.PM4ConfigOverrides.getFileEndpoint;
-        return `${endpoint}/${file.id}`;
+        return `${endpoint}/${file.id}/contents`;
       }
 
       return `/files/${file.id}/contents`;

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -280,6 +280,7 @@ export default {
     resetScreenState() {
       if (this.$refs.renderer && this.$refs.renderer.$children[0]) {
         this.$refs.renderer.$children[0].currentPage = 0;
+        this.$refs.renderer.restartValidation();
       }
     },
     checkTaskStatus() {

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -171,7 +171,7 @@ export default {
     this.containerObserver.observe(this.$refs.formRendererContainer);
   },
   methods: {
-    ...mapActions("globalErrorsModule", ["validate", "hasSubmitted", "showValidationOnLoad"]),
+    ...mapActions("globalErrorsModule", ["validate", "hasSubmitted", "showValidationOnLoad", "restartValidation"]),
     getMainScreen() {
       return this.$refs.renderer && this.$refs.renderer.$refs.component;
     },

--- a/src/store/modules/globalErrorsModule.js
+++ b/src/store/modules/globalErrorsModule.js
@@ -32,6 +32,11 @@ function countErrors(obj) {
 }
 
 const updateValidationRules = async (screens, commit) => {
+  if (screens.length === 0) {
+    // When validation was restarted, the screens array is empty
+    // and we don't need to do anything
+    return;
+  }
   const rootScreen = findRootScreen(screens[0]);
   const awaitLoad = [];
   screens.forEach((screen) => {

--- a/src/store/modules/globalErrorsModule.js
+++ b/src/store/modules/globalErrorsModule.js
@@ -126,6 +126,9 @@ const globalErrorsModule = {
     }
   },
   actions: {
+    restartValidation() {
+      screensToValidate.length = 0;
+    },
     validate({ commit }, mainScreen) {
       queueUpdateValidationRules(mainScreen, commit);
     },


### PR DESCRIPTION
Restart screens to be validated when a task resets screen state.

Required for process testing.

## Related tickets
- https://processmaker.atlassian.net/browse/FOUR-8066

ci:next
