### PR TITLE
FOUR-13455: Logs section for Calcs

### DIFF
--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -9,7 +9,7 @@ export default {
         // Monitor if variable belongs to data (defined variables) or
         // vdata (external variables)in this way the event is not
         // executed again when the variable is update
-
+        console.log('start, evaluateExpression!');
         const data = this.getDataReference(null, () => {
           throw new Error(
             "You are not allowed to set properties from inside an expression"
@@ -19,18 +19,64 @@ export default {
         if (type === "expression") {
           value = Parser.evaluate(expression, data);
         } else {
+          // Create a new function with the expression and bind the data context
           // eslint-disable-next-line no-new-func
-          value = new Function(expression).bind(data)();
+          const func = new Function(expression).bind(data);
+          // value = new Function(expression).bind(data)();
+          return { result: func(), error: null };
         }
 
         if (value instanceof Date) {
           value = value.toISOString();
         }
-
+        console.log('end-evaluateExpression!');
         return value;
-      } catch (e) {
-        console.warn("There was a problem evaluating the expression", e);
+      } catch (error) {
+        // Catch any errors and return them
+        return { result: null, error };
       }
+    },
+    /**
+     * Logs an error message with a custom format.
+     * @param {string} name - The name of the calculation.
+     * @param {string} message - The error message.
+     */
+    customErrorLog(name, message) {
+      // Unicode character for the common error icon
+      const errorIcon = "\u274C"; // Heavy multiplication X
+      // Create the error message with a background similar to console.error
+      const style =
+        "background-color: rgba(255, 0, 0, 0.1); color: red; padding: 2px 4px; border-radius: 3px;";
+      // start console log group
+      console.groupCollapsed(
+        `%c${errorIcon} %cCalc "${name}" has %cFailed`,
+        style,
+        "background-color: rgba(255, 0, 0, 0.1)",
+        style
+      );
+      // Log the message
+      console.log(`%c${message}`, style);
+      // End the console group
+      console.groupEnd();
+    },
+
+    /**
+     * Logs a success message with a custom format.
+     * @param {string} name - The name of the calculation.
+     */
+    customSuccessLog(name) {
+      // Unicode character for the success icon
+      const successIcon = "\u2705"; // Checkmark
+      // Create the success message with a green background
+      const style =
+        "background-color: rgba(0, 128, 0, 0.1); color: green; padding: 1px 1px; border-radius: 3px;";
+      // Log the styled success message with an icon
+      console.log(
+        `%c${successIcon} %cCalc "${name}" has %cRUN`,
+        style,
+        "background-color: rgba(0, 128, 0, 0.1)",
+        style
+      );
     }
   }
 };

--- a/src/mixins/extensions/ComputedFields.js
+++ b/src/mixins/extensions/ComputedFields.js
@@ -9,7 +9,8 @@ export default {
      *   this.setValueAsync("calcProperty", value, this.vdata);
      * }
      */
-    computedFields(screen, definition) {
+    computedFields(screen, definition, logsEnabled = true) {
+      debugger;
       // For each computed field defined
       definition.computed.forEach((computed) => {
         const formula = JSON.stringify(computed.formula);
@@ -17,10 +18,29 @@ export default {
         const name = JSON.stringify(computed.property);
         const safeDotName = this.safeDotName(computed.property);
         const code = `
+
         let value = this.evaluateExpression(${formula}, ${type});
-        value = this.addNonDefinedComputedAttributes(value);
-        this.setValue(${name}, value, this.vdata);
-        return value;`;
+          // Handle errors if any
+          if (value.error) {
+            if (${logsEnabled}) {
+              this.customErrorLog(${name}, value.error);
+            }
+          } else {
+            // Add non-defined computed attributes
+            value = this.addNonDefinedComputedAttributes(value.result);
+
+            // Set the value
+            this.setValue(name, value.result, this.vdata);
+
+            // Log the successful calculation if logging is enabled
+            if (${logsEnabled}) {
+              this.customSuccessLog(${name});
+            }
+
+            // Return the result
+            return value.result;
+          }
+        `;
         this.addComputed(screen, safeDotName, code, "");
         // required to enable reactivity of computed field
         this.addWatch(screen, safeDotName, "");


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
As a Designer I want to have the option where I can see the Logs after the Calcs run.
Actual behavior: 
n/a
## Solution
- add calc logs support

## How to Test
1. create a screen
2. create a calc
3. add a wrong js code
4. open the developer tool

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-13455

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next