### PR TITLE
FOUR-14364 Fix Drag and drop pages are not allowed in the modal with screens imported from previous versions

### DIFF
--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -47,7 +47,14 @@ export default {
   data() {
     return {
       search: "",
-      filteredItems: [...this.items],
+      filteredItems: [...this.items].map((item, index) => {
+        // Add the order property to the items if it doesn't exist
+        if (item.order === undefined) {
+          // eslint-disable-next-line no-param-reassign
+          this.$set(item, "order", index + 1);
+        }
+        return item;
+      })
     };
   },
   watch: {

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -234,3 +234,52 @@ export const UserCanSortWithFilterByText = {
     expect(itemsOrder[4]).toHaveAttribute("data-order", "5");
   }
 };
+
+// User can reorder items that does not have an order
+export const UserCanReorderItemsThatDoesNotHaveAnOrder = {
+  args: {
+    filterKey: "name",
+    items: [
+      { name: "Page 1" },
+      { name: "Page 2" },
+      { name: "Page 3" },
+      { name: "Page 4" },
+      { name: "Page 5" }
+    ]
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Drag item-1 item-5 position
+    await dragAndDrop(
+      canvas.getByTestId("item-1"),
+      canvas.getByTestId("item-5")
+    );
+
+    // Drag item-1 item-4 position
+    await dragAndDrop(
+      canvas.getByTestId("item-1"),
+      canvas.getByTestId("item-4")
+    );
+
+    // Drag item-1 item-3 position
+    await dragAndDrop(
+      canvas.getByTestId("item-1"),
+      canvas.getByTestId("item-3")
+    );
+
+    // Drag item-1 item-2 position
+    await dragAndDrop(
+      canvas.getByTestId("item-1"),
+      canvas.getByTestId("item-2")
+    );
+
+    // Check the new order
+    const items = canvas.getAllByTestId(/item-\d+/);
+    expect(items[0]).toHaveTextContent("Page 5");
+    expect(items[1]).toHaveTextContent("Page 4");
+    expect(items[2]).toHaveTextContent("Page 3");
+    expect(items[3]).toHaveTextContent("Page 2");
+    expect(items[4]).toHaveTextContent("Page 1");
+  }
+};


### PR DESCRIPTION
## Issue & Reproduction Steps

- The imported screens does not have the new property order, causing the reorder feature to fail

## Solution
- Add a step to add the missing `.order` property

## How to Test
- Import the attached screens
- Open the All pages popup
- Try to reorder the pages

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14364

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:processmaker:next
