### PR TITLE
Resolve Task Progression and Error in Guided Templates

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -299,7 +299,11 @@ export default {
           .then((response) => {
             this.task = response.data;
             this.checkTaskStatus();
-            if (window.PM4ConfigOverrides.getScreenEndpoint && window.PM4ConfigOverrides.getScreenEndpoint.includes('tasks/')) {
+            if (
+              window.PM4ConfigOverrides
+              && window.PM4ConfigOverrides.getScreenEndpoint
+              && window.PM4ConfigOverrides.getScreenEndpoint.includes('tasks/')
+            ) {
               const screenPath = window.PM4ConfigOverrides.getScreenEndpoint.split('/');
               screenPath[1] = this.task.id;
               window.PM4ConfigOverrides.getScreenEndpoint = screenPath.join('/');


### PR DESCRIPTION
This PR addresses an ongoing bug in CI servers related to task progression and error handling in Guided Templates. The issues included a 422 error indicating the task was already closed, replication of closed tasks displaying, and incorrect task statuses (In Progress instead of Completed) upon completion.

## Cause

1. The <task> component was not automatically progressing to the next task.
2. An error was thrown from Screen Builder upon closing the first task, with an unknown `getScreenEndpoint` message.

## Solution

1. Removed the initial `getNextTask` method and allow the <task> component progresses correctly.
2. Updated the conditional to check if the `getScreenEndpoint` variable exists, preventing an error and allowing the <task> component to progress.

## How to Test

1. Install the latest Send Email Connector.
2. Symlink the latest Screen Builder.
3. Run `php artisan processmaker:sync-guided-templates`.
4. Navigate to Processes > Guided Templates.
5. Select a guided template.
6. Click 'Start Now' and complete the process (use 'Skip' if needed).
7. Verify no 422 errors occur.
8. Confirm that previously closed tasks do not replicate.
9. After completing the process, check Requests to ensure it has a status of 'Completed'.

## Related Tickets & Packages
- CORE PR - [https://github.com/ProcessMaker/processmaker/pull/6074](https://github.com/ProcessMaker/processmaker/pull/6074)
- [https://processmaker.atlassian.net/browse/FOUR-13331](https://processmaker.atlassian.net/browse/FOUR-13331)

ci:next
ci:processmaker:observation/FOUR-13331

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
