### PR TITLE
QA Observation bugfix/FOUR-13934: List Table must be in Dashboard

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -886,8 +886,8 @@ export default [
     rendererBinding: "FormListTable",
     control: {
       popoverContent: "Create List Table",
-      order: 3.0,
-      group: 'Files',
+      order: 6.5,
+      group: 'Dashboards',
       label: "List Table",
       component: "FormListTable",
       "editor-component": "FormListTable",


### PR DESCRIPTION
## Solution
- List Table option must be in Dashboards section in Screen Builder

## How to Test
- Open or Edit an Screen of type "Display"
- Click on Dashboards section

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-13934

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next