### PR TITLE
FOUR-17142 the distribution of columns in edit page has been modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 `@processmaker/screen-builder` is a VueJS powered Screen Builder that produces compatible JSON for our vue-form-renderer.
 
-- [Project setup](#project-setup)
-- [Testing](#testing)
+- [ProcessMaker Screen Builder](#processmaker-screen-builder)
+  - [Project setup](#project-setup)
+  - [Testing](#testing)
 
 ## Project setup
 
@@ -17,8 +18,8 @@ cd screen-builder
 Install dependencies using NPM, then run the local development server:
 
 ```bash
-npm i
-npm run serve
+npm ci
+npm run dev
 ```
 
 ## Testing

--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -28,7 +28,6 @@
         class="mb-3"
         :fields="fields"
         :items="current"
-        filter-key="name,type"
         disable-key="byPass"
         :inline-edit="false"
         :data-test-actions="{

--- a/src/components/sortable/Sortable.vue
+++ b/src/components/sortable/Sortable.vue
@@ -52,7 +52,6 @@ export default {
   props: {
     fields: { type: Array, required: true },
     items: { type: Array, required: true },
-    filterKey: { type: String, required: true },
     disableKey: { type: String, default: null },
     inlineEdit: { type: Boolean, default: true },
     dataTestActions: {
@@ -62,10 +61,10 @@ export default {
     searchProperties: {
       type: Array,
       required: false,
-      default: function() {
+      default() {
         return []; // Return a new instance of the array
-      }
-    }
+      },
+    },
   },
   data() {
     return {

--- a/src/components/sortable/sortableList/sortableList.scss
+++ b/src/components/sortable/sortableList/sortableList.scss
@@ -25,7 +25,8 @@ $border-color: #cdddee;
       }
 
       &:nth-child(2) {
-        width: 30%;
+        min-width: 30%;
+        width: auto;
       }
 
       &:not(:first-child):not(:nth-child(2)):not(:last-child) {

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -381,7 +381,7 @@
       <Sortable
         :fields="fields"
         :items="config"
-        filter-key="name"
+        :search-properties="searchProperties"
         @item-edit="() => {}"
         @item-delete="confirmDelete"
         @add-page="$bvModal.show('addPageModal')"
@@ -629,7 +629,8 @@ export default {
       editorContentKey: 0,
       cancelledJobs: [],
       collapse: {},
-      groupOrder: {}
+      groupOrder: {},
+      searchProperties: ['name'],
     };
   },
   computed: {

--- a/src/components/watchers-list.vue
+++ b/src/components/watchers-list.vue
@@ -2,7 +2,6 @@
   <Sortable
     :fields="fields"
     :items="value"
-    filter-key="name,watching,output_variable,script.title"
     disable-key="byPass"
     :inline-edit="false"
     :data-test-actions="{


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The distribution of the edit page columns should not be modified, it should look like the image below

Actual behavior: 
The distribution of columns in edit page has been modificated

## Solution
- add a min-width property to first second column
- remove unused property

## How to Test
1. Login
2. Create screen or import attached screen
3. Search screen and edit
4. Click on menu button
5. Click on See all pages

## Related Tickets & Packages
[FOUR-17142](https://processmaker.atlassian.net/browse/FOUR-17142)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy


[FOUR-17142]: https://processmaker.atlassian.net/browse/FOUR-17142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ