### PR TITLE
FOUR-13951 Added vue-monaco and monaco-editor in the externals array

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,7 @@ export default defineConfig({
     extensions: [".js", ".mjs", ".vue", ".json"]
   },
   build: {
+    sourcemap: true,
     lib: {
       entry: resolve(__dirname, "src/components/index.js"),
       name: libraryName,
@@ -51,7 +52,9 @@ export default defineConfig({
         "moment-timezone",
         "lodash",
         "@processmaker/vue-form-elements",
-        "@processmaker/vue-multiselect"
+        "@processmaker/vue-multiselect",
+        "vue-monaco",
+        "monaco-editor"
       ],
       output: {
         exports: "named",


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
No console.errors and the editor for the Javascript working

Actual behavior: 
Error was saying that `editor` is undefined or undeclared.
## Solution
- Added `vue-monaco` to the externals array since this package is already being provided in core

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13951
- https://processmaker.atlassian.net/browse/FOUR-13952

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
