### PR TITLE
FOUR-15854 on task completed - override behavior

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -395,7 +395,15 @@ export default {
         this.screen = this.task.interstitial_screen;
         this.loadNextAssignedTask(parentRequestId);
       } else if (!this.taskPreview) {
-        this.$emit('closed', this.task.id);
+        let { elementDestination } = this.task;
+
+        if (elementDestination === 'taskSource') {
+          elementDestination = null;
+        } else if (!elementDestination) {
+          elementDestination = sessionStorage.getItem('elementDestinationURL') ?? null;
+        }
+
+        this.$emit('closed', this.task.id, elementDestination);
       }
     },
     loadNextAssignedTask(requestId = null) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The user wants to be redirected based on predefined settings, such as the process LaunchPad (of the source process), task list, user homepage dashboard (welcome screen or custom dashboard), a specific dashboard, or an external URL.

## Related Tickets & Packages
[FOUR-15854](https://processmaker.atlassian.net/browse/FOUR-15854)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-15854]: https://processmaker.atlassian.net/browse/FOUR-15854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ