### PR TITLE
FOUR-16802: Search is Faling When Two Names Are Partially the Same

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -39,6 +39,7 @@
         @item-edit="editProperty"
         @item-delete="deleteProperty"
         @add-page="displayFormProperty"
+        :searchProperties= "searchProperties"
       >
         <template #options="{ item }">
           <button
@@ -229,6 +230,7 @@ export default {
       },
       monacoEditor: null,
       errors: {},
+      searchProperties: ['property', 'type'],
     };
   },
   computed: {

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -151,7 +151,7 @@ export default {
      */
     getPropertyValue(obj, path) {
       const parts = path.split('.');
-      return parts.reduce((acc, curr) => acc?[curr], obj);
+      return parts.reduce((acc, curr) => acc?.[curr], obj);
     },
 
     /**

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -151,7 +151,7 @@ export default {
      */
     getPropertyValue(obj, path) {
       const parts = path.split('.');
-      return parts.reduce((acc, curr) => acc && acc[curr], obj);
+      return parts.reduce((acc, curr) => acc?[curr], obj);
     },
 
     /**

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -116,16 +116,31 @@ export default {
      * @returns {Array} - The filtered items.
      */
     filterItems(searchValue, items, searchProperties) {
+      console.log('filterItems', searchValue, searchProperties);
+
       const cleanSearch = this.clearSearch(searchValue).toLowerCase();
+
       return items.filter((item) => {
-        return searchProperties.some((property) => {
-          const value = this.getPropertyValue(item, property);
-          if (value) {
-            const valueString = value.toString().toLowerCase();
-            return valueString.includes(cleanSearch);
-          }
-          return false;
-        });
+        return this.propertyMatchesSearch(item, searchProperties, cleanSearch);
+      });
+    },
+
+    /**
+     * Checks if any of the specified properties of an item match the cleaned search value as a substring.
+     *
+     * @param {Object} item - The item object to check.
+     * @param {Array} properties - The properties to search within each item.
+     * @param {string} cleanSearch - The cleaned and lowercase search value.
+     * @returns {boolean} - True if any property matches the search value, otherwise false.
+     */
+    propertyMatchesSearch(item, properties, cleanSearch) {
+      return properties.some((property) => {
+        const value = this.getPropertyValue(item, property);
+        if (value && typeof value === 'string') {
+          const normalizedValue = value.toLowerCase();
+          return normalizedValue.includes(cleanSearch);
+        }
+        return false;
       });
     },
 
@@ -138,7 +153,7 @@ export default {
      */
     getPropertyValue(obj, path) {
       const parts = path.split('.');
-      return parts.reduce((acc, curr) => acc?.[curr], obj);
+      return parts.reduce((acc, curr) => acc && acc[curr], obj);
     },
 
     /**
@@ -148,7 +163,7 @@ export default {
      * @returns {string} - The cleaned search value.
      */
     clearSearch(searchValue) {
-      return searchValue.replace(/[^\w\s]/gi, '').trim();
+      return searchValue.trim();
     },
   },
 };

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -116,8 +116,6 @@ export default {
      * @returns {Array} - The filtered items.
      */
     filterItems(searchValue, items, searchProperties) {
-      console.log('filterItems', searchValue, searchProperties);
-
       const cleanSearch = this.clearSearch(searchValue).toLowerCase();
 
       return items.filter((item) => {

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -61,7 +61,10 @@ export default {
     },
     searchProperties: {
       type: Array,
-      default: []
+      required: false,
+      default: function() {
+        return []; // Return a new instance of the array
+      }
     }
   },
   data() {

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -135,7 +135,7 @@ export default {
      */
     getPropertyValue(obj, path) {
       const parts = path.split('.');
-      return parts.reduce((acc, curr) => acc && acc[curr], obj);
+      return parts.reduce((acc, curr) => acc?.[curr], obj);
     },
 
     /**

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -15,6 +15,7 @@
     @item-delete="deleteProperty"
     @add-page="displayFormProperty"
     @ordered="$emit('ordered', $event)"
+    :searchProperties= "searchProperties"
   >
     <template #options="{ item }">
       <button
@@ -84,6 +85,7 @@ export default {
           key: 'script.title',
         },
       ],
+      searchProperties: ['name', 'output_variable', 'watching', 'script.title'],
     };
   },
   methods: {

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -253,20 +253,26 @@ export const UserCanSortWithFilterByText = {
     const items = canvas.getAllByTestId(/item-\d+/);
     expect(items[0]).toHaveTextContent("Zeus");
     expect(items[1]).toHaveTextContent("Poseidon");
-    expect(items[2]).toHaveTextContent("Hera");
+    expect(items[2]).toHaveTextContent("Hephaïstus");
     expect(items[3]).toHaveTextContent("Athena");
-    expect(items[4]).toHaveTextContent("Hephaïstus");
- 
-    // Drag "Athena" to "Hera" position
-    await dragAndDrop(canvas.getByTitle("Athena"), canvas.getByTitle("Hera"));
+    expect(items[4]).toHaveTextContent("Hera");
 
-    // Check the new order
+    await dragAndDrop(
+      canvas.getByTitle("Hephaïstus"),
+      canvas.getByTitle("Athena")
+    );
+    await dragAndDrop(
+      canvas.getByTitle("Hephaïstus"),
+      canvas.getByTitle("Hera")
+    );
+ 
+    // // Check the new order
     const itemsOrder = canvas.getAllByTestId(/item-\d+/);
-    expect(itemsOrder[0]).toHaveAttribute("data-order", "1");
-    expect(itemsOrder[1]).toHaveAttribute("data-order", "2");
-    expect(itemsOrder[2]).toHaveAttribute("data-order", "3");
-    expect(itemsOrder[3]).toHaveAttribute("data-order", "4");
-    expect(itemsOrder[4]).toHaveAttribute("data-order", "5");
+    await expect(itemsOrder[0]).toHaveAttribute("data-order", "1");
+    await expect(itemsOrder[1]).toHaveAttribute("data-order", "2");
+    await expect(itemsOrder[2]).toHaveAttribute("data-order", "3");
+    await expect(itemsOrder[3]).toHaveAttribute("data-order", "4");
+    await expect(itemsOrder[4]).toHaveAttribute("data-order", "5");
   }
 };
 

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -147,7 +147,9 @@ export const UserCanFilterByText = {
       { name: "Hera", order: 2 },
       { name: "Poseidon", order: 3 },
       { name: "Athena", order: 4 },
-      { name: "Hephaïstus", order: 5 }
+      { name: "Hephaïstus", order: 5 },
+      { name: "newTotalLeave", order: 5 },
+      { name: "newLeaveRemaining", order: 5 },
     ]
   },
   play: async ({ canvasElement, step }) => {
@@ -170,7 +172,7 @@ export const UserCanFilterByText = {
       await userEvent.type(search, "a");
       const items = canvas.getAllByTestId(/item-\d+/);
       await waitFor(() => {
-        expect(items).toHaveLength(3);
+        expect(items).toHaveLength(5);
       });
     });
 
@@ -181,6 +183,14 @@ export const UserCanFilterByText = {
       const items = canvas.getAllByTestId(/item-\d+/);
       await waitFor(() => {
         expect(items).toHaveLength(1);
+      });
+    });
+    await step("Type 'new'", async () => {
+      await userEvent.clear(search);
+      await userEvent.type(search, "new");
+      const items = canvas.getAllByTestId(/item-\d+/);
+      await waitFor(() => {
+        expect(items).toHaveLength(2);
       });
     });
   }

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -253,10 +253,11 @@ export const UserCanSortWithFilterByText = {
     const items = canvas.getAllByTestId(/item-\d+/);
     expect(items[0]).toHaveTextContent("Zeus");
     expect(items[1]).toHaveTextContent("Poseidon");
-    expect(items[2]).toHaveTextContent("Hephaïstus");
+    expect(items[2]).toHaveTextContent("Hera");
     expect(items[3]).toHaveTextContent("Athena");
-    expect(items[4]).toHaveTextContent("Hera");
-
+    expect(items[4]).toHaveTextContent("Hephaïstus");
+   
+   
     // Drag "Athena" to "Hera" position
     await dragAndDrop(canvas.getByTitle("Athena"), canvas.getByTitle("Hera"));
 

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -31,6 +31,7 @@ export default {
         @sorted="sorted"
         @item-edit="editPage"
         @item-delete="deletePage"
+        :searchProperties= "['name']"
       />
     `,
     data() {

--- a/src/stories/Sortable.stories.js
+++ b/src/stories/Sortable.stories.js
@@ -256,8 +256,7 @@ export const UserCanSortWithFilterByText = {
     expect(items[2]).toHaveTextContent("Hera");
     expect(items[3]).toHaveTextContent("Athena");
     expect(items[4]).toHaveTextContent("Hephaïstus");
-   
-   
+ 
     // Drag "Athena" to "Hera" position
     await dragAndDrop(canvas.getByTitle("Athena"), canvas.getByTitle("Hera"));
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Search must rpovide the list of all calcs with the selected criteria. It also must search with newTotal or newLeave
Actual behavior: 
When writing new, the search selects one of the two calcs despite both starting with “new”. 
## Solution
- improve filterItem method  to make a clean search in the defined properties

https://github.com/ProcessMaker/screen-builder/assets/1401911/bd64bcba-fa09-4e74-804f-c5a3079907a6




## How to Test
Test the steps above

1. Have a set of calcs with names as in the video
2. Write “new”

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16802

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
