### PR TITLE
FOUR-15485 37736 - Runing a test case gives 404 error with multiple file upload

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -229,20 +229,42 @@ export default {
         }
       }
 
-      this.$dataProvider.get(endpoint).then((response) => {
-        const fileInfo = response.data.data
-          ? _.get(response, "data.data.0", null)
-          : _.get(response, "data", null);
-        if (fileInfo) {
-          if (typeof this.value === "number" && this.filesInfo.length > 0) {
-            this.filesInfo[0] = fileInfo;
+      this.$dataProvider
+        .get(endpoint)
+        .then((response) => {
+          const fileInfo = response.data.data
+            ? _.get(response, "data.data.0", null)
+            : _.get(response, "data", null);
+          if (fileInfo) {
+            if (typeof this.value === "number" && this.filesInfo.length > 0) {
+              this.filesInfo[0] = fileInfo;
+            } else {
+              this.filesInfo.push(fileInfo);
+            }
           } else {
-            this.filesInfo.push(fileInfo);
+            console.log(this.$t("File ID does not exist"));
           }
-        } else {
-          console.log(this.$t("File ID does not exist"));
-        }
-      });
+        })
+        .catch((error) => {
+          const alert = document.querySelector(".alert-danger");
+
+          if (!alert) {
+            let message = this.$t(
+              "Something went wrong and the file cannot be previewed or downloaded."
+            );
+
+            if (error?.response?.data?.message) {
+              message = error.response.data.message;
+            }
+
+            if (
+              error?.response?.status === 404 ||
+              error?.response?.data?.message
+            ) {
+              window.ProcessMaker.alert(message, "danger");
+            }
+          }
+        });
     },
     setFilesInfoFromCollectionValue() {
       const files = this.value

--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -212,7 +212,12 @@ export default {
       let { endpoint } = this;
 
       if (this.requestFiles) {
-        this.filesInfo.push(_.get(this.requestFiles, this.fileDataName, null));
+        const fileInfo = this.requestFiles?.[this.fileDataName];
+
+        if (fileInfo) {
+          this.filesInfo.push(fileInfo);
+        }
+
         return;
       }
 
@@ -247,22 +252,16 @@ export default {
         })
         .catch((error) => {
           const alert = document.querySelector(".alert-danger");
+          const defaultMessage = this.$t(
+            "Something went wrong and the file cannot be previewed or downloaded."
+          );
+          const message = error?.response?.data?.message || defaultMessage;
 
-          if (!alert) {
-            let message = this.$t(
-              "Something went wrong and the file cannot be previewed or downloaded."
-            );
-
-            if (error?.response?.data?.message) {
-              message = error.response.data.message;
-            }
-
-            if (
-              error?.response?.status === 404 ||
-              error?.response?.data?.message
-            ) {
-              window.ProcessMaker.alert(message, "danger");
-            }
+          if (
+            !alert &&
+            (error?.response?.status === 404 || error?.response?.data?.message)
+          ) {
+            window.ProcessMaker.alert(message, "danger");
           }
         });
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
When you upload more than 1 file running a test, you will get a 404 error after submitting the form

## Solution
- Put the File Preview and File Download controls into a Loop control
- Add a validation to files as an instance of Media

https://github.com/ProcessMaker/processmaker/assets/3604190/ec011df0-aa07-42c1-9442-72cc4fbc2fcd

## Related Tickets & Packages
[FOUR-15485](https://processmaker.atlassian.net/browse/FOUR-15485)
https://github.com/ProcessMaker/package-files/pull/129

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
ci:package-files:FOUR-15485



[FOUR-15485]: https://processmaker.atlassian.net/browse/FOUR-15485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ