### PR TITLE
FOUR-17258 Fix Task Initialization in Webentries

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -102,6 +102,7 @@ export default {
     loading: { type: Number, default: null },
     alwaysAllowEditing: { type: Boolean, default: false },
     disableInterstitial: { type: Boolean, default: false },
+    waitLoadingListeners: { type: Boolean, default: false },
   },
   data() {
     return {
@@ -122,7 +123,7 @@ export default {
       redirecting: null,
       loadingButton: false,
       loadingTask: false,
-      loadingListeners: true,
+      loadingListeners: this.waitLoadingListeners,
     };
   },
   watch: {
@@ -258,6 +259,10 @@ export default {
       }
     },
     loadTask() {
+      if (!this.taskId) {
+        return;
+      }
+
       const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`;
       // For Vocabularies
       if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -417,7 +417,7 @@ export default {
      * Emits a closed event.
      */
     async emitClosedEvent() {
-      this.$emit("closed", this.task.id, await this.getDestinationUrl());
+      this.$emit("closed", this.task?.id, await this.getDestinationUrl());
     },
     /**
      * Retrieves the destination URL for the closed event.
@@ -473,6 +473,7 @@ export default {
       const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${timestamp}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
+          console.log(url, response.data);
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
             if (task.process_request_id !== this.requestId) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -473,7 +473,6 @@ export default {
       const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${timestamp}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
-          console.log(url, response.data);
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
             if (task.process_request_id !== this.requestId) {


### PR DESCRIPTION
## Fix Task Initialization in Webentries

When a webentry is opened, it does not count with request or task, this caused error in the Task component new changes. Also the screen kept disabled because of that.
Also there is a problem in the screens endpoint when selecting an screen.

## Solution
- Fix the initialization of the Task considering it could not have a request
- Disable the screen at the begining only when a request is present
- Fix screen endpoint and add some tests to validate it.

https://github.com/user-attachments/assets/25661c71-5648-4dde-ba8c-9aa8e2ed7b5c

## How to Test
- Create a process with an anonnymous webentry
  - Variations: With interstitial screen
  - Variation: Without interstitial screen
- Open the web entry
- Complete the form

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17258

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
