### PR TITLE
FOUR-14223 the correct tabs are not closed when after deleting the first tab

### DIFF
--- a/src/components/TabsBar.vue
+++ b/src/components/TabsBar.vue
@@ -45,7 +45,7 @@
           :data-test="`close-tab-${n}`"
           class="close-tab"
           role="link"
-          @click.stop="closeTab(n)"
+          @click.stop="closeTab(index)"
         >
           <i class="fas fa-times" />
         </span>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -382,6 +382,7 @@
         @item-edit="() => {}"
         @item-delete="confirmDelete"
         @add-page="$bvModal.show('addPageModal')"
+        @ordered="orderPages"
       />
     </b-modal>
 
@@ -1352,7 +1353,9 @@ export default {
       this.updateState();
       this.inspect(clone);
     },
-
+    orderPages(items) {
+      this.config = [...items];
+    },
   }
 };
 </script>

--- a/tests/e2e/specs/pagesDropdown.spec.js
+++ b/tests/e2e/specs/pagesDropdown.spec.js
@@ -9,6 +9,7 @@ describe("Page Dropdown", () => {
     // Define Page 2
     cy.get("[data-cy=add-page-name]").clear().type("Page_2");
     cy.get("[data-cy=add-page-modal] button.btn").eq(1).click();
+    cy.wait(300);
     cy.get('[data-cy=controls-FormButton]:contains("Page")').drag(
       "[data-cy=screen-drop-zone]",
       { position: "bottom" }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The tab where x is clicked should be closed (in this case the second tab)

Actual behavior: 
The last tabs are closed consecutively but not the second tab

## Solution
send the page number instead of the index to the `closeTab` method

## How to Test
1. Import the attached screen
2. Open screen
3. Display 6 more pages like tabs
4. Go to the last tab
5. Close first tab
6. Try closing second tab(Click on x on the second tab 5 times)

## Related Tickets & Packages
[FOUR-14223](https://processmaker.atlassian.net/browse/FOUR-14223)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-14223]: https://processmaker.atlassian.net/browse/FOUR-14223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ