### PR TITLE
FOUR-13456 enlarge the source code field in the calcs window

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -315,6 +315,7 @@ export default {
     },
     displayTableList() {
       this.emptyForm();
+      this.modalSize = 'lg';
       this.displayList = true;
     },
     displayFormProperty() {

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -480,4 +480,8 @@ export default {
     display: none;
   }
 }
+
+.btn[data-test='calcs-enlarge-source-code'] {
+  border-color: #CDDDEE;
+}
 </style>

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -91,17 +91,7 @@
 
       <div class="form-group mb-3" style="position: relative">
         <div class="d-flex justify-content-between mb-1">
-          <div class="d-flex align-items-center">
-            <button
-              class="btn btn-sm btn-outline-light mr-1 text-secondary shadow-sm"
-              data-test="calcs-enlarge-source-code"
-              @click.prevent="toggleModalSize"
-            >
-              <i class="fas fa-expand"></i>
-            </button>
-
-            <label class="m-0">{{ $t('Formula') + ' *' }}</label>
-          </div>
+          <label class="m-0">{{ $t('Formula') + ' *' }}</label>
 
           <div>
             <a
@@ -239,7 +229,6 @@ export default {
       },
       monacoEditor: null,
       errors: {},
-      modalSize: "lg",
     };
   },
   computed: {
@@ -263,7 +252,10 @@ export default {
     },
     isJS() {
       return this.add.type === "javascript";
-    }
+    },
+    modalSize() {
+      return this.displayList ? 'lg' : 'xl';
+    },
   },
   watch: {
     value() {
@@ -315,7 +307,6 @@ export default {
     },
     displayTableList() {
       this.emptyForm();
-      this.modalSize = 'lg';
       this.displayList = true;
     },
     displayFormProperty() {
@@ -408,9 +399,6 @@ export default {
         import.meta.url,
       ).href;
     },
-    toggleModalSize() {
-      this.modalSize = this.modalSize === 'lg' ? 'xl' : 'lg';
-    },
   }
 };
 </script>
@@ -480,9 +468,5 @@ export default {
   & > label {
     display: none;
   }
-}
-
-.btn[data-test='calcs-enlarge-source-code'] {
-  border-color: #CDDDEE;
 }
 </style>

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -2,7 +2,7 @@
   <b-modal
     id="computed-properties"
     ref="modal"
-    size="lg"
+    :size="modalSize"
     content-class="p-3"
     header-class="m-0 p-0 mb-3"
     body-class="m-0 p-0"
@@ -15,7 +15,7 @@
   >
     <template #modal-title>
       <h5 class="modal-title">{{ $t('Calculated Properties') }}</h5>
-      <small v-show="!displayList" class="modal-subtitle mb-n2">
+      <small v-show="!displayList" class="modal-subtitle my-2">
         {{
           $t(
             'Perform mathematical calculations offering quick, convenient, and accurate operations, enhancing user efficiency and usability.',
@@ -90,24 +90,37 @@
       </b-row>
 
       <div class="form-group mb-3" style="position: relative">
-        <label v-show="isJS">{{ $t("Formula") + " *" }}</label>
-        <div class="float-right">
-          <a
-            class="btn btn-sm"
-            :class="expressionTypeClass"
-            data-cy="calcs-switch-formula"
-            @click="switchExpressionType('expression')"
-          >
-            <i class="fas fa-square-root-alt" />
-          </a>
-          <a
-            class="btn btn-sm"
-            :class="javascriptTypeClass"
-            data-cy="calcs-switch-javascript"
-            @click="switchExpressionType('javascript')"
-          >
-            <i class="fab fa-js-square fa-lg"></i>
-          </a>
+        <div class="d-flex justify-content-between mb-1">
+          <div class="d-flex align-items-center">
+            <button
+              class="btn btn-sm btn-outline-light mr-1 text-secondary shadow-sm"
+              data-test="calcs-enlarge-source-code"
+              @click.prevent="toggleModalSize"
+            >
+              <i class="fas fa-expand"></i>
+            </button>
+
+            <label class="m-0">{{ $t('Formula') + ' *' }}</label>
+          </div>
+
+          <div>
+            <a
+              class="btn btn-sm"
+              :class="expressionTypeClass"
+              data-cy="calcs-switch-formula"
+              @click="switchExpressionType('expression')"
+            >
+              <i class="fas fa-square-root-alt" />
+            </a>
+            <a
+              class="btn btn-sm"
+              :class="javascriptTypeClass"
+              data-cy="calcs-switch-javascript"
+              @click="switchExpressionType('javascript')"
+            >
+              <i class="fab fa-js-square fa-lg"></i>
+            </a>
+          </div>
         </div>
 
         <form-text-area
@@ -115,7 +128,6 @@
           ref="formula"
           v-model="add.formula"
           rows="5"
-          :label="$t('Formula') + ' *'"
           name="formula"
           :error="errors.formula"
           data-cy="calcs-property-formula"
@@ -226,7 +238,8 @@ export default {
         minimap: false
       },
       monacoEditor: null,
-      errors: {}
+      errors: {},
+      modalSize: "lg",
     };
   },
   computed: {
@@ -394,6 +407,9 @@ export default {
         import.meta.url,
       ).href;
     },
+    toggleModalSize() {
+      this.modalSize = this.modalSize === 'lg' ? 'xl' : 'lg';
+    },
   }
 };
 </script>
@@ -432,6 +448,7 @@ export default {
 }
 
 .modal-subtitle {
+  display: block;
   color: #556271;
   font-size: 1rem;
   font-weight: 400;
@@ -454,9 +471,13 @@ export default {
 
 .calcs-input-formula::v-deep {
   & > textarea.form-control {
-    height: 430px !important;
+    height: 430px;
     border-color: #CDDDEE;
     resize: none;
+  }
+
+  & > label {
+    display: none;
   }
 }
 </style>

--- a/tests/e2e/specs/CalcDragAndDrop.spec.js
+++ b/tests/e2e/specs/CalcDragAndDrop.spec.js
@@ -131,4 +131,29 @@ describe('Calcs list Drag&Drop', () => {
 
     cy.get('@secondRow').should('have.class', 'sortable-item-disabled');
   });
+
+  it('should enlarge the source code field', () => {
+    clickTopBarCalcs();
+
+    cy.get('[data-cy="calcs-table"] [data-test="item-1"]').eq(0).as('firstRow');
+
+    cy.get('@firstRow').contains('first_name_calc');
+
+    cy.get('@firstRow').find('[data-cy="calcs-table-edit"]').click();
+
+    cy.get('[data-cy="calcs-modal"] .modal-dialog').as('calcsModal');
+    cy.get('@calcsModal').should('be.visible');
+
+    cy.get('@calcsModal').should('have.class', 'modal-lg');
+
+    cy.get('[data-test="calcs-enlarge-source-code"]').as('enlargeSourceCode');
+
+    cy.get('@enlargeSourceCode').click();
+
+    cy.get('@calcsModal').should('have.class', 'modal-xl');
+
+    cy.get('@enlargeSourceCode').click();
+
+    cy.get('@calcsModal').should('have.class', 'modal-lg');
+  });
 });

--- a/tests/e2e/specs/CalcDragAndDrop.spec.js
+++ b/tests/e2e/specs/CalcDragAndDrop.spec.js
@@ -144,15 +144,9 @@ describe('Calcs list Drag&Drop', () => {
     cy.get('[data-cy="calcs-modal"] .modal-dialog').as('calcsModal');
     cy.get('@calcsModal').should('be.visible');
 
-    cy.get('@calcsModal').should('have.class', 'modal-lg');
-
-    cy.get('[data-test="calcs-enlarge-source-code"]').as('enlargeSourceCode');
-
-    cy.get('@enlargeSourceCode').click();
-
     cy.get('@calcsModal').should('have.class', 'modal-xl');
 
-    cy.get('@enlargeSourceCode').click();
+    cy.get('[data-cy="calcs-button-save"]').click();
 
     cy.get('@calcsModal').should('have.class', 'modal-lg');
   });


### PR DESCRIPTION
## Issue & Reproduction Steps
As a Designer when I open the Calc options I would like to have a bigger space in the “Formula Field”

## Solution

https://github.com/ProcessMaker/screen-builder/assets/3604190/046ef0e1-ac8b-45cf-abc9-0fd29c6ac260

## Related Tickets & Packages
[FOUR-13456](https://processmaker.atlassian.net/browse/FOUR-13456)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-13456]: https://processmaker.atlassian.net/browse/FOUR-13456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ