### PR TITLE
FOUR-14287 Fix Reordering pages in the modal is not reflected in the menu list

### DIFF
--- a/src/components/editor/pagesDropdown.vue
+++ b/src/components/editor/pagesDropdown.vue
@@ -106,7 +106,7 @@ export default {
      * @param {PageItem} page - The selected page item.
      */
     onClickPage(page) {
-      this.$emit("clickPage", page);
+      this.$emit("clickPage", this.data[page]);
     }
   }
 };

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -57,22 +57,16 @@ export default {
     return {
       draggedItem: 0,
       draggedOverItem: 0,
-      itemsClone: [],
       editRowIndex: null,
     };
   },
   computed: {
     sortedItems() {
-      return this.filteredItems.sort((a, b) => a.order - b.order);
+      const sortedItems = [...this.filteredItems].sort(
+        (a, b) => a.order - b.order
+      );
+      return sortedItems;
     }
-  },
-  watch: {
-    items: {
-      handler(newVal) {
-        this.itemsClone = [...newVal];
-      },
-      immediate: true,
-    },
   },
   methods: {
     onBlur() {
@@ -101,34 +95,41 @@ export default {
       event.target.classList.remove('dragging');
 
       // get the index of the dragged item and the dragged over item
-      const draggedItemIndex = this.itemsClone.findIndex(item => item.order === this.draggedItem);
-      const draggedOverItemIndex = this.itemsClone.findIndex(item => item.order === this.draggedOverItem);
+      const itemsSortedClone = [...this.items].sort(
+        (a, b) => a.order - b.order
+      );
+      const draggedItemIndex = itemsSortedClone.findIndex(
+        (item) => item.order === this.draggedItem
+      );
+      const draggedOverItemIndex = itemsSortedClone.findIndex(
+        (item) => item.order === this.draggedOverItem
+      );
 
       if (draggedItemIndex !== draggedOverItemIndex) {
         // get the order of the dragged over item
-        const tempOrder = this.itemsClone[draggedOverItemIndex].order;
+        const tempOrder = itemsSortedClone[draggedOverItemIndex].order;
         // set the increment
         const increment = this.draggedItem > this.draggedOverItem ? 1 : -1;
 
         // update the order of the items between the dragged item and the dragged over item
         if (draggedItemIndex < draggedOverItemIndex) {
           for (let i = draggedItemIndex + 1; i <= draggedOverItemIndex; i++) {
-            const orderAux = this.itemsClone[i].order;
-            this.itemsClone[i].order = orderAux + increment;
+            const orderAux = itemsSortedClone[i].order;
+            itemsSortedClone[i].order = orderAux + increment;
           }
 
-          this.itemsClone[draggedItemIndex].order = tempOrder;
+          itemsSortedClone[draggedItemIndex].order = tempOrder;
         } else if (draggedItemIndex > draggedOverItemIndex) {
           for (let i = draggedOverItemIndex; i <= draggedItemIndex - 1; i++) {
-            const orderAux = this.itemsClone[i].order;
-            this.itemsClone[i].order = orderAux + increment;
+            const orderAux = itemsSortedClone[i].order;
+            itemsSortedClone[i].order = orderAux + increment;
           }
 
-          this.itemsClone[draggedItemIndex].order = tempOrder;
+          itemsSortedClone[draggedItemIndex].order = tempOrder;
         }
       }
 
-      this.$emit('ordered', this.itemsClone);
+      this.$emit('ordered', itemsSortedClone);
     },
     dragOver(event) {
       event.preventDefault();

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -109,7 +109,7 @@
         <template #tabs-start>
           <pages-dropdown
             v-if="showToolbar"
-            :data="config"
+            :data="sortedPages"
             @addPage="$bvModal.show('addPageModal')"
             @clickPage="onClick"
             @seeAllPages="$bvModal.show('openSortable')"
@@ -624,6 +624,9 @@ export default {
     };
   },
   computed: {
+    sortedPages() {
+      return [...this.config].sort((a, b) => a.order - b.order);
+    },
     builder() {
       return this;
     },
@@ -764,7 +767,7 @@ export default {
       return this.config[currentPage]?.items?.length === 0;
     },
     onClick(page) {
-      this.$refs.tabsBar.openPageByIndex(page);
+      this.$refs.tabsBar.openPageByIndex(this.config.indexOf(page));
     },
     checkPageName(value, force = false) {
       if (!force && !this.showAddPageValidations) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -115,9 +115,9 @@
             @seeAllPages="$bvModal.show('openSortable')"
           />
         </template>
-        <template #default>
+        <template #default="{ currentPage: tabPage }">
           <div
-            v-if="isCurrentPageEmpty(currentPage)"
+            v-if="isCurrentPageEmpty(tabPage)"
             data-cy="screen-drop-zone"
             class="d-flex justify-content-center align-items-center drag-placeholder text-center position-absolute rounded mt-4 flex-column"
           >
@@ -150,7 +150,7 @@
             data-cy="editor-content"
             class="h-100"
             ghost-class="form-control-ghost"
-            :value="config[currentPage].items"
+            :value="config[tabPage].items"
             v-bind="{
               group: { name: 'controls' },
               swapThreshold: 0.5
@@ -158,7 +158,7 @@
             @input="updateConfig"
           >
             <div
-              v-for="(element, index) in config[currentPage].items"
+              v-for="(element, index) in config[tabPage].items"
               :key="index"
               class="control-item mt-4 mb-4"
               :class="{
@@ -279,7 +279,7 @@
             </div>
           </draggable>
 
-          <div v-if="!isCurrentPageEmpty" data-cy="screen-drop-zone">
+          <div v-if="!isCurrentPageEmpty(tabPage)" data-cy="screen-drop-zone">
             &nbsp;
           </div>
         </template>

--- a/src/stories/DropdownAndPages.stories.js
+++ b/src/stories/DropdownAndPages.stories.js
@@ -37,7 +37,8 @@ export default {
       onSeeAllPages() {
         console.log("See all pages clicked");
       },
-      onClick(index) {
+      onClick(page) {
+        const index = this.pages.indexOf(page);
         this.$refs.tabsBar.openPageByIndex(index);
       }
     }

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -221,5 +221,16 @@ export const UserCanSortWithFilterByText = {
     expect(items[2]).toHaveTextContent("Hephaïstus");
     expect(items[3]).toHaveTextContent("Athena");
     expect(items[4]).toHaveTextContent("Hera");
+
+    // Drag "Athena" to "Hera" position
+    await dragAndDrop(canvas.getByTitle("Athena"), canvas.getByTitle("Hera"));
+
+    // Check the new order
+    const itemsOrder = canvas.getAllByTestId(/item-\d+/);
+    expect(itemsOrder[0]).toHaveAttribute("data-order", "1");
+    expect(itemsOrder[1]).toHaveAttribute("data-order", "2");
+    expect(itemsOrder[2]).toHaveAttribute("data-order", "3");
+    expect(itemsOrder[3]).toHaveAttribute("data-order", "4");
+    expect(itemsOrder[4]).toHaveAttribute("data-order", "5");
   }
 };

--- a/tests/e2e/specs/Pages.spec.js
+++ b/tests/e2e/specs/Pages.spec.js
@@ -7,6 +7,7 @@ describe("Pages and navigations", () => {
     // Define Page 2
     cy.get("[data-cy=add-page-name]").clear().type("Page 2");
     cy.get("[data-cy=add-page-modal] button.btn").eq(1).click();
+    cy.wait(500);
     cy.get('[data-cy=controls-FormButton]:contains("Page")').drag(
       "[data-cy=screen-drop-zone]",
       { position: "bottom" }
@@ -18,6 +19,7 @@ describe("Pages and navigations", () => {
     // Define Page 1
     cy.get("[data-test=page-dropdown]").click();
     cy.get("[data-cy=page-0]").click({ force: true });
+    cy.wait(500);
     cy.get('[data-cy=controls-FormButton]:contains("Page")').drag(
       "[data-cy=screen-drop-zone]",
       { position: "bottom" }

--- a/tests/e2e/specs/Pagination.spec.js
+++ b/tests/e2e/specs/Pagination.spec.js
@@ -58,6 +58,7 @@ beforeEach(() => {
   cy.visit("/");
   cy.openAcordeon("collapse-2");
   cy.openAcordeon("collapse-1");
+  cy.wait(200);
   cy.get("[data-cy=controls-FormRecordList]").drag(
     "[data-cy=screen-drop-zone]",
     { position: "bottom" }
@@ -66,6 +67,7 @@ beforeEach(() => {
   cy.get("[data-test=add-page]").click({ force: true });
   cy.get("[data-cy=add-page-name]").type("page2");
   cy.get("#addPageModal___BV_modal_footer_ > .btn-secondary").click();
+  cy.wait(200);
   cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", {
     position: "bottom"
   });

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -20,6 +20,10 @@ describe("Undo and Redo", () => {
     });
     cy.get("[data-cy=toolbar-undo]").click();
     cy.get("[data-cy=toolbar-redo]").click();
-    cy.get("[data-cy=screen-drop-zone]").should("not.exist");
+    // Check that New Input control was restored
+    cy.get("[data-cy=screen-element-container]").should(
+      "contain.text",
+      "New Input"
+    );
   });
 });


### PR DESCRIPTION
## Reordering pages in the modal is not reflected in the menu list

## Solution
- Add a calculated property with the sorted pages
- Use the object reference to the page to select the page

## How to Test
1. Create multiple pages
2. Sort the pages
3. Use the drop-down of pages check it has the same order as the step 2

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14287

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
