### PR TITLE
FOUR-12754 Fix Screen Interstitial unexpected behavior

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -578,23 +578,6 @@ export default {
     this.nodeId = this.initialNodeId;
     this.requestData = this.value;
     this.loopContext = this.initialLoopContext;
-    if (
-      this.$parent.task &&
-      !this.$parent.task.screen &&
-      this.$parent.task.allow_interstitial &&
-      this.$parent.task.interstitial_screen
-    ) {
-      // if interstitial screen exists, show it
-      this.screen = this.$parent.task.interstitial_screen;
-    }
-
-    if (
-      this.$parent.task &&
-      this.$parent.task.interstitial_screen &&
-      this.$parent.task.process_request.status === 'ACTIVE'
-    ) {
-      this.screen = this.$parent.task.interstitial_screen;
-    }
   },
   destroyed() {
     this.unsubscribeSocketListeners();


### PR DESCRIPTION
Do not display interstitial by default at the beginning

Expected behavior: 
- Do not display interstitial by default at the beginning when screen is loading

## Solution
- Do not display interstitial when loading screen

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12754

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:processmaker:develop
