### PR TITLE
FOUR-17044 an add button appears when doing d&d

### DIFF
--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -181,6 +181,7 @@ export default {
       this.draggedItem = order;
       // add dragging class to the element
       event.target.classList.add('dragging');
+      event.dataTransfer.effectAllowed = 'move';
     },
     dragEnter(event, order) {
       this.draggedOverItem = order;

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -67,7 +67,7 @@
               v-else
               v-b-tooltip="{ customClass: 'sortable-item-action-btn-tooltip' }"
               class="btn"
-              title="Edit"
+              :title="$t('Edit')"
               v-bind="dataTestActions.btnEdit"
               @click.stop="onClick(item, index)"
             >
@@ -78,7 +78,7 @@
             <button
               v-b-tooltip="{ customClass: 'sortable-item-action-btn-tooltip' }"
               class="btn"
-              title="Delete"
+              :title="$t('Delete')"
               v-bind="dataTestActions.btnDelete"
               @click="$emit('item-delete', item)"
             >

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -65,6 +65,7 @@
             </button>
             <button
               v-else
+              v-b-tooltip="{ customClass: 'sortable-item-action-btn-tooltip' }"
               class="btn"
               title="Edit"
               v-bind="dataTestActions.btnEdit"
@@ -75,6 +76,7 @@
             <div class="sortable-item-vr"></div>
             <slot name="options" :item="item"></slot>
             <button
+              v-b-tooltip="{ customClass: 'sortable-item-action-btn-tooltip' }"
               class="btn"
               title="Delete"
               v-bind="dataTestActions.btnDelete"
@@ -181,7 +183,9 @@ export default {
       this.draggedItem = order;
       // add dragging class to the element
       event.target.classList.add('dragging');
-      event.dataTransfer.effectAllowed = 'move';
+      if (event?.dataTransfer) {
+        event.dataTransfer.effectAllowed = 'move';
+      }
     },
     dragEnter(event, order) {
       this.draggedOverItem = order;

--- a/src/components/sortable/sortableList/sortableList.scss
+++ b/src/components/sortable/sortableList/sortableList.scss
@@ -70,6 +70,18 @@ $border-color: #cdddee;
       display: flex;
       margin: 0 16px;
       border-color: $border-color !important;
+
+      &-btn-tooltip::v-deep {
+        & .tooltip-inner {
+          background-color: #EBEEF2 !important;
+          color: #444444 !important;
+        }
+
+        & .arrow:before {
+          border-top-color: #EBEEF2 !important;
+          border-bottom-color: #EBEEF2 !important;
+        }
+      }
     }
 
     &-vr {

--- a/src/components/sortable/sortableList/sortableList.scss
+++ b/src/components/sortable/sortableList/sortableList.scss
@@ -86,4 +86,7 @@ $border-color: #cdddee;
 
 .dragging {
   box-shadow: 0 1px 5px 0 rgba(86, 104, 119, 0.4);
+  cursor: move;
+  cursor: -webkit-grab;
+  cursor: -moz-grab;
 }

--- a/tests/e2e/specs/WatchersDragAndDrop.spec.js
+++ b/tests/e2e/specs/WatchersDragAndDrop.spec.js
@@ -166,8 +166,12 @@ describe('Watchers list Drag&Drop', () => {
     cy.get('[data-cy="watchers-modal"] .close').click();
 
     cy.get('[data-cy=mode-preview]').click();
-    cy.get('[data-cy=preview-content] [name=form_input_1]').clear().type('name');
-    cy.get('#watchers-synchronous').should('be.visible');
+    cy.get('[data-cy=preview-content] [name=form_input_1]')
+      .clear()
+      .type('name')
+      .then(() => {
+        cy.get('#watchers-synchronous').should('be.visible');
+      });
     cy.wait(2000);
 
     assertion();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
An add button should not appear when doing drag and drop in Calcs and watchers

Actual behavior: 
An add button appears when doing drag and drop in Calcs and watchers

## Solution
- Hide the plus icon
- Add tooltips to edit and delete buttons

## How to Test
1. Import attached secreen
2. Go to designer tab
3. Search screen and edit
4. First scenario: Calcs
5. Click on Calcs button
6. Drag and drop last Calc(C3) to top

## Related Tickets & Packages
[FOUR-17044](https://processmaker.atlassian.net/browse/FOUR-17044)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next



[FOUR-17044]: https://processmaker.atlassian.net/browse/FOUR-17044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ