### PR TITLE
FOUR-13458: Insert the Bypass Option in each Watcher

### DIFF
--- a/src/mixins/extensions/Watchers.js
+++ b/src/mixins/extensions/Watchers.js
@@ -20,6 +20,11 @@ export default {
       if (definition.watchers) {
         screen.mixins.push(watchersMixin);
         definition.watchers.filter(this.filterWatchers).forEach((watcher) => {
+          console.log('watcher', watcher);
+          if (watcher.byPass) {
+            // If the watcher has bypass set to true, skip it
+            return;
+          }
           this.addMounted(screen, `
             this.$nextTick(() => this.$watch('vdata.${watcher.watching}', (newValue) => {
               if (typeof newValue !== 'undefined') {

--- a/tests/e2e/specs/WatchersBypass.spec.js
+++ b/tests/e2e/specs/WatchersBypass.spec.js
@@ -1,0 +1,189 @@
+describe("Watchers", () => {
+  beforeEach(() => {
+    cy.intercept(
+      "GET",
+      "/api/1.0/screens/1",
+      JSON.stringify({
+        id: 1,
+        screen_category_id: 1,
+        title: "Sub screen example",
+        description: "A sub screen example",
+        type: "FORM",
+        config: [
+          {
+            name: "Sub screen example",
+            items: [
+              {
+                config: {
+                  icon: "far fa-square",
+                  label: "First name",
+                  name: "firstname",
+                  placeholder: "",
+                  validation: "",
+                  helper: null,
+                  type: "text",
+                  dataFormat: "string",
+                  customCssSelector: "first-name"
+                },
+                inspector: [],
+                component: "FormInput",
+                "editor-component": "FormInput",
+                "editor-control": "FormInput",
+                label: "Line Input",
+                value: "__vue_devtool_undefined__"
+              },
+              {
+                config: {
+                  icon: "far fa-square",
+                  label: "Last name",
+                  name: "lastname",
+                  placeholder: "",
+                  validation: "",
+                  helper: null,
+                  type: "text",
+                  dataFormat: "string",
+                  customCssSelector: ""
+                },
+                inspector: [],
+                component: "FormInput",
+                "editor-component": "FormInput",
+                "editor-control": "FormInput",
+                label: "Line Input",
+                value: "__vue_devtool_undefined__"
+              }
+            ]
+          }
+        ],
+        computed: [],
+        watchers: [],
+        custom_css: "[selector='first-name'] label { font-style: italic; }",
+        status: "ACTIVE"
+      })
+    );
+  });
+  it("Ensure that a watch is not bypassed", () => {
+    // Mock script response
+
+    cy.intercept(
+      "POST",
+      "/api/1.0/scripts/execute/1",
+      JSON.stringify({
+        output: {
+          name: "Steve"
+        }
+      })
+    );
+
+    cy.visit("/");
+    cy.openAcordeon("collapse-1");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", {
+      position: "bottom"
+    });
+    cy.get("[data-cy=controls-FormInput]").drag(
+      "[data-cy=screen-element-container]",
+      { position: "top" }
+    );
+    cy.get("[data-cy=screen-element-container]").last().click();
+    cy.get("[data-cy=inspector-name]").clear().type("user.name");
+
+    // Create
+    cy.get('[data-cy="topbar-watchers"]').click();
+    cy.get('[data-cy="watchers-add-watcher"]').click();
+    cy.get('[data-cy="watchers-watcher-name"]').clear().type("Watcher test");
+    cy.setMultiselect('[data-cy="watchers-watcher-variable"]', "form_input_2");
+    cy.get('[data-cy="watchers-accordion-source"]').click({
+      waitForAnimations: true
+    });
+    cy.setMultiselect('[data-cy="watchers-watcher-source"]', "Test Script");
+    cy.setVueComponentValue(
+      '[data-cy="watchers-watcher-input_data"]',
+      '{"form_input_2":"{{form_input_2}}"}'
+    );
+    cy.get('[data-cy="watchers-accordion-output"]').click({
+      waitForAnimations: true
+    });
+    cy.get('[data-cy="watchers-watcher-output_variable"]').clear().type("user");
+    cy.get('[data-cy="watchers-button-save"]').click();
+    cy.get('[data-cy="watchers-table"]').should("contain.text", "Watcher test");
+    cy.get('[data-cy="watchers-modal"] .close').click();
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.get("[data-cy=preview-content] [name=form_input_2]")
+      .clear()
+      .type("name");
+    // Assertion: Watcher popup is not displayed
+    cy.get("#watchers-synchronous").should("not.exist");
+    // wait for watcher execution
+    cy.wait(3000);
+    cy.assertPreviewData({
+      form_input_2: "name",
+      user: {
+        name: "Steve"
+      }
+    });
+  });
+  it("Ensure that a watch is bypassed", () => {
+    // Mock script response
+
+    cy.intercept(
+      "POST",
+      "/api/1.0/scripts/execute/1",
+      JSON.stringify({
+        output: {
+          name: "Steve"
+        }
+      })
+    );
+
+    cy.visit("/");
+    cy.openAcordeon("collapse-1");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", {
+      position: "bottom"
+    });
+    cy.get("[data-cy=controls-FormInput]").drag(
+      "[data-cy=screen-element-container]",
+      { position: "top" }
+    );
+    cy.get("[data-cy=screen-element-container]").last().click();
+    cy.get("[data-cy=inspector-name]").clear().type("user.name");
+
+    // Create
+    cy.get('[data-cy="topbar-watchers"]').click();
+    cy.get('[data-cy="watchers-add-watcher"]').click();
+    cy.get('[data-cy="watchers-watcher-name"]').clear().type("Watcher test");
+    cy.setMultiselect('[data-cy="watchers-watcher-variable"]', "form_input_2");
+    cy.get('[data-cy="watchers-accordion-source"]').click({
+      waitForAnimations: true
+    });
+    cy.setMultiselect('[data-cy="watchers-watcher-source"]', "Test Script");
+    cy.setVueComponentValue(
+      '[data-cy="watchers-watcher-input_data"]',
+      '{"form_input_2":"{{form_input_2}}"}'
+    );
+    cy.get('[data-cy="watchers-accordion-output"]').click({
+      waitForAnimations: true
+    });
+    cy.get('[data-cy="watchers-watcher-output_variable"]').clear().type("user");
+    cy.get('[data-cy="watchers-button-save"]').click();
+    cy.get('[data-cy="watchers-table"]').should("contain.text", "Watcher test");
+    // Set byPass as true
+    cy.get('[data-test="watchers-bypass"]').click();
+
+    cy.get('[data-cy="watchers-modal"] .close').click();
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.get("[data-cy=preview-content] [name=form_input_2]")
+      .clear()
+      .type("name");
+    // Assertion: Watcher popup is not displayed
+    cy.get("#watchers-synchronous").should("not.exist");
+    // wait for watcher execution
+    cy.wait(3000);
+    cy.assertPreviewData({
+      form_input_2: "name",
+      user: {
+        name: ""
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps
Insert the Bypass Option in each Watcher
Expected behavior: 
As a Designer I want to have the option to Bypass a selected list of Watchers that I am creating in the Screen Builder.
Actual behavior: 
n/a
## Solution
- add bypass to the watchers execution engine


https://github.com/ProcessMaker/screen-builder/assets/1401911/a46a6b82-2c30-4f28-883c-7f011d799bab


## How to Test
Test the steps above

1. create a screen
2. add a watcher
3. set the watcher as bypassed
4. preview the screen


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13458

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next