### PR TITLE
FOUR-14952 | Notification Text Overflows Container

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1386,7 +1386,7 @@ export default {
 };
 </script>
 
-<style>
+<style scoped>
 .custom-popover {
   margin-right: -400px;
   padding: 16px;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-14952](https://processmaker.atlassian.net/browse/FOUR-14952)

When opening the Notifications popover, the popover content overflows its container. There are also borders on the tabs and container.

# Solution
- The styling issues stemmed from screen-builder. Some screen-builder styles that were not scoped were overriding the notification popover styles.

# Previous UI
![Screen Shot 2024-04-16 at 11 23 59 AM](https://github.com/ProcessMaker/processmaker/assets/73713665/2d3a1dc6-f1d5-4398-856d-2926a9e5036f)


# Updated UI
![Screen Shot 2024-04-17 at 12 20 38 PM](https://github.com/ProcessMaker/processmaker/assets/73713665/38dec323-bd13-4dce-b38d-523a051b23c2)


# How to Test
1. Go to branch `observation/FOUR-14952` in `processmaker` and in `screen-builder`.
2. In ProcessMaker, click on the Notifications bell in the top navigation menu.
3. In the popover that appears, the content should be contained within the popover container.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14952]: https://processmaker.atlassian.net/browse/FOUR-14952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ