### PR TITLE
Send information about what button was clicked when submitting

### DIFF
--- a/src/components/renderer/form-button.vue
+++ b/src/components/renderer/form-button.vue
@@ -57,6 +57,13 @@ export default {
         boundary: 'window',
       };
     },
+    buttonInfo() {
+      return {
+        name: this.name,
+        label: this.label,
+        value: this.fieldValue
+      };
+    }
   },
   methods: {
     setValue(parent, name, value) {
@@ -83,7 +90,7 @@ export default {
         }
         this.$emit('input', this.fieldValue);
         this.$nextTick(() => {
-          this.$emit('submit', this.eventData, this.loading);
+          this.$emit('submit', this.eventData, this.loading, this.buttonInfo);
         });
         return;
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -433,7 +433,7 @@ export default {
       }
       return 'card-header text-capitalize text-white ' + header;
     },
-    submit(formData = null, loading = false) {
+    submit(formData = null, loading = false, buttonInfo = null) {
       //single click
       if (this.disabled) {
         return;
@@ -449,7 +449,7 @@ export default {
       } else {
         this.loadingButton = false;
       }
-      this.$emit('submit', this.task, loading);
+      this.$emit('submit', this.task, loading, buttonInfo);
 
       if (this.task && this.task.allow_interstitial && !this.loadingButton) {
         this.task.interstitial_screen['_interstitial'] = true;

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -246,8 +246,8 @@ export default {
         node.$children.forEach((child) => this.registerCustomFunctions(child));
       }
     },
-    submit(eventData, loading = false) {
-      this.$emit("submit", this.data, loading);
+    submit(eventData, loading = false, buttonInfo = null) {
+      this.$emit("submit", this.data, loading, buttonInfo);
     },
     parseCss() {
       const containerSelector = `.${this.containerClass}`;

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -53,8 +53,8 @@ export default {
     dot2bracket(str) {
       return str.replace(/\.\d/g, match => `[${match.substr(1)}]`);
     },
-    submit(eventData, loading = false) {
-      this.$emit('submit', this.value, loading);
+    submit(eventData, loading = false, buttonInfo = null) {
+      this.$emit('submit', this.value, loading, buttonInfo);
     },
     buildComponent(definition) {
       if (window.ProcessMaker && window.ProcessMaker.EventBus) {

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -145,7 +145,7 @@ export default {
         return 'MUSTACHE: ' + e.message;
       }
     },
-    async submitForm(eventData, loading = false) {
+    async submitForm(eventData, loading = false, buttonInfo = null) {
       await this.validateNow(findRootScreen(this));
       this.hasSubmitted(true);
       if (!this.valid__ || this.disableSubmit__) {
@@ -155,7 +155,7 @@ export default {
         // if the form is not valid the data is not emitted
         return;
       }
-      this.$emit('submit', this.vdata, loading);
+      this.$emit('submit', this.vdata, loading, buttonInfo);
     },
     resetValue(safeDotName, variableName) {
       this.setValue(safeDotName, null);


### PR DESCRIPTION
## Issue & Reproduction Steps
See https://processmaker.atlassian.net/browse/FOUR-14411

## Solution
- Emit button info as a 3rd parameter in the submit event

## How to Test
- Create an inbox rule, fill form data, and click a submit button. Ensure the correct submit button is shown on the inbox rule config.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14411

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
