### PR TITLE
FOUR-14225  it is not possible to reorder the pages from the modal

### DIFF
--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -5,8 +5,8 @@
         <i class="fa fa-search sortable-search-icon"></i>
         <input
           id="search"
-          class="form-control border-0 shadow-none px-0"
           v-model="search"
+          class="form-control border-0 shadow-none px-0"
           :placeholder="$t('Search here')"
           data-test="search"
         />
@@ -52,11 +52,28 @@ export default {
   },
   watch: {
     search(value) {
-      const cleanValue = value.trim().toLowerCase();
-
-      this.filteredItems = this.items.filter((item) => item[this.filterKey].toLowerCase().includes(cleanValue));
+      this.filteredItems = this.filterItems(value, this.items);
     },
-  }
+    items: {
+      handler(newItems) {
+        this.filteredItems = newItems;
+
+        if (this.search.length > 0) {
+          this.filteredItems = this.filterItems(this.search, newItems);
+        }
+      },
+      deep: true,
+    },
+  },
+  methods: {
+    clearSearch(value) {
+      return value.trim().toLowerCase();
+    },
+    filterItems(searchValue, items) {
+      const cleanSearch = this.clearSearch(searchValue);
+      return items.filter((item) => item[this.filterKey].toLowerCase().includes(cleanSearch));
+    },
+  },
 }
 </script>
 

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -47,7 +47,7 @@ export default {
   data() {
     return {
       search: "",
-      filteredItems: this.items,
+      filteredItems: [...this.items],
     };
   },
   watch: {
@@ -56,7 +56,7 @@ export default {
     },
     items: {
       handler(newItems) {
-        this.filteredItems = newItems;
+        this.filteredItems = [...newItems];
 
         if (this.search.length > 0) {
           this.filteredItems = this.filterItems(this.search, newItems);

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -107,20 +107,24 @@ export default {
       if (draggedItemIndex !== draggedOverItemIndex) {
         // get the order of the dragged over item
         const tempOrder = this.itemsClone[draggedOverItemIndex].order;
-        // swap the order of the dragged item and the dragged over item
-        this.itemsClone[draggedItemIndex].order = tempOrder;
-        // set the index of the dragged item
-        const start = Math.min(draggedItemIndex, draggedOverItemIndex);
-        // set the index of the dragged over item
-        const end = Math.max(draggedItemIndex, draggedOverItemIndex);
         // set the increment
         const increment = draggedItemIndex > draggedOverItemIndex ? 1 : -1;
 
-        // update the order of the items
-        for (let i = start; i <= end; i++) {
-          if (i !== draggedItemIndex) {
-            this.itemsClone[i].order += increment;
+        // update the order of the items between the dragged item and the dragged over item
+        if (draggedItemIndex < draggedOverItemIndex) {
+          for (let i = draggedItemIndex + 1; i <= draggedOverItemIndex; i++) {
+            const orderAux = this.itemsClone[i].order;
+            this.itemsClone[i].order = orderAux + increment;
           }
+
+          this.itemsClone[draggedItemIndex].order = tempOrder;
+        } else if (draggedItemIndex > draggedOverItemIndex) {
+          for (let i = draggedOverItemIndex; i <= draggedItemIndex - 1; i++) {
+            const orderAux = this.itemsClone[i].order;
+            this.itemsClone[i].order = orderAux + increment;
+          }
+
+          this.itemsClone[draggedItemIndex].order = tempOrder;
         }
       }
 

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -108,7 +108,7 @@ export default {
         // get the order of the dragged over item
         const tempOrder = this.itemsClone[draggedOverItemIndex].order;
         // set the increment
-        const increment = draggedItemIndex > draggedOverItemIndex ? 1 : -1;
+        const increment = this.draggedItem > this.draggedOverItem ? 1 : -1;
 
         // update the order of the items between the dragged item and the dragged over item
         if (draggedItemIndex < draggedOverItemIndex) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -360,7 +360,7 @@
       role="dialog"
       size="lg"
       :title="$t('Edit Pages')"
-      :ok-title="$t('CONFIRM')"
+      :ok-title="$t('DONE')"
       ok-only
       ok-variant="secondary"
     >
@@ -370,6 +370,7 @@
         @item-edit="() => {}"
         @item-delete="confirmDelete"
         @add-page="$bvModal.show('addPageModal')"
+        @ordered="orderPages"
       />
     </b-modal>
 
@@ -1339,6 +1340,9 @@ export default {
       this.updateState();
       this.inspect(clone);
     },
+    orderPages(items) {
+      this.config = [...items];
+    }
   }
 };
 </script>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -378,7 +378,6 @@
         @item-edit="() => {}"
         @item-delete="confirmDelete"
         @add-page="$bvModal.show('addPageModal')"
-        @ordered="orderPages"
       />
     </b-modal>
 
@@ -1348,9 +1347,7 @@ export default {
       this.updateState();
       this.inspect(clone);
     },
-    orderPages(items) {
-      this.config = [...items];
-    }
+
   }
 };
 </script>

--- a/src/mixins/canOpenJsonFile.js
+++ b/src/mixins/canOpenJsonFile.js
@@ -24,7 +24,7 @@ export default {
       if (json instanceof Array) {
         screen = { config:json, computed: [], customCSS: null };
       } else if (json && json.screens instanceof Array) {
-        screen = json.screens[1];
+        screen = json.screens[0];
         if (window.exampleScreens instanceof Array) {
           window.exampleScreens = json.screens;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
It should be possible to reorder the pages from the modal

Actual behavior: 
It is not possible to reorder the pages from the modal

## Solution
Fix the sortable component to allow ordering for imported screens

## How to Test
1. Import attached screen
2. Open screen
3. Click on See all pages
4. Try to move the last page to the top 

## Related Tickets & Packages
[FOUR-14225](https://processmaker.atlassian.net/browse/FOUR-14225)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-14225]: https://processmaker.atlassian.net/browse/FOUR-14225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ