### PR TITLE
FOUR-15064 Fix Performance improvements in interstitials, endpoints to get the task and watchers with scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@processmaker/screen-builder",
-  "version": "2.83.12",
+  "version": "2.83.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@processmaker/screen-builder",
-      "version": "2.83.12",
+      "version": "2.83.12.1",
       "dependencies": {
         "@chantouchsek/validatorjs": "1.2.3",
         "axios-extensions": "^3.1.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/screen-builder",
-  "version": "2.83.12",
+  "version": "2.83.12.1",
   "scripts": {
     "dev": "VITE_COVERAGE=true vite",
     "build": "vite build",

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -480,7 +480,11 @@ export default {
       return allowed ? this.parentRequest : this.requestId
     },
     processUpdated: _.debounce(function(data) {
-      if (data.event === 'ACTIVITY_ACTIVATED') {
+      if (
+        (data.event === "ACTIVITY_COMPLETED" ||
+          data.event === "ACTIVITY_ACTIVATED") &&
+        data.elementType === 'task'
+      ) {
         this.reload();
       }
       if (data.event === 'ACTIVITY_EXCEPTION') {
@@ -529,14 +533,12 @@ export default {
         '.ProcessUpdated',
         (data) => {
           if (
-            ['ACTIVITY_ACTIVATED'].includes(data.event) &&
-            !this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)
+            ['ACTIVITY_ACTIVATED'].includes(data.event)
           ) {
             this.closeTask(this.parentRequest);
           }
           if (
-            ["ACTIVITY_COMPLETED"].includes(data.event) &&
-            !this.existsEventMessage(`${data.event}-${this.userId}-${this.taskId}`)
+            ["ACTIVITY_COMPLETED"].includes(data.event)
           ) {
             if (this.task.process_request.status === 'COMPLETED') {
               this.processCompleted();

--- a/tests/e2e/specs/MultiInstanceLoopContext.spec.js
+++ b/tests/e2e/specs/MultiInstanceLoopContext.spec.js
@@ -5,7 +5,7 @@ describe("FOUR-3375 FileUpload inside MultiInstance Task", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,requestData,loopContext,bpmnTagName,interstitial,definition,userRequestPermission",
       {
         id: 1,
         advanceStatus: "open",
@@ -33,6 +33,11 @@ describe("FOUR-3375 FileUpload inside MultiInstance Task", () => {
         },
         user_request_permission: [{ process_request_id: 1, allowed: true }]
       }
+    );
+    cy.intercept(
+      "GET",
+      "http://localhost:5173/api/1.0/tasks/1/screen?include=screen,nested",
+      Screens.screens[0]
     );
 
     cy.visit("/?scenario=TaskMultiInstance", {

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -3,6 +3,18 @@ import Screens from "../fixtures/webentry.json";
 import SingleScreen from "../fixtures/single_line_input.json";
 import InterstitialScreen from "../fixtures/interstitial_screen.json";
 
+function initializeTaskAndScreenIntercepts(method, url, response) {
+  cy.intercept(
+    method,
+    url.replace(",screen,", ",").replace(",nested,", ","),
+    response
+  );
+  cy.intercept(
+    method,
+    url.replace(/\?.*$/, "/screen?include=screen,nested"),
+    response.screen
+  );
+}
 describe("Task component", () => {
   it("In a webentry", () => {
     cy.visit("/?scenario=WebEntry", {
@@ -22,7 +34,7 @@ describe("Task component", () => {
   });
 
   it("Task inside a Request", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -77,7 +89,7 @@ describe("Task component", () => {
   });
 
   it("Completes the Task", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -139,7 +151,7 @@ describe("Task component", () => {
           .should("have.been.calledOnce")
           .and("have.been.calledWith", "Task Completed Successfully")
           .then(function () {
-            cy.intercept(
+            initializeTaskAndScreenIntercepts(
               "GET",
               "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
               {
@@ -156,7 +168,7 @@ describe("Task component", () => {
   });
 
   it("Progresses to the interstitial screen", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -310,7 +322,7 @@ describe("Task component", () => {
             cy.intercept("GET", "/api/1.0/tasks**", {
               body: completedBodyRequest
             });
-            cy.intercept(
+            initializeTaskAndScreenIntercepts(
               "GET",
               "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
               { body: completedBodyRequest }
@@ -326,7 +338,7 @@ describe("Task component", () => {
     );
   });
   it("It updates the PM4ConfigOverrides", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -392,7 +404,7 @@ describe("Task component", () => {
    After childTask1 should redirect to childTask2
   */
   it("Task with display next assigned task checked with another pending task in same request should redirect to the next task of same request", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -468,7 +480,7 @@ describe("Task component", () => {
                         (DNAT)
   */
   it("Task with display next assigned task checked in subprocess and no pending task and status closed or open should redirect to parent requests", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -539,7 +551,7 @@ describe("Task component", () => {
    After childTask1 should redirect to parentTask2
   */
   it("Task with display next assigned task checked in different process request should redirect to the next task of parent request", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -614,7 +626,7 @@ describe("Task component", () => {
    After childTask1 (Not DNAT) should redirect to tasks list
   */
   it("Task with display next assigned task unchecked should redirect to tasks list", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -664,7 +676,7 @@ describe("Task component", () => {
    After parentTask1 and not pending tasks should redirect to same request
   */
   it("Process without pending task should redirect to request", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -721,7 +733,7 @@ describe("Task component", () => {
    After childTask1 and not pending tasks should redirect to parent Request
   */
   it("Subprocess without pending task should redirect to parent request", () => {
-    cy.intercept(
+    initializeTaskAndScreenIntercepts(
       "GET",
       "http://localhost:5173/api/1.0/tasks/1?include=data,user,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
       {
@@ -778,7 +790,7 @@ describe("Task component", () => {
 });
 
 function getTask(url, responseData) {
-  cy.intercept("GET", url, {
+  initializeTaskAndScreenIntercepts("GET", url, {
     id: responseData.id,
     advanceStatus: "completed",
     component: "task-screen",


### PR DESCRIPTION
## Intembeko - Performance improvements in interstitials and endpoints to get the task

## Solution
- Create an cached endpoint to return the screen of a task
- Reduce and group the number of events when running interstitial
- Use nayra engine to run the script watchers to improve its performance
- Use `cursor()` instead of `all()` to reduce the use of memory when running lots of timer events

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15064

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:processmaker:FOUR-15064
