### PR TITLE
FOUR-11278: Enlarge the participant task preview panel

### DIFF
--- a/src/components/renderer/form-tasks.vue
+++ b/src/components/renderer/form-tasks.vue
@@ -43,7 +43,7 @@
         </span>
       </template>
     </vuetable>
-    <component :is="tasksPreview" ref="preview" />
+    <component :is="tasksPreview" ref="preview-sidebar" />
   </div>
   <div v-else>
     <formEmpty link="Tasks" title="No tasks in sight" url="/tasks" />
@@ -79,7 +79,7 @@ export default {
         }
       ],
       tasksPreview:
-        (window.SharedComponents && window.SharedComponents.TasksPreview) || {}
+        (window.SharedComponents && window.SharedComponents.TasksHome) || {}
     };
   },
   mounted() {
@@ -272,8 +272,15 @@ export default {
       }
       return link;
     },
+    /**
+     * Show the preview tasks
+     */
     previewTasks(info) {
-      this.$refs.preview.showSideBar(info, this.tableData.data, true);
+      this.$refs["preview-sidebar"].showSideBar(
+        info,
+        this.tableData.data,
+        true
+      );
     },
     classDueDate(value) {
       const dueDate = moment(value);


### PR DESCRIPTION
## Issue & Reproduction Steps
My Task: Enlarge the participant task preview panel
![image](https://github.com/ProcessMaker/screen-builder/assets/42388723/87a48b27-85eb-43bf-a55d-9ba1ec1cdbf6)

## Solution
- The preview pane needs to use the 50%

## How to Test

- Create Request
- Create Route Request
- See the preview Pane From Task and Welcome Screen

## Related Tickets & Packages
- [FOUR-11278](https://processmaker.atlassian.net/browse/FOUR-11278)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next

[FOUR-11278]: https://processmaker.atlassian.net/browse/FOUR-11278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ