### PR TITLE
Bugfix/four 11025 Loading Submit is not working correctly when required field is enabled

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -78,7 +78,7 @@ export default {
         this.setValue(this.$parent, this.name, this.fieldValue);
       }
       if (this.event === 'submit') {
-        if (this.loading) {
+        if (this.loading && this.valid) {
           this.showSpinner = true;
         }
         this.$emit('input', this.fieldValue);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Loading submit button should validate all required field before it displays its Loading Label message

Actual behavior: 
The loading submit button is not working correctly when a field is marked as Requited

## Solution
Check the validation of the formdata before changing the submit button 

## How to Test

Create a Screen 
Create a line input control and check Make Required option
Create a Submit control and check Loading Submit Button option
Assign that Screen in a Web Entry
Run a Request from Web Entry

## Related Tickets & Packages

https://processmaker.atlassian.net/browse/FOUR-11025

ci:next