### PR TITLE
Update the new request list

### DIFF
--- a/src/components/renderer/card.vue
+++ b/src/components/renderer/card.vue
@@ -1,49 +1,47 @@
 <template>
   <div>
-    <template v-for="event in emptyStartEvents">
-      <div :key="event.id" class="mb-3 card-request">
-        <div class="card-body">
-          <div class="d-flex justify-content-between">
-            <div>
-              <span v-uni-id="event.id.toString()" class="card-info card-title">
-                {{ transformedName }}
-              </span>
-              <span class="card-info">
-                {{ event.name }}
-              </span>
-            </div>
-            <div class="d-flex align-items-center">
-              <button
-                :aria-expanded="ariaExpanded"
-                :aria-controls="getComputedId(process, event)"
-                class="btn btn-ellipsis btn-sm mr-1"
-                @click="showRequestDetails(process, event)"
-              >
-                <i class="fas fa-ellipsis-v"></i>
-              </button>
-              <button
-                v-uni-aria-describedby="event.id.toString()"
-                :href="getNewRequestLinkHref(process, event)"
-                class="btn btn-custom btn-sm"
-                @click.prevent="newRequestLink(process, event)"
-              >
-                {{ $t("Start") }}
-                <i class="fas fa-play mr-1 card-icon"></i>
-              </button>
-            </div>
+    <div class="mb-3 card-request">
+      <div class="card-body">
+        <div class="d-flex justify-content-between">
+          <div>
+            <span v-uni-id="event.id.toString()" class="card-info card-title">
+              {{ transformedName }}
+            </span>
+            <span class="card-info">
+              {{ event.name }}
+            </span>
           </div>
-          <b-collapse
-            :id="getComputedId(process, event)"
-            :aria-hidden="ariaHidden"
-          >
-            <hr />
-            <p class="card-text text-muted card-description">
-              {{ process.description }}
-            </p>
-          </b-collapse>
+          <div class="d-flex align-items-center">
+            <button
+              :aria-expanded="ariaExpanded"
+              :aria-controls="getComputedId(process, event)"
+              class="btn btn-ellipsis btn-sm mr-1"
+              @click="showRequestDetails(process, event)"
+            >
+              <i class="fas fa-ellipsis-v"></i>
+            </button>
+            <button
+              v-uni-aria-describedby="event.id.toString()"
+              :href="getNewRequestLinkHref(process, event)"
+              class="btn btn-custom btn-sm"
+              @click.prevent="newRequestLink(process, event)"
+            >
+              {{ $t("Start") }}
+              <i class="fas fa-play mr-1 card-icon"></i>
+            </button>
+          </div>
         </div>
+        <b-collapse
+          :id="getComputedId(process, event)"
+          :aria-hidden="ariaHidden"
+        >
+          <hr />
+          <p class="card-text text-muted card-description">
+            {{ process.description }}
+          </p>
+        </b-collapse>
       </div>
-    </template>
+    </div>
   </div>
 </template>
 
@@ -54,7 +52,7 @@ const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
   mixins: [uniqIdsMixin],
-  props: ["name", "description", "filter", "id", "process"],
+  props: ["name", "description", "filter", "id", "process", "event"],
   data() {
     return {
       disabled: false,

--- a/src/components/renderer/form-new-request.vue
+++ b/src/components/renderer/form-new-request.vue
@@ -1,15 +1,17 @@
 <template>
   <div>
     <div v-if="Object.keys(processes).length && !loading" class="process-list">
-      <b-container fluid>
-        <div v-for="(process, index) in processes" :key="`process-${index}`">
-          <ProcessCard
-            v-if="hasEmptyStartEvents(process)"
-            :filter="filter"
-            :process="process"
-          />
-        </div>
-      </b-container>
+      <div class="row">
+        <template v-for="(process, index) in processes">
+          <div v-for="(event, indexE) in emptyStartEvents(process)" :key="`process-${index}-${indexE}`" class="col-sm-6">
+            <ProcessCard
+              :filter="filter"
+              :process="process"
+              :event="event"
+            />
+          </div>
+        </template>
+      </div>
     </div>
     <div v-else>
       <formEmpty link="" title="No Request to Start" url="" />
@@ -39,6 +41,12 @@ export default {
     this.$root.$on("dropdownSelectionStart", this.fetchData);
   },
   methods: {
+    emptyStartEvents(process) {
+      return process.startEvents.filter(
+        (event) =>
+          !event.eventDefinitions || event.eventDefinitions.length === 0
+      );
+    },
     hasEmptyStartEvents(process) {
       return !!process.events.find(
         (event) =>


### PR DESCRIPTION
## Issue & Reproduction Steps
Expand the Start Cases section into two columns in order to remove the Analytics Chart

## Solution
- The list of new request is showing in two columns

## How to Test

1. Login
2. Go to Home
3. Remove the Analytics Chart
4.The Start Cases section is expanded in Two columns

## Related Tickets & Packages
- [FOUR-16148](https://processmaker.atlassian.net/browse/FOUR-16148)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

[FOUR-16148]: https://processmaker.atlassian.net/browse/FOUR-16148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ