### PR TITLE
QA observation Bugfix/FOUR-14948: Clear Task Button in Inbox Rules page does not clear Date and Datetime fields

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -85,6 +85,7 @@ export default {
     VueFormRenderer
   },
   props: {
+    clearTask: { type: Boolean, default: false},
     initialTaskId: { type: Number, default: null },
     initialScreenId: { type: Number, default: null },
     initialRequestId: { type: Number, default: null },
@@ -121,6 +122,15 @@ export default {
     };
   },
   watch: {
+    clearTask: {
+      handler() {
+        /*console.log("handler watcher clearTask: ", this.clearTask);
+        console.log("draft data: ", this.task.draft);
+        this.task.draft.data = {};*/
+        this.clearTask ? this.prepareTask() : null;
+      }
+    },
+
     initialScreenId: {
       handler() {
         this.screenId = this.initialScreenId;
@@ -328,7 +338,9 @@ export default {
         this.resetScreenState();
         this.requestData = _.get(this.task, 'request_data', {});
         this.loopContext = _.get(this.task, "loop_context", "");
-
+        if(this.clearTask) {
+          this.task.draft.data = {};
+        }
         if (this.task.draft) {
           this.requestData = _.merge(
             {},

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -124,7 +124,9 @@ export default {
   watch: {
     clearTask: {
       handler() {
-        this.clearTask ? this.prepareTask() : null;
+        if (this.clearTask) {
+          this.prepareTask();
+        }
       }
     },
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -124,9 +124,6 @@ export default {
   watch: {
     clearTask: {
       handler() {
-        /*console.log("handler watcher clearTask: ", this.clearTask);
-        console.log("draft data: ", this.task.draft);
-        this.task.draft.data = {};*/
         this.clearTask ? this.prepareTask() : null;
       }
     },
@@ -338,10 +335,12 @@ export default {
         this.resetScreenState();
         this.requestData = _.get(this.task, 'request_data', {});
         this.loopContext = _.get(this.task, "loop_context", "");
-        if(this.clearTask) {
-          this.task.draft.data = {};
-        }
+        
         if (this.task.draft) {
+          //If Clear Task button is clicked from Inbox Rule page
+          if(this.clearTask) {
+            this.task.draft.data = {};
+          }
           this.requestData = _.merge(
             {},
             this.requestData,


### PR DESCRIPTION
## How to Test
Select a Task
Go to Inbox Rules
Select "Save and reuse fill data"
Press NEXT button
Click on Quick Fill button
Select a previous task and press Use This Task Data
Click on "Clear Task" button.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14948

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:next