### PR TITLE
FOUR-17261: When the calc has bypass activated, the content of the entire form is not displayed

### DIFF
--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -237,11 +237,10 @@ export default {
     },
     isComputedVariable(name, definition) {
       return definition.computed && definition.computed.some(computed => {
-        if (computed?.byPass) {
-          return false;
-        }
-        // Check if the first part of an element's name (up to the first `.`)
-        // matches the name of a computed property.
+        // add byPass computed property validation
+        if (computed?.byPass) return false;
+        // Check if the first part of an element'ßs name (up to the first `.`)
+        // matches the name of a computed propertåy.
         const regex = new RegExp(`^${computed.property}(\\.|$)`, 'i');
         return regex.test(name);
       });

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -236,7 +236,7 @@ export default {
       return name && typeof name === 'string' && name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/);
     },
     isComputedVariable(name, definition) {
-      return definition.computed && definition.computed.some(computed => {
+      return definition?.computed?.some(computed => {
         // add byPass computed property validation
         if (computed?.byPass) return false;
         // Check if the first part of an element'ßs name (up to the first `.`)

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -237,6 +237,7 @@ export default {
     },
     isComputedVariable(name, definition) {
       return definition.computed && definition.computed.some(computed => {
+        if (!definition.computed) return false;
         // Check if the first part of an element's name (up to the first `.`)
         // matches the name of a computed property.
         const regex = new RegExp(`^${computed.property}(\\.|$)`, 'i');

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -237,7 +237,9 @@ export default {
     },
     isComputedVariable(name, definition) {
       return definition.computed && definition.computed.some(computed => {
-        if (!definition.computed) return false;
+        if (computed?.byPass) {
+          return false;
+        }
         // Check if the first part of an element's name (up to the first `.`)
         // matches the name of a computed property.
         const regex = new RegExp(`^${computed.property}(\\.|$)`, 'i');


### PR DESCRIPTION
## Issue & Reproduction Steps
hen the calc has bypass activated, the content of the entire form is not displayed
Expected behavior: 
The content of the screen should be displayed, only the calcs values ​​should not be displayed
Actual behavior: 
When the calc has bypass activated, the content of the entire form is not displayed (For example: New submit Button  is not showed)
## Solution
- improve isComputedVariable method to support byPass computed property

## How to Test
Detailed in the related ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17261
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
c:next