### PR TITLE
FOUR-10311 Redirect automatically to Request if the request was already completed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -164,6 +164,10 @@ export default {
 
     task: {
       handler() {
+        if (!this.screen) {
+          // if no current screen show the interstitial screen if exists
+          this.screen = this.task && this.task.interstitial_screen;
+        }
         this.taskId = this.task.id;
         this.nodeId = this.task.element_id;
         this.listenForParentChanges();
@@ -528,6 +532,16 @@ export default {
     this.nodeId = this.initialNodeId;
     this.requestData = this.value;
     this.loopContext = this.initialLoopContext;
+    if (
+      this.$parent.task &&
+      !this.$parent.task.screen &&
+      this.$parent.task.allow_interstitial &&
+      this.$parent.task.interstitial_screen
+    ) {
+      // if interstitial screen exists, show it
+      console.log(this.$parent.task.interstitial_screen);
+      this.screen = this.$parent.task.interstitial_screen;
+    }
   },
   destroyed() {
     this.unsubscribeSocketListeners();

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -167,6 +167,9 @@ export default {
         this.taskId = this.task.id;
         this.nodeId = this.task.element_id;
         this.listenForParentChanges();
+        if (this.task.process_request.status === 'COMPLETED') {
+          this.$emit('completed', this.task.process_request.id);
+        }
       },
     },
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -539,7 +539,6 @@ export default {
       this.$parent.task.interstitial_screen
     ) {
       // if interstitial screen exists, show it
-      console.log(this.$parent.task.interstitial_screen);
       this.screen = this.$parent.task.interstitial_screen;
     }
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
Redirect automatically to Request if the request was already completed

Expected behavior: 

Actual behavior: 

## Solution
-

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10311

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
