### PR TITLE
FOUR-14341 Fix Not all tabs are shown in Settings

### DIFF
--- a/src/assets/css/tabs.css
+++ b/src/assets/css/tabs.css
@@ -10,10 +10,12 @@
   /* Override Bootstrap default tab styles */
   .nav-tabs {
     border-bottom: 1px solid var(--tabs-border) !important;
+  }
+  .nav-tabs-nowrap {
     flex-wrap: nowrap !important;
     overflow: hidden !important;
   }
-  
+
   .nav-tabs .nav-item .nav-link {
     display: flex;
     align-items: center;

--- a/src/components/TabsBar.vue
+++ b/src/components/TabsBar.vue
@@ -4,6 +4,7 @@
     v-model="activeTab"
     class="h-100 w-100 flat-tabs"
     content-class="h-tab"
+    nav-class="nav-tabs-nowrap"
     lazy
     @changed="tabsUpdated"
     @input="tabOpened"


### PR DESCRIPTION
## Issue & Reproduction Steps
Not all tabs are shown in Settings.

## Solution
- Restore default behavior of tab wrap.
- Add a css class to apply nowrap to SB tabs only

## How to Test

1. Login
2. Go to admin tab
3. Click on Setting option in sidebar menu

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14341

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:next
