### PR TITLE
Validations rules do not work the first time before pressing the Submit button

### DIFF
--- a/src/mixins/extensions/ValidationRules.js
+++ b/src/mixins/extensions/ValidationRules.js
@@ -54,14 +54,19 @@ export default {
       return check.str;
     },
     fieldValidationShow (element) {
+      console.log('fieldValidationShow', element.config.name, element.config, element.config.validation);
       let showError = true;
-      if (element.config.validation) {
+      if (element.config && element.config.validation) {
         const validationHidden = ['Required', 'Required if'];
-        element.config.validation.forEach((validation) => {
-          if (validationHidden.includes(validation.content)) {
-            showError = false;
-          }
-        });
+        if (Array.isArray(element.config.validation)) {
+          element.config.validation.forEach((validation) => {
+            if (validationHidden.includes(validation.content)) {
+              showError = false;
+            }
+          });
+        } else {
+          showError = validationHidden.includes(element.config.validation);
+        }
       }
       return showError;
     }

--- a/src/mixins/extensions/ValidationRules.js
+++ b/src/mixins/extensions/ValidationRules.js
@@ -54,7 +54,6 @@ export default {
       return check.str;
     },
     fieldValidationShow (element) {
-      console.log('fieldValidationShow', element.config.name, element.config, element.config.validation);
       let showError = true;
       if (element.config && element.config.validation) {
         const validationHidden = ['Required', 'Required if'];

--- a/src/mixins/extensions/ValidationRules.js
+++ b/src/mixins/extensions/ValidationRules.js
@@ -17,8 +17,8 @@ export default {
               console.error("Invalid variable name");
             }
           } else {
-            properties[':class'] = `{ 'form-group--error': showValidationErrors && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && $v.vdata.${element.config.name}.$invalid || showValidationErrors && ${this.checkVariableExists('$v.schema.' + element.config.name)} && $v.schema.${element.config.name}.$invalid }`;
-            properties[':error'] = `showValidationErrors && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && validationMessage($v.vdata.${element.config.name}) || showValidationErrors && ${this.checkVariableExists('$v.schema.' + element.config.name)} && validationMessage($v.schema.${element.config.name})`;
+            properties[':class'] = `{ 'form-group--error': (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && $v.vdata.${element.config.name}.$invalid || (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && $v.schema.${element.config.name}.$invalid }`;
+            properties[':error'] = `(showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && validationMessage($v.vdata.${element.config.name}) || (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && validationMessage($v.schema.${element.config.name})`;
           }
         }
       },
@@ -53,5 +53,17 @@ export default {
       }, {str: '', variable: ''});
       return check.str;
     },
+    fieldValidationShow (element) {
+      let showError = true;
+      if (element.config.validation) {
+        const validationHidden = ['Required', 'Required if'];
+        element.config.validation.forEach((validation) => {
+          if (validationHidden.includes(validation.content)) {
+            showError = false;
+          }
+        });
+      }
+      return showError;
+    }
   },
 };

--- a/tests/e2e/specs/ValidationShownOnSubmit.spec.js
+++ b/tests/e2e/specs/ValidationShownOnSubmit.spec.js
@@ -9,8 +9,14 @@ describe('Validation Rules', () => {
   it('Invalid default values', () => {
     cy.loadFromJson('validation_rules.json', 0);
     cy.get('[data-cy=mode-preview]').click();
-    
-    cy.shouldNotHaveValidationErrors('screen-field-form_input_1');
+
+    cy.shouldHaveValidationErrors('screen-field-form_checkbox_1');
+    cy.shouldHaveValidationErrors('screen-field-form_input_1');
+    cy.shouldHaveValidationErrors('screen-field-form_input_2');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_3');
+    cy.shouldHaveValidationErrors('screen-field-form_input_4');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_5');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_6');
 
     cy.get('[data-cy=preview-content] .page button').click();
 
@@ -19,6 +25,13 @@ describe('Validation Rules', () => {
     cy.get('[data-cy=preview-content] [data-cy="screen-field-form_input_1"]')
       .clear()
       .type('on');
+
+    cy.shouldHaveValidationErrors('screen-field-form_checkbox_1');
     cy.shouldNotHaveValidationErrors('screen-field-form_input_1');
+    cy.shouldHaveValidationErrors('screen-field-form_input_2');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_3');
+    cy.shouldHaveValidationErrors('screen-field-form_input_4');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_5');
+    cy.shouldNotHaveValidationErrors('screen-field-form_input_6');
   });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
Validations are only shown after submitting.

Expected behavior: 
- When the form opens, there is no validation.
- All required fields should be marked with a red asterisk (*).
- Fields designated as "Required If," which meet their specified conditions, should also be identified with an asterisk (*).
- While filling out the form, if a required field is left blank when completing the form in order, the empty field should be highlighted in red.
- An alert message should be displayed when the validation criteria are not met while filling a field.
- The field should also highlight in red when the Submit Button is clicked, and the validation criteria are not met.
- These rules apply to loops, nested screens, and multiple screens.

Actual behavior: 
Validations are only shown after submitting.

## Solution
- validate fields that only have required and required if validations

## How to Test
validate forms that have validations

## Related Tickets & Packages
- [FOUR-11286](https://processmaker.atlassian.net/browse/FOUR-11286)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11286]: https://processmaker.atlassian.net/browse/FOUR-11286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy