### PR TITLE
FOUR-14224 numbers appear next to the name of each page in see all pages

### DIFF
--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -29,7 +29,7 @@
               autofocus
               @blur.stop="onBlur()"
             />
-            <span v-else>{{ item.name }} {{ item.order }}</span>
+            <span v-else>{{ item.name }}</span>
           </div>
           <div class="border rounded-lg sortable-item-action">
             <button class="btn" @click.stop="onClick(item, index)">


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The numbers next to the name of each page in See all pages should not appear, only the names should be shown

Actual behavior: 
Numbers appear next to the name of each page in See all pages

## Solution
- Fix the sortable list

## How to Test
1. Open screen
2. Create a few pages 
3. Click on See all pages

## Related Tickets & Packages
[FOUR-14224](https://processmaker.atlassian.net/browse/FOUR-14224)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-14224]: https://processmaker.atlassian.net/browse/FOUR-14224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ