### PR TITLE
FOUR-17058: A confirmation message should appear before deleting a calcs

### DIFF
--- a/src/components/computed-properties.vue
+++ b/src/components/computed-properties.vue
@@ -408,7 +408,7 @@ export default {
     deleteProperty(item) {
       globalObject.ProcessMaker.confirmModal(
         this.$t('Are you sure you want to delete the calc ?'),
-        this.$t('If you do, you wont be able to recover the calc configuration.'),
+        this.$t('If you do, you won’t be able to recover the Calc configuration.'),
         '',
         () => {
           this.remove(item);


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
- update delete a calc confirmation message

## How to Test
Describe how to test that this solution works.

1. Import screen
2. Search screen and edit
3. Click on Calcs button
4. Delete any calcs (Click on delete button)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17058

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
c:next