### PR TITLE
FOUR-15858 On Process End - Override Behavior

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -437,12 +437,11 @@ export default {
      * Retrieves the destination URL for the closed event.
      * @returns {string|null} - The destination URL.
      */
-     getDestinationUrl() {
+    getDestinationUrl() {
       // If the element destination is 'taskSource', use the document referrer
       if (this.task?.elementDestination === 'taskSource') {
           return document.referrer;
       }
-      
       // If element destination is not set, try to get it from sessionStorage
       return this.task.elementDestination || sessionStorage.getItem('elementDestinationURL') || null;
     },
@@ -529,14 +528,14 @@ export default {
     activityAssigned() {
       // This may no longer be needed
     },
-    processCompleted() {
+    processCompleted(data = null) {
       let requestId;
       if (this.parentRequest) {
         requestId = this.getAllowedRequestId();
         this.$emit('completed', requestId);
       }
       if (requestId !== this.requestId) {
-        this.$emit('completed', this.requestId);
+        this.$emit('completed', this.requestId, data?.endEventDestination);
       }
     },
     getAllowedRequestId() {


### PR DESCRIPTION
## Issue & Reproduction Steps
The user wants to be redirected based on predefined settings, such as the process LaunchPad (of the source process), task list, user homepage dashboard (welcome screen or custom dashboard), a specific dashboard, or an external URL.

## Related Tickets & Packages
[FOUR-15858](https://processmaker.atlassian.net/browse/FOUR-15858)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

