### PR TITLE
FOUR-17102 calcs type should change from expression to formula

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -220,6 +220,16 @@ export default {
         {
           label: this.$t("Type"),
           key: "type",
+          cb: (value) => {
+            switch (value) {
+              case 'expression':
+                return 'Formula';
+              case 'javascript':
+                return 'JavaScript';
+              default:
+                return value;
+            }
+          },
         },
       ],
       monacoOptions: {

--- a/src/components/sortable/sortableList/SortableList.vue
+++ b/src/components/sortable/sortableList/SortableList.vue
@@ -55,7 +55,7 @@
             @keydown.esc.stop="onCancel(item)"
             @focus="onFocus(item)"
           />
-          <span v-else>{{ getItemValue(item, field.key) }}</span>
+          <span v-else>{{ getItemValue(item, field.key, field.cb) }}</span>
         </div>
 
         <div class="sortable-list-td">
@@ -121,11 +121,15 @@ export default {
     /** Get the value of a nested field in an object
      * @param {Object} item - The object to get the value from
      * @param {String} fieldKey - The key of the field to get the value from
+     * @param {Function} cb - Callback function to apply to the value
      *
      * @returns {String} The value of the field
      */
-    getItemValue(item, fieldKey) {
-      return fieldKey.split('.').reduce((obj, key) => obj[key] || '', item);
+    getItemValue(item, fieldKey, cb = null) {
+      return fieldKey.split('.').reduce((obj, key) => {
+        if (!obj[key]) return '';
+        return cb instanceof Function ? cb(obj[key]) : obj[key];
+      }, item);
     },
     validateState(name, item) {
       const isEmpty = !name?.trim();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Calcs type should change from expression to Formula

Actual behavior: 
When you create a calculation from a formula, the type displays as an expression

## Solution
- Add a callback to fields property

## How to Test
1. Import the attached screen
2. Search screen and edit
3. Click on calcs button

## Related Tickets & Packages
[FOUR-17102](https://processmaker.atlassian.net/browse/FOUR-17102)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

