### PR TITLE
Observation/FOUR-14837: The text that is shown with the mouse over of each control does not allow you to easily select the control to create on screens

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1391,6 +1391,9 @@ export default {
   margin-right: -400px;
   padding: 16px;
 }
+.popover-body {
+  max-width: 350px;
+}
 </style>
 
 <style>


### PR DESCRIPTION
## Issue & Reproduction Steps
Fix for observations
[FOUR-14837](https://processmaker.atlassian.net/browse/FOUR-14837)
[FOUR-14840](https://processmaker.atlassian.net/browse/FOUR-14840)

Actual behavior: 
Tooltip for screen builder controls are overlapping the controls and that make it imposible to select them.

## Solution
- Added a max-width to the popover

## How to Test
- Hover the screen builder controls to make the popover appears. The popovers should show to the right of the elements and not overlap the controls

## Related Tickets & Packages
- [FOUR-14837](https://processmaker.atlassian.net/browse/FOUR-14837)
- [FOUR-14840](https://processmaker.atlassian.net/browse/FOUR-14840)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-14837]: https://processmaker.atlassian.net/browse/FOUR-14837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-14840]: https://processmaker.atlassian.net/browse/FOUR-14840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-14837]: https://processmaker.atlassian.net/browse/FOUR-14837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-14840]: https://processmaker.atlassian.net/browse/FOUR-14840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ