### PR TITLE
FOUR-17272 tasks in a process without interstitial automatically skip to the next task

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -604,18 +604,12 @@ export default {
         process_request_id: params.processRequestId,
         page: params.page,
         per_page: params.perPage,
-        status: params.status
+        status: params.status,
       };
 
-      const queryString = Object.entries(queryParams)
-        .filter(([, value]) => value !== undefined && value !== null)
-        .map(
-          ([key, value]) =>
-            `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
-        )
-        .join("&");
+      const queryString = new URLSearchParams(queryParams).toString();
 
-      return window.ProcessMaker.apiClient.get(`tasks?${queryString}`);
+      return this.$dataProvider.getTasks(`?${queryString}`);
     },
     /**
      * Parses a JSON string and returns the result.
@@ -690,7 +684,6 @@ export default {
         data.event === "ACTIVITY_ACTIVATED"
         && data.elementType === 'task'
       ) {
-        this.taskId = data.tokenId;
         this.reload();
       }
       if (data.event === 'ACTIVITY_EXCEPTION') {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -684,8 +684,13 @@ export default {
         data.event === "ACTIVITY_ACTIVATED"
         && data.elementType === 'task'
       ) {
+        if (!this.task.elementDestination?.type) {
+          this.taskId = data.taskId;
+        }
+
         this.reload();
       }
+
       if (data.event === 'ACTIVITY_EXCEPTION') {
         this.$emit('error', this.requestId);
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -420,7 +420,7 @@ export default {
      */
     // eslint-disable-next-line consistent-return
     async getDestinationUrl() {
-      const { elementDestination } = this.task || {};
+      const { elementDestination, allow_interstitial: allowInterstitial } = this.task || {};
 
       if (!elementDestination) {
         return null;
@@ -437,7 +437,7 @@ export default {
           const response = await this.retryApiCall(() => this.getTasks(params));
 
           const firstTask = response.data.data[0];
-          if (firstTask?.user_id === this.userId) {
+          if (allowInterstitial && firstTask?.user_id === this.userId) {
             return `/tasks/${firstTask.id}/edit`;
           }
 
@@ -487,6 +487,8 @@ export default {
             this.nodeId = task.element_id;
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
+          } else if (!this.taskPreview) {
+            this.emitClosedEvent();
           }
         });
     },
@@ -602,8 +604,8 @@ export default {
       const queryParams = {
         user_id: this.userId,
         process_request_id: params.processRequestId,
-        page: params.page,
-        per_page: params.perPage,
+        page: params.page || 1,
+        per_page: params.perPage || 1,
         status: params.status,
       };
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
If we do not have interstitial enabled in the tasks, we should not jump to the next form

Actual behavior: 
As we see, the tasks are shown alone without opening in the Form Task

## Solution
- Validate interstitial on redirect to the next task

## How to Test
1. Log in 
2. Create a process with a task 
3. Verify that the tasks and the start event are not configured with interstitial
4. Start a new  case

## Requires
[FOUR-17160](https://processmaker.atlassian.net/browse/FOUR-17160)

## Related Tickets & Packages
[FOUR-17272](https://processmaker.atlassian.net/browse/FOUR-17272)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next



[FOUR-17272]: https://processmaker.atlassian.net/browse/FOUR-17272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-17160]: https://processmaker.atlassian.net/browse/FOUR-17160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ