### PR TITLE
[36258 ]Interstitial pages load twice

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -480,7 +480,7 @@ export default {
       return allowed ? this.parentRequest : this.requestId
     },
     processUpdated: _.debounce(function(data) {
-      if (data.event === 'ACTIVITY_COMPLETED') {
+      if (data.event === 'ACTIVITY_ACTIVATED') {
         this.reload();
       }
       if (data.event === 'ACTIVITY_EXCEPTION') {
@@ -528,12 +528,16 @@ export default {
         `ProcessMaker.Models.ProcessRequest.${this.parentRequest}`,
         '.ProcessUpdated',
         (data) => {
-          if (['ACTIVITY_ACTIVATED'].includes(data.event)) {
-            if (['ACTIVITY_ACTIVATED'].includes(data.event) && this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)) {
-              this.closeTask(this.parentRequest);
-            }
+          if (
+            ['ACTIVITY_ACTIVATED'].includes(data.event) &&
+            !this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)
+          ) {
+            this.closeTask(this.parentRequest);
           }
-          if (['ACTIVITY_COMPLETED'].includes(data.event)) {
+          if (
+            ["ACTIVITY_COMPLETED"].includes(data.event) &&
+            !this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)
+          ) {
             if (this.task.process_request.status === 'COMPLETED') {
               this.processCompleted();
             }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -480,10 +480,7 @@ export default {
       return allowed ? this.parentRequest : this.requestId
     },
     processUpdated: _.debounce(function(data) {
-      if (
-        data.event === 'ACTIVITY_COMPLETED' ||
-        data.event === 'ACTIVITY_ACTIVATED'
-      ) {
+      if (data.event === 'ACTIVITY_COMPLETED') {
         this.reload();
       }
       if (data.event === 'ACTIVITY_EXCEPTION') {
@@ -532,7 +529,7 @@ export default {
         '.ProcessUpdated',
         (data) => {
           if (['ACTIVITY_ACTIVATED'].includes(data.event)) {
-            if (['ACTIVITY_ACTIVATED'].includes(data.event) && this.existsEventMessage(`ACTIVATED-${this.userId}-${this.taskId}`)) {
+            if (['ACTIVITY_ACTIVATED'].includes(data.event) && this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)) {
               this.closeTask(this.parentRequest);
             }
           }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -515,6 +515,13 @@ export default {
         this.reload();
       }
     },
+    existsEventMessage(id, data) {
+      if (sessionStorage.getItem(id)) {
+        return true;
+      }
+      sessionStorage.setItem(id, data);
+      return false;
+    },
     listenForParentChanges() {
       if (!this.parentRequest) {
         return;
@@ -525,7 +532,9 @@ export default {
         '.ProcessUpdated',
         (data) => {
           if (['ACTIVITY_ACTIVATED'].includes(data.event)) {
-            this.closeTask(this.parentRequest);
+            if (['ACTIVITY_ACTIVATED'].includes(data.event) && this.existsEventMessage(`ACTIVATED-${this.userId}-${this.taskId}`)) {
+              this.closeTask(this.parentRequest);
+            }
           }
           if (['ACTIVITY_COMPLETED'].includes(data.event)) {
             if (this.task.process_request.status === 'COMPLETED') {


### PR DESCRIPTION
## Issue & Reproduction Steps
When you have a process with multiple thread levels and interstitial enabled, the interstitial is loaded twice.

## Solution
- check if the activate event has already arrived.

## How to Test
In order to reproduce the problem you need to add a 2 second sleep to the file
ProcessMaker/Models/ProcessRequest.php
in the notifyProcessUpdated function before sending the event.
In this way a delay is created in the sending of the events.

create a case and then derive it to check that the interstitial is not loaded twice.

## Related Tickets & Packages
- [FOUR-14542](https://processmaker.atlassian.net/browse/FOUR-14542)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.



[FOUR-14542]: https://processmaker.atlassian.net/browse/FOUR-14542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ