### PR TITLE
Set node id before loading the task for webentry

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -488,8 +488,8 @@ export default {
               this.emitIfTaskCompleted(requestId);
             }
             this.taskId = task.id;
-            this.loadTask();
             this.nodeId = task.element_id;
+            this.loadTask();
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
           } else if (!this.taskPreview) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -7,15 +7,16 @@
   >
     <template v-if="screen">
       <b-overlay
-          :show="disabled"
+          :show="disabled || isSelfService"
           id="overlay-background"
-          variant="white"
+          :variant="isSelfService ? 'white' : 'transparent'"
+          :blur="null"
           cardStyles="pointer-events: none;pointer-events: none;inset: 1px"
           rounded="sm"
       >
       <template #overlay>
         <div class="text-center">
-          <p>Please claim this task to continue.</p>
+          <p v-if="isSelfService">Please claim this task to continue.</p>
         </div>
       </template>
       <div class="card card-body border-top-0 h-100" :class="screenTypeClass">
@@ -124,6 +125,7 @@ export default {
       loadingButton: false,
       loadingTask: false,
       loadingListeners: this.waitLoadingListeners,
+      isSelfService: false,
     };
   },
   watch: {
@@ -359,12 +361,12 @@ export default {
       }
       this.prepareTask();
     },
-    disableForSelfService() {
+    setSelfService() {
       this.$nextTick(() => {
         if (window.ProcessMaker.isSelfService) {
-          this.disabled = true;
+          this.isSelfService = true;
         } else {
-          this.disabled = false;
+          this.isSelfService = false;
         }
       });
     },
@@ -546,7 +548,7 @@ export default {
     },
     onUpdate(data) {
       this.$emit('input', data);
-      this.disableForSelfService();
+      this.setSelfService();
     },
     activityAssigned() {
       // This may no longer be needed

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -691,7 +691,7 @@ export default {
         data.event === "ACTIVITY_ACTIVATED"
         && data.elementType === 'task'
       ) {
-        if (!this.task.elementDestination?.type) {
+        if (!this.task?.elementDestination?.type) {
           this.taskId = data.taskId;
         }
 


### PR DESCRIPTION
## Issue & Reproduction Steps

"Display next task to assignee" option is not redirecting to the next task and the submit button was not submitting to the correct endpoint (node id in the url was wrong)

## Solution
- `this.nodeId` needs to be set before `loadTask` because webentry needs to load the config with the new nodeId (using the `beforeLoadTask` hook)

## How to Test
See jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17438
- Requires: https://github.com/ProcessMaker/screen-builder/pull/1660

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
