### PR TITLE
FOUR-14227: Design in modal to edit pages is not the same with mockup

### DIFF
--- a/src/components/sortable/sortableList/sortableList.scss
+++ b/src/components/sortable/sortableList/sortableList.scss
@@ -9,6 +9,7 @@ $border-color: #cdddee;
     &-header {
       display: flex;
       align-items: center;
+      border-bottom: 1px solid $border-color;
     }
 
     &-title {
@@ -31,7 +32,7 @@ $border-color: #cdddee;
     display: flex;
     align-items: center;
     height: 56px;
-    border-top: 1px solid $border-color;
+    border-bottom: 1px solid $border-color;
     cursor: move;
 
     &-icon {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -371,8 +371,6 @@
     <template #modal-header-close="{ close }">
       <button type="button" aria-label="Close" class="close"  @click="close()">×</button>
     </template>
-
-  
       <Sortable
         :items="config"
         filter-key="name"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1511,7 +1511,7 @@ $side-bar-font-size: 0.875rem;
   }
 }
 .modal-subtitle {
-  font-size: 16px;
+  font-size: 14px;
   font-weight: normal;
 }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1511,7 +1511,7 @@ $side-bar-font-size: 0.875rem;
   }
 }
 .modal-subtitle {
-  font-size: 14px;
+  font-size: 15px;
   font-weight: normal;
 }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -359,11 +359,20 @@
       header-close-content="&times;"
       role="dialog"
       size="lg"
-      :title="$t('Edit Pages')"
       :ok-title="$t('CONFIRM')"
       ok-only
       ok-variant="secondary"
+      header-class = "modal-header-custom"
     >
+    <template #modal-title>
+      <h5 class="modal-title">{{ $t('Edit Pages') }}</h5>
+      <p class="modal-subtitle">{{ $t('Change pages order and name') }}</p>
+    </template>
+    <template #modal-header-close="{ close }">
+      <button type="button" aria-label="Close" class="close"  @click="close()">×</button>
+    </template>
+
+  
       <Sortable
         :items="config"
         filter-key="name"
@@ -1500,5 +1509,9 @@ $side-bar-font-size: 0.875rem;
   100% {
     box-shadow: 0 0 0 13px rgba(0, 0, 0, 0);
   }
+}
+.modal-subtitle {
+  font-size: 16px;
+  font-weight: normal;
 }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -366,7 +366,7 @@
     >
     <template #modal-title>
       <h5 class="modal-title">{{ $t('Edit Pages') }}</h5>
-      <p class="modal-subtitle">{{ $t('Change pages order and name') }}</p>
+      <span class="modal-subtitle">{{ $t('Change pages order and name') }}</span>
     </template>
     <template #modal-header-close="{ close }">
       <button type="button" aria-label="Close" class="close"  @click="close()">×</button>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The subtitle should appear in the modal Edit pages
The height of the rows must be the same

Actual behavior: 
Subtitle does not appear in modal Edit pages
The height of the rows is not the same

## Solution
- subtitle component was added
- height was adjusted




## How to Test
Test the steps above

Open any screen
Go to menu dropdown
Click on See all pages

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14227

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
