### PR TITLE
FOUR-15486 Screen can be disabled while task is loading

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -23,7 +23,7 @@
           <vue-form-renderer
             ref="renderer"
             v-model="requestData"
-            :class="{ loading }"
+            :class="{ loading: loadingTask }"
             :config="screen.config"
             :computed="screen.computed"
             :custom-css="screen.custom_css"
@@ -121,7 +121,7 @@ export default {
       refreshScreen: 0,
       redirecting: null,
       loadingButton: false,
-      loading: false,
+      loadingTask: false,
     };
   },
   watch: {
@@ -323,7 +323,7 @@ export default {
             this.hasErrors = true;
           })
           .finally(() => {
-            this.loading = false;
+            this.loadingTask = false;
           });
       });
     },

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -23,6 +23,7 @@
           <vue-form-renderer
             ref="renderer"
             v-model="requestData"
+            :class="{ loading }"
             :config="screen.config"
             :computed="screen.computed"
             :custom-css="screen.custom_css"
@@ -120,6 +121,7 @@ export default {
       refreshScreen: 0,
       redirecting: null,
       loadingButton: false,
+      loading: false,
     };
   },
   watch: {
@@ -319,6 +321,9 @@ export default {
           })
           .catch(() => {
             this.hasErrors = true;
+          })
+          .finally(() => {
+            this.loading = false;
           });
       });
     },
@@ -618,3 +623,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.loading {
+  pointer-events: none;
+}
+</style>


### PR DESCRIPTION
## Screen can be disabled while loading

While loading a task the user can modify the data, this can cause the lost of the changes once the task is loaded.

## Solution
- Screen can be disabled while task is being loaded to avoid data missing

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15486

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

