### PR TITLE
Bugfix/FOUR-15004: PMQL in record list doesnt work with pm variables

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -193,7 +193,7 @@ export default {
    * @param {object} params
    * @returns {object}
    */
-  getDataSource(dataSourceId, params) {
+  getDataSource(dataSourceId, params, nonce = null) {
     // keep backwards compatibility
     if (
       !window.ProcessMaker.screen.cacheEnabled &&
@@ -210,7 +210,7 @@ export default {
         pmds_data: JSON.stringify(params.data)
       }
     }).then((response) => {
-      return response;
+      return [response, nonce];
     });
   },
 
@@ -266,7 +266,7 @@ export default {
   },
 
   getCollectionRecords(collectionId, options, nonce = null) {
-    options.useCache = window.ProcessMaker.screen.cacheEnabled;
+    options.useCache = window.ProcessMaker?.screen?.cacheEnabled;
 
     return this.get(
       `/collections/${collectionId}/records${this.authQueryString()}`,

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -227,7 +227,7 @@
 
     <div v-if="dataSource === dataSourceValues.dataConnector">
       <pmql-input
-        :search-type="'collections'"
+        :search-type="'collections_w_mustaches'"
         class="mb-1"
         :input-label="'PMQL'"
         v-model="pmqlQuery"


### PR DESCRIPTION
## Issue & Reproduction Steps

Please see https://processmaker.atlassian.net/browse/FOUR-15004

To reproduce:
- Create a screen 
- Add an input with a default and name it **user** (you can use your custom example)
- Add a select list of type data connector (you can use the users endpoint)
- Configure Options Variable: response.data
- Type of Value Returned: Object
- Content {{data.username}}
- Data connector: Users
- Endpoint ListAll
- Add a PMQL: **data.username="{{user}}"** (user is the name of the input you added before)
- Go to preview and type some valid user in the input to make the pmql trigger and change the option list of the select

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/2fa1ce60-a5e5-44b8-9d45-4389aa603c6a


## Solution
- Fix PMQL render and code refactor for dataconnector
- Fix issue with cacheEnabled
- Fix NL to PMQL to call microservice for PMQL input in select lists
- Add nonce to use last call in select list dataconnector

## How to Test
- Follow steps above. You can test also type collections for data source

## Related Tickets & Packages
- [FOUR-15004](https://processmaker.atlassian.net/browse/FOUR-15004)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/7115)
- [Screen builder PR](https://github.com/ProcessMaker/screen-builder/pull/1649)
- [Vue form elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/430)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next



[FOUR-15004]: https://processmaker.atlassian.net/browse/FOUR-15004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ