### PR TITLE
Bugfix/FOUR-11185: Icons of buttons displaced to the left in Screen builder

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -81,7 +81,7 @@
             data-cy="toolbar-edit"
             @click="openEditPageModal(currentPage)"
           >
-            <i class="far fa-edit" />
+            <i class="far fa-edit p-0" />
           </b-button>
 
           <b-button
@@ -93,7 +93,7 @@
             data-cy="toolbar-remove"
             @click="confirmDelete()"
           >
-            <i class="far fa-trash-alt" />
+            <i class="far fa-trash-alt p-0" />
           </b-button>
 
           <b-button
@@ -105,7 +105,7 @@
             data-cy="toolbar-add"
             @click="originalPageName = null"
           >
-            <i class="fas fa-plus" />
+            <i class="fas fa-plus p-0" />
           </b-button>
         </div>
 


### PR DESCRIPTION
### Description

Steps to reproduce:
- Login as admin
- Go to Designer > Screen
- Click on +Screen
- Set the information required
- Drag and drop any control

Current behavior:
The icons of the buttons are displaced to the left

Expected behavior:
The icons should be centered 

Please see the image in the ticket for more information
https://processmaker.atlassian.net/jira/software/c/projects/FOUR/boards/493?selectedIssue=FOUR-11185


### Solution
Fix padding for buttons in screen builder

<img width="1503" alt="Screenshot 2023-11-07 at 09 28 58" src="https://github.com/ProcessMaker/screen-builder/assets/90727999/f37faedf-19de-4b16-b832-11e0b3ff9b5d">

### Related tickets
- [FOUR-11185](https://processmaker.atlassian.net/jira/software/c/projects/FOUR/boards/493?selectedIssue=FOUR-11185)

ci:next

[FOUR-11185]: https://processmaker.atlassian.net/browse/FOUR-11185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ