### PR TITLE
FOUR-14904 | Required Validation Does Not Work With Percentage Input

### DIFF
--- a/src/components/renderer/form-input-masked.vue
+++ b/src/components/renderer/form-input-masked.vue
@@ -47,10 +47,7 @@ export default {
       },
     },
     currencyValue() {
-      this.unformattedValue = parseFloat(
-        this.currencyInput.inputmask.unmaskedvalue().replace(',', '.')
-      );
-      this.$emit('input', this.unformattedValue || 0);
+      this.handleInput();
     },
   },
   methods: {
@@ -74,8 +71,16 @@ export default {
       // the decimal does not trigger an input event
       if (this.currencyValue !== event.target.value) {
         this.currencyValue = event.target.value;
+      } else {
+        this.handleInput();
       }
     },
+    handleInput() {
+      this.unformattedValue = parseFloat(
+        this.currencyInput.inputmask.unmaskedvalue().replace(',', '.')
+      );
+      this.$emit('input', this.unformattedValue || 0);
+    }
   },
   mounted() {
     this.loadMasks();


### PR DESCRIPTION
# Issue
Ticket: [FOUR-14904](https://processmaker.atlassian.net/browse/FOUR-14904)

In a Screen that uses Page Navigation and has a Required Input field with Percentage data type, users can submit the Screen without any input in the field.

# Solution
- In `screen-builder`, there is a bug in `form-input-masked.vue` where backspacing after the decimal does not trigger an input event. The code to handle that bug was no longer working.
- The conditional in the `keyup()` method was not being met, so the code for the bug was not being run.
- Added an `else` statement in the case that the conditional is not met, so that the input event is triggered.

# How to Test
1. Go to branch `observation/FOUR-14904` in `screen-builder`.
2. Go to Designer → Screens → +SCREEN.
3. Create a Screen.
4. Add a Line Input with a Percentage type. Add Required validation to the Line Input.
5. Add Page Navigation.
6. Within the Screen Preview:
	- Add a number to the Percentage field.
	- Click the Page Navigation.
	- Go back to the first page.
	- Highlight everything in your Input field and hit Backspace.
	- Click Submit.
		- You should not be able to Submit if the Required Input field is empty.
7. Create a Process and assign your screen to it.
8. Create a Request.
9. Repeat Step 6 within your Task.

ci:next
ci:deploy

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-14904]: https://processmaker.atlassian.net/browse/FOUR-14904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ