### PR TITLE
FOUR-10115: Prevent form changes if task has not been claimed as self service

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -6,6 +6,18 @@
     class="tab-pane active show h-100"
   >
     <template v-if="screen">
+      <b-overlay
+          :show="disabled"
+          id="overlay-background"
+          variant="white"
+          cardStyles="pointer-events: none;pointer-events: none;inset: 1px"
+          rounded="sm"
+      >
+      <template #overlay>
+        <div class="text-center">
+          <p>Please claim this task to continue.</p>
+        </div>
+      </template>
       <div class="card card-body border-top-0 h-100" :class="screenTypeClass">
         <div v-if="renderComponent === 'task-screen'">
           <vue-form-renderer
@@ -43,6 +55,7 @@
           {{ $t('Complete Task') }}
         </button>
       </div>
+      </b-overlay>
     </template>
     <template v-if="showTaskIsCompleted">
       <div class="card card-body text-center" v-cloak>
@@ -294,6 +307,15 @@ export default {
       }
       this.prepareTask();
     },
+    disableForSelfService() {
+      this.$nextTick(() => {
+        if (window.ProcessMaker.isSelfService) {
+          this.disabled = true;
+        } else {
+          this.disabled = false;
+        }
+      });
+    },
     closeTask(parentRequestId = null) {
       if (this.hasErrors) {
         this.$emit('error', this.requestId);
@@ -384,8 +406,8 @@ export default {
     },
     onUpdate(data) {
       this.$emit('input', data);
+      this.disableForSelfService();
     },
-
     activityAssigned() {
       // This may no longer be needed
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a new [process](https://github.com/ProcessMaker/screen-builder/files/12831232/four-10115.json.zip) with a minimum of two tasks, each with a form
2. In the second task, the assignment rule is self-service
3. Run a request up to the self-service task
4. Open the second task, notice you can fill the form without claiming the task
5. Fill out the form and try to submit it, you will get a message that says you need to claim the task first
6. Claim the task, at that point, the form is reloaded and all the previous data you filled in is whipped out

## Solution
- Added a bootstrap-vue component overlay to prevent the task form(s) from being altered before the self-service is claimed.

## How to Test
Run through the reproduction steps and you should now not be able to change the form inputs on the second task before you claim it as self-service.

## Related Tickets & Packages
- [FOUR-10115](https://processmaker.atlassian.net/browse/FOUR-10115)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10115]: https://processmaker.atlassian.net/browse/FOUR-10115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ