### PR TITLE
FOUR-17160 a user not assigned to the next task is redirected to it when interstitial is enabled

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -604,18 +604,12 @@ export default {
         process_request_id: params.processRequestId,
         page: params.page,
         per_page: params.perPage,
-        status: params.status
+        status: params.status,
       };
 
-      const queryString = Object.entries(queryParams)
-        .filter(([, value]) => value !== undefined && value !== null)
-        .map(
-          ([key, value]) =>
-            `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
-        )
-        .join("&");
+      const queryString = new URLSearchParams(queryParams).toString();
 
-      return window.ProcessMaker.apiClient.get(`tasks?${queryString}`);
+      return this.$dataProvider.getTasks(`?${queryString}`);
     },
     /**
      * Parses a JSON string and returns the result.
@@ -690,7 +684,6 @@ export default {
         data.event === "ACTIVITY_ACTIVATED"
         && data.elementType === 'task'
       ) {
-        this.taskId = data.tokenId;
         this.reload();
       }
       if (data.event === 'ACTIVITY_EXCEPTION') {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -684,8 +684,13 @@ export default {
         data.event === "ACTIVITY_ACTIVATED"
         && data.elementType === 'task'
       ) {
+        if (!this.task.elementDestination?.type) {
+          this.taskId = data.taskId;
+        }
+
         this.reload();
       }
+
       if (data.event === 'ACTIVITY_EXCEPTION') {
         this.$emit('error', this.requestId);
       }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The user of the first task should be redirected to the source from which the task was accessed

Actual behavior: 
The user of the first task is redirected to the next task

## Solution
- Ensure to use the `tasks` endpoint v1.1
- Remove `taskId` assignment on `ProcessUpdated` event

## How to Test
1. Import attached process
2. Assign a other user in Second task
3. Publish process
4. Create a case of process ('SEManual' start event)
5. Complete first task

## Related Tickets & Packages
[FOUR-17160](https://processmaker.atlassian.net/browse/FOUR-17160)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-17160]: https://processmaker.atlassian.net/browse/FOUR-17160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ