### PR TITLE
FOUR-13459 logs section for watchers

### DIFF
--- a/src/customLogs.js
+++ b/src/customLogs.js
@@ -8,7 +8,6 @@ export default class CustomLog {
     const logStatus = `%c${status}`;
 
     if (status === 'RUN') {
-      console.log('Hello');
       console.log(`${logPrefix} ${logStatus}`, style, transparentStyle, style);
     } else if (status === 'FAILED') {
       console.groupCollapsed(`${logPrefix} ${logStatus}`, style, transparentStyle, style);

--- a/src/customLogs.js
+++ b/src/customLogs.js
@@ -1,0 +1,27 @@
+export default class CustomLog {
+  static logWithStyle(icon, type, name, status, message, color) {
+    const baseColor = color === '255, 0, 0' ? 'red' : 'green';
+    const style = `background-color: rgba(${color}, 0.1); color: ${baseColor}; padding: 2px 4px; border-radius: 3px;`;
+    const transparentStyle = 'background-color: transparent';
+
+    const logPrefix = `%c${icon} %c${type} "${name}" has`;
+    const logStatus = `%c${status}`;
+
+    if (status === 'RUN') {
+      console.log('Hello');
+      console.log(`${logPrefix} ${logStatus}`, style, transparentStyle, style);
+    } else if (status === 'FAILED') {
+      console.groupCollapsed(`${logPrefix} ${logStatus}`, style, transparentStyle, style);
+      console.log(`%c${message}`, style);
+      console.groupEnd();
+    }
+  }
+
+  static success(type, name) {
+    this.logWithStyle('\u2705', type, name, 'RUN', '', '0, 128, 0');
+  }
+
+  static error(type, name, message) {
+    this.logWithStyle('\u274C', type, name, 'FAILED', message, '255, 0, 0');
+  }
+}

--- a/src/mixins/computedFields.js
+++ b/src/mixins/computedFields.js
@@ -1,4 +1,5 @@
 import { Parser } from "expr-eval";
+import CustomLog from '../customLogs';
 
 export default {
   methods: {
@@ -39,22 +40,7 @@ export default {
      * @param {string} message - The error message.
      */
     customErrorLog(name, message) {
-      // Unicode character for the common error icon
-      const errorIcon = "\u274C"; // Heavy multiplication X
-      // Create the error message with a background similar to console.error
-      const style =
-        "background-color: rgba(255, 0, 0, 0.1); color: red; padding: 2px 4px; border-radius: 3px;";
-      // start console log group
-      console.groupCollapsed(
-        `%c${errorIcon} %cCalc "${name}" has %cFAILED`,
-        style,
-        "background-color: rgba(255, 0, 0, 0.1)",
-        style
-      );
-      // Log the message
-      console.log(`%c${message}`, style);
-      // End the console group
-      console.groupEnd();
+      CustomLog.error('Calc', name, message);
     },
 
     /**
@@ -62,18 +48,7 @@ export default {
      * @param {string} name - The name of the calculation.
      */
     customSuccessLog(name) {
-      // Unicode character for the success icon
-      const successIcon = "\u2705"; // Checkmark
-      // Create the success message with a green background
-      const style =
-        "background-color: rgba(0, 128, 0, 0.1); color: green; padding: 1px 1px; border-radius: 3px;";
-      // Log the styled success message with an icon
-      console.log(
-        `%c${successIcon} %cCalc "${name}" has %cRUN`,
-        style,
-        "background-color: rgba(0, 128, 0, 0.1)",
-        style
-      );
-    }
+      CustomLog.success('Calc', name);
+    },
   }
 };

--- a/src/mixins/watchers.js
+++ b/src/mixins/watchers.js
@@ -1,5 +1,6 @@
 import Mustache from 'mustache';
 import _ from 'lodash';
+import CustomLog from '../customLogs';
 
 const broadcastEvent = '.Illuminate\\\\Notifications\\\\Events\\\\BroadcastNotificationCreated';
 
@@ -44,7 +45,7 @@ export default {
           // Data Source
           const requestId = _.get(this.vdata, '_request.id', null);
           const params = { config: JSON.parse(config), data: this.vdata };
-          
+
           this.$dataProvider.postDataSource(scriptId, requestId, params).then(response => {
             this.$emit('asyncWatcherCompleted');
             complete(response.data);
@@ -67,6 +68,7 @@ export default {
           });
         }
       }).then((response) => {
+        CustomLog.success('Watcher', watcher.name);
         // If watcher has an output variable and is a script
         if (watcher.output_variable && (watcher.script_key || '').length === 0) {
           this.setValue(watcher.output_variable, response, this.vdata);
@@ -94,6 +96,7 @@ export default {
         }
         return response;
       }).catch(error => {
+        CustomLog.error('Watcher', watcher.name, error.message);
         const message = _.get(error, 'response.data.message', error.message);
         if (watcher.synchronous) {
           this.$parent.$refs.watchersSynchronous.error(message);


### PR DESCRIPTION
## Issue & Reproduction Steps
As a Designer I want to have the option where I can see the Logs after the Watchers run

## Solution
https://github.com/ProcessMaker/screen-builder/assets/3604190/5eb9e209-2af0-4b28-8a47-6bfe31bf3c64

## Related Tickets & Packages
[FOUR-13459](https://processmaker.atlassian.net/browse/FOUR-13459)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:develop


[FOUR-13459]: https://processmaker.atlassian.net/browse/FOUR-13459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ