### PR TITLE
QA Observation Bugfix/FOUR-11084: The "Analytics Management" does not show the value selected

### DIFF
--- a/src/components/inspector/analytics-selector.vue
+++ b/src/components/inspector/analytics-selector.vue
@@ -19,6 +19,7 @@
 const globalObject = typeof window === "undefined" ? global : window;
 
 export default {
+  props: ["value"],
   data() {
     return {
       selectedOption: null,
@@ -28,10 +29,14 @@ export default {
   watch: {
     selectedOption(newValue) {
       this.$emit("input", newValue);
+    },
+    value() {
+      this.selectedOption = this.value;
     }
   },
-  created() {
+  mounted() {
     this.fetchChartData();
+    this.selectedOption = this.value;
   },
   methods: {
     fetchChartData() {


### PR DESCRIPTION
## Solution
- The Analytics Management dropdown in Screen Builder shows the name of selected Analytics Chart

## How to Test
- Package Analytics Reporting must be installed with last version which includes new API's

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next