### PR TITLE
FOUR-13914 | The Language Selected for a User Is Not Complete

### DIFF
--- a/src/components/renderer/form-empty-table.vue
+++ b/src/components/renderer/form-empty-table.vue
@@ -5,7 +5,7 @@
       {{ $t(title) }}
     </span>
     <b-link v-if="url !== ''" @click="openLink()">
-      {{ linkText }}
+      {{ $t(linkText) }}
     </b-link>
   </div>
 </template>

--- a/src/components/renderer/form-list-table.vue
+++ b/src/components/renderer/form-list-table.vue
@@ -11,7 +11,7 @@
             class="avatar-text"
           ></b-avatar>
           <p class="control-text mb-0" :style="dataControl.colorText">
-            {{ title }}
+            {{ $t(title) }}
           </p>
           <template v-if="dataControl.dropdownShow === 'requests'">
             <b-dropdown variant="outline-secondary" no-caret>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-13914](https://processmaker.atlassian.net/browse/FOUR-13914)
 

When a language is selected for a user, all strings are not translated into the selected language.

# Solution
- Ensure missing translations are wrapped in the `$t(...)` translation method.
- Ensure missing translations are added to the language JSON files.

# How to Test
1. Go to branch `observation/FOUR-13914-b` in `processmaker`.
2. Go to branch `observation/FOUR-13914-b` in `screen-builder`.
3. Create a user. Change their language to `es` for Spanish.
4. Ensure that the text on the following pages is translated into Spanish:
	- Homepage (Custom Dashboard text)
	- Processes
	- Designer

ci:next
..

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-13914]: https://processmaker.atlassian.net/browse/FOUR-13914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ