### PR TITLE
FOUR-17058: A confirmation message should appear before deleting a calcs

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -183,6 +183,8 @@ import Validator from "@chantouchsek/validatorjs";
 import FocusErrors from "../mixins/focusErrors";
 import Sortable from './sortable/Sortable.vue';
 
+const globalObject = typeof window === 'undefined' ? global : window;
+
 export default {
   components: {
     FormInput,
@@ -403,6 +405,16 @@ export default {
       this.displayList = false;
     },
     deleteProperty(item) {
+      globalObject.ProcessMaker.confirmModal(
+        this.$t('Are you sure you want to delete the calc ?'),
+        this.$t('If you do, you wont be able to recover the calc configuration.'),
+        '',
+        () => {
+          this.remove(item);
+        }
+      );
+    },
+    remove(item) {
       this.current = this.current.filter((val) => {
         return val.id !== item.id;
       });


### PR DESCRIPTION
## Issue & Reproduction Steps
A confirmation message should appear before deleting a calcs
## Solution
- add confirmation message to delete a calc


https://github.com/ProcessMaker/processmaker/assets/1401911/a2a6b39e-d5d3-4aad-bd91-0d94e9254303



## How to Test
Describe how to test that this solution works.
- confirmation message was added

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17058
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
