### PR TITLE
Screen components are not displayed

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -650,6 +650,10 @@ export default {
       let filter = this.filterQuery.toLowerCase();
       const filtered = this.controls.filter((control) => {
         let result = control.label.toLowerCase().includes(filter);
+        if (!control.group) {
+          // If the group is not defined
+          control.group = 'Advanced';
+        }
         if (control.group.toLowerCase().includes(filter)) {
           result = true;
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
The list of components is not displayed correctly when a component is found that does not have the group to which it should be registered defined.

Expected behavior: 
The component list should be displayed normally.

Actual behavior: 
If a component is registered from a package and does not have a group defined, the component listing is blocked.

## Solution
- Add a default group if the group is not defined.

## How to Test
Test the steps above

## Related Tickets & Packages
-  [FOUR-17914](https://processmaker.atlassian.net/browse/FOUR-17914)

ci:next

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-17914]: https://processmaker.atlassian.net/browse/FOUR-17914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ