### PR TITLE
FOUR-12665 The interstitial screen in the start event stops working

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -587,6 +587,14 @@ export default {
       // if interstitial screen exists, show it
       this.screen = this.$parent.task.interstitial_screen;
     }
+
+    if (
+      this.$parent.task &&
+      this.$parent.task.interstitial_screen &&
+      this.$parent.task.process_request.status === 'ACTIVE'
+    ) {
+      this.screen = this.$parent.task.interstitial_screen;
+    }
   },
   destroyed() {
     this.unsubscribeSocketListeners();


### PR DESCRIPTION
## Issue & Reproduction Steps
Currently, if the interstitial screen is configured in the start event, it never shows up and the request’s task is shown directly. We have noticed that this happens with a process with more than 50 elements (meaning tasks, events, lines, pools, etc.) at the beginning you will see this behavior intermittently but if you increase the number of elements (>50) you will see it permanently.
If you reduce the number of elements you will see that the interstitial works normally.

## Solution
- Check if the interstitial screen is set

## Related Tickets & Packages
[FOUR-12665](https://processmaker.atlassian.net/browse/FOUR-12665)
https://github.com/ProcessMaker/processmaker/pull/5753

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12665]: https://processmaker.atlassian.net/browse/FOUR-12665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ