### PR TITLE
FOUR-15859: On Process End - Start a request for another selected process

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -385,7 +385,6 @@ export default {
      * @param {string|null} parentRequestId - The parent request ID.
      */
     closeTask(parentRequestId = null) {
-      debugger;
       if (this.hasErrors) {
         this.emitError();
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -436,16 +436,25 @@ export default {
      * @returns {string|null} - The destination URL.
      */
     getDestinationUrl() {
-      // If the element destination is 'taskSource', use the document referrer
-      if (this.task?.elementDestination === "taskSource") {
-        return document.referrer;
+      // If the element destination type is 'taskSource', use the document referrer
+      if (this.task?.elementDestination?.type === "taskSource") {
+        return document.referrer || null;
       }
-      // If element destination is not set, try to get it from sessionStorage
-      return (
-        this.task.elementDestination?.url ||
-        sessionStorage.getItem("elementDestinationURL") ||
-        null
-      );
+
+      // If element destination URL is available, return it
+      const elementDestinationUrl = this.task?.elementDestination?.value;
+      if (elementDestinationUrl) {
+        return elementDestinationUrl;
+      }
+
+      // If no element destination URL, try to get it from sessionStorage
+      const sessionStorageUrl = sessionStorage.getItem("elementDestinationURL");
+      if (sessionStorageUrl) {
+        return sessionStorageUrl;
+      }
+
+      // If none of the above conditions are met, return null
+      return null;
     },
     loadNextAssignedTask(requestId = null) {
       if (!requestId) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -295,7 +295,7 @@ export default {
       }
     },
     loadTask() {
-      const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`;
+      const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`;
       // For Vocabularies
       if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
         window.ProcessMaker.VocabulariesSchemaUrl = `vocabularies/task_schema/${this.taskId}`;

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -430,7 +430,6 @@ export default {
      * Emits a closed event.
      */
     emitClosedEvent() {
-      debugger;
       this.$emit('closed', this.task.id, this.getDestinationUrl());
     },
     /**
@@ -438,7 +437,6 @@ export default {
      * @returns {string|null} - The destination URL.
      */
     getDestinationUrl() {
-      debugger;
       // If the element destination is 'taskSource', use the document referrer
       if (this.task?.elementDestination === "taskSource") {
         return document.referrer;
@@ -614,7 +612,11 @@ export default {
       try {
         // Verify if is not anotherProcess type
         if (data.endEventDestination.type !== "anotherProcess") {
-          this.$emit("completed", this.requestId, data?.endEventDestination);
+          this.$emit(
+            "completed",
+            this.requestId,
+            data?.endEventDestination.value
+          );
           return;
         }
         // Parse endEventDestination from the provided data

--- a/tests/e2e/specs/MultiInstanceLoopContext.spec.js
+++ b/tests/e2e/specs/MultiInstanceLoopContext.spec.js
@@ -5,7 +5,7 @@ describe("FOUR-3375 FileUpload inside MultiInstance Task", () => {
   beforeEach(() => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -24,7 +24,7 @@ describe("Task component", () => {
   it("Task inside a Request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -79,7 +79,7 @@ describe("Task component", () => {
   it("Completes the Task", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -141,7 +141,7 @@ describe("Task component", () => {
           .then(function () {
             cy.intercept(
               "GET",
-              "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+              "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
               {
                 id: 1,
                 advanceStatus: "completed",
@@ -158,7 +158,7 @@ describe("Task component", () => {
   it("Progresses to the interstitial screen", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -312,7 +312,7 @@ describe("Task component", () => {
             });
             cy.intercept(
               "GET",
-              "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+              "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
               { body: completedBodyRequest }
             );
             cy.reload();
@@ -328,7 +328,7 @@ describe("Task component", () => {
   it("It updates the PM4ConfigOverrides", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -394,7 +394,7 @@ describe("Task component", () => {
   it("Task with display next assigned task checked with another pending task in same request should redirect to the next task of same request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -424,7 +424,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 
@@ -450,7 +450,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask2
         );
 
@@ -470,7 +470,7 @@ describe("Task component", () => {
   it("Task with display next assigned task checked in subprocess and no pending task and status closed or open should redirect to parent requests", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -501,7 +501,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 
@@ -520,7 +520,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask2
         );
 
@@ -541,7 +541,7 @@ describe("Task component", () => {
   it("Task with display next assigned task checked in different process request should redirect to the next task of parent request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -571,7 +571,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 
@@ -596,7 +596,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask2.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask2
         );
 
@@ -616,7 +616,7 @@ describe("Task component", () => {
   it("Task with display next assigned task unchecked should redirect to tasks list", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -646,7 +646,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 
@@ -666,7 +666,7 @@ describe("Task component", () => {
   it("Process without pending task should redirect to request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -696,7 +696,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 
@@ -723,7 +723,7 @@ describe("Task component", () => {
   it("Subprocess without pending task should redirect to parent request", () => {
     cy.intercept(
       "GET",
-      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission",
+      "http://localhost:5173/api/1.0/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
       {
         id: 1,
         advanceStatus: "open",
@@ -760,7 +760,7 @@ describe("Task component", () => {
         };
 
         getTask(
-          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission`,
+          `http://localhost:5173/api/1.0/tasks/${responseDataTask1.id}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`,
           responseDataTask1
         );
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 

ent event must redirect to another process if have this configuration
Actual behavior: 

## Solution
- add another process redirect feature for end event



https://github.com/ProcessMaker/screen-builder/assets/1401911/9a8f267f-c40b-477c-ae4c-255642272bef


Uploading endEventProcessRedirect.mov…


Uploading endEventProcessRedirect.mov…



## How to Test
- create the process A
- create the process B
- assign to both process the same user to the first task
- in process A create a end event 
- add end event redirection as process
- select the process B
- select the start event B
- run the process
 
## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-15859
- https://github.com/ProcessMaker/processmaker/pull/6918 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next