### PR TITLE
feature/FOUR-12358

### DIFF
--- a/src/components/renderer/card.vue
+++ b/src/components/renderer/card.vue
@@ -115,6 +115,7 @@ export default {
         .then((response) => {
           this.spin = 0;
           const instance = response.data;
+          this.$cookies.set("fromTriggerStartEvent", true, "1min");
           window.location = `/requests/${instance.id}?fromRedirect=true`;
         })
         .catch((err) => {


### PR DESCRIPTION
## Issue & Reproduction Steps

**Current Behavior:**
The workflow started with +Request button goes directly the assigned screen. In Welcome screen case, this does not happen, it goes to the Task Summary

**Expected Behavior:**
Welcome Screen with the configuration given above must go directly to the assigned screen.


## How to Test
1. Have a process to start a request
2. Configure the start event with Display Next Assigned Task to Task Asignee
3. Start a request in both: +Request button and Welcome Screen

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-12358

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy