### PR TITLE
FOUR-14220: The size and color of the dropdown button must be adjusted

### DIFF
--- a/src/assets/css/custom.css
+++ b/src/assets/css/custom.css
@@ -1,4 +1,11 @@
 .btn-platform {
   background-color: #ffff;
   color: #6a7888;
+  padding: 8px 8px 2px 8px;
+}
+.btn-platform:hover {
+  color: #6a7888;
+}
+.page-dropdown-menu {
+  min-width: 333px;
 }

--- a/src/components/editor/pagesDropdown.vue
+++ b/src/components/editor/pagesDropdown.vue
@@ -3,7 +3,13 @@
     Dropdown component to display options related to pages.
     Provides options to add a new page, see all pages, and select individual pages.
   -->
-  <b-dropdown data-test="page-dropdown" variant="platform" :boundary="boundary">
+  <b-dropdown
+    ref="pageDropdown"
+    data-test="page-dropdown"
+    variant="platform"
+    :boundary="boundary"
+    menu-class="page-dropdown-menu"
+  >
     <!-- Dropdown button content -->
     <template #button-content>
       <!-- Icon representing a file -->


### PR DESCRIPTION
## Issue & Reproduction Steps

The size of the menu is small, it is in black
Its contain is small too

## Solution
- improve styles

## How to Test
Describe how to test that this solution works.

- Open any screen
- Go to menu dropdown

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14220

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
