### PR TITLE
FOUR-13460: Enlarge the source code field in the Watchers window

### DIFF
--- a/src/components/watchers-form.vue
+++ b/src/components/watchers-form.vue
@@ -744,7 +744,7 @@ export default {
 }
 
 .editor {
-  height: 8.5em;
+  height: 375px;
   z-index: 0;
 }
 

--- a/src/components/watchers-popup.vue
+++ b/src/components/watchers-popup.vue
@@ -1,7 +1,7 @@
 <template>
   <b-modal
     ref="modal"
-    size="lg"
+    :size="modalSize"
     id="watchers-popup"
     @hidden="displayList"
     hide-footer
@@ -71,6 +71,11 @@ export default {
         byPass: false,
       },
     };
+  },
+  computed: {
+    modalSize() {
+      return this.enableList ? "lg" : "xl";
+    },
   },
   watch: {
     value: {

--- a/tests/e2e/specs/Watchers.spec.js
+++ b/tests/e2e/specs/Watchers.spec.js
@@ -316,6 +316,24 @@ describe("Watchers", () => {
       }
     });
   });
+  it("should enlarge the source code field", () => {
+    cy.visit("/");
+    // Create
+    cy.get('[data-cy="topbar-watchers"]').click();
+    cy.get('[data-cy="watchers-add-watcher"]').click();
+    cy.get('[data-cy="watchers-watcher-name"]').clear().type("Watcher test");
+    cy.setMultiselect('[data-cy="watchers-watcher-variable"]', "form_input_2");
+    cy.get('[data-cy="watchers-accordion-source"]').click({
+      waitForAnimations: true
+    });
+    cy.get('[data-cy="watchers-modal"] .modal-dialog').as("watcherModal");
+    cy.get("@watcherModal").should("be.visible");
+
+    cy.get("@watcherModal").should("have.class", "modal-xl");
+    cy.get('[data-cy="watchers-button-cancel"]').click();
+
+    cy.get("@watcherModal").should("have.class", "modal-lg");
+  });
   it("Test asynchronous watcher", () => {
     // Mock script response
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
As a Designer  when I open a Watcher options I would like to have a bigger space into the “Formula Field”
Actual behavior: 
n/a
## Solution
- enlarge the modal and the formula field

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13460

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
