### PR TITLE
FOUR-13065 AIAssistant was coming as undefined due to a watcher race-condition issue

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -31,7 +31,10 @@
           <!-- Accordion Bootstrap -->
           <template v-for="(group, index) in controlGroups">
             <b-button
-              v-if="filteredControlsGrouped[group.key].length > 0"
+              v-if="
+                !!filteredControlsGrouped &&
+                filteredControlsGrouped[group.key].length > 0
+              "
               v-b-toggle="`collapse-${index}`"
               class="w-100 rounded-0 text-left"
               style="
@@ -84,7 +87,10 @@
                     />
                     {{ $t(element.label) }}
                   </b-list-group-item>
-                  <li v-if="!filteredControls.length" class="list-group-item">
+                  <li
+                    v-if="!!filteredControls && filteredControls.length > 0"
+                    class="list-group-item"
+                  >
                     <slot />
                   </li>
                 </draggable>
@@ -684,6 +690,7 @@ export default {
         { key: "Files", label: "Files" },
         { key: "Advanced", label: "Advanced" }
       ],
+      filteredControlsGrouped: {},
 
       isCollapsed: new Array(6).fill(true)
     };
@@ -813,7 +820,8 @@ export default {
       handler(newVal) {
         this.groupFilteredControls(newVal);
       },
-      deep: true
+      deep: true,
+      immediate: true
     }
   },
   created() {

--- a/tests/e2e/specs/FileUpload.spec.js
+++ b/tests/e2e/specs/FileUpload.spec.js
@@ -2,7 +2,6 @@ describe('File Upload', () => {
   it('Automatically sets a variable name', () => {
     cy.visit('/');
     cy.openAcordeon("collapse-4");
-    //cy.openAcordeon("collapse-1");
     cy.get('[data-cy=controls-FileUpload]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=screen-element-container]').click();
 
@@ -10,17 +9,18 @@ describe('File Upload', () => {
       const data = div[0].__vue__.name;
       expect(data).to.eql('file_upload_1');
     });
-    
+
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=file-upload-button]').should('not.have.attr', 'disabled');
   });
-  
+
   it('Disables when task is self service', () => {
     cy.visit('/');
     cy.window().then((win) => {
       win.ProcessMaker.isSelfService = true;
     });
 
+    cy.openAcordeon("collapse-4");
     cy.get('[data-cy=controls-FileUpload]').drag('[data-cy=screen-drop-zone]', 'bottom');
     cy.get('[data-cy=mode-preview]').click();
     cy.get('[data-cy=file-upload-button]').should('have.attr', 'disabled');

--- a/tests/e2e/specs/MultiInstanceLoopContext.spec.js
+++ b/tests/e2e/specs/MultiInstanceLoopContext.spec.js
@@ -65,7 +65,6 @@ describe("FOUR-3375 FileUpload inside MultiInstance Task", () => {
         fileUploadId: 1
       })
     ).as("uploadMainFile");
-    cy.openAcordeon("collapse-4");
     cy.uploadFile(
       "[data-cy='screen-field-rootUpload'] input[type=file]",
       "avatar.jpeg",


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
No errors should appear when using Screen Builder

Actual behavior: 
There was an error appearing about `AIAssistant` being undefined due to a race condition where the watcher was being executed AFTER rendering and we needed that watcher to be executed immediatly when rendering. 

## Solution
- Added `immediate` to be `true` on watcher
- Re-indent
- Added the filteredGroupedControls varaible to the v-data since it was missing.

## How to Test
Test the steps above

* Open a Screen of type FORM and no errors should appear in the console.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13065?atlOrigin=eyJpIjoiMjc4ZDllNDU5YzRiNDQ3ZWJmM2YxM2U2NzJiZTYwMGEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
