### PR TITLE
FOUR-17911 loop created between two tasks with self service

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -448,7 +448,7 @@ export default {
             return `/tasks/${firstTask.id}/edit`;
           }
 
-          return document.referrer || null;
+          return this.getSessionRedirectUrl();
         } catch (error) {
           console.error("Error in getDestinationUrl:", error);
           return null;
@@ -465,7 +465,27 @@ export default {
       const sessionStorageUrl = sessionStorage.getItem("elementDestinationURL");
       return sessionStorageUrl || null;
     },
+    /**
+     * Retrieves the URL from the session storage or the document referrer.
+     *
+     * This method is used to determine the source of the redirection when the task is claimed.
+     * It retrieves the 'sessionUrlSelfService' value from sessionStorage, and if present, removes it.
+     * If the value is not found, it returns the document referrer.
+     *
+     * @returns {string|null} - The URL from the session storage or the document referrer.
+     */
+    getSessionRedirectUrl() {
+      const urlSelfService = sessionStorage.getItem('sessionUrlSelfService');
 
+      if (urlSelfService) {
+        // Remove 'sessionUrlSelfService' from sessionStorage after retrieving its value
+        sessionStorage.removeItem('sessionUrlSelfService');
+        // Emit the source of the redirection
+        return urlSelfService;
+      }
+
+      return document.referrer || null;
+    },
     loadNextAssignedTask(requestId = null) {
       if (!requestId) {
         requestId = this.requestId;
@@ -809,8 +829,8 @@ export default {
      * Checks for the presence of a URL action blocker in sessionStorage and handles it.
      *
      * This method retrieves the 'sessionUrlActionBlocker' value from sessionStorage,
-     * and if present, removes it and emits a 'closed' event with the task id and 
-     * the source of the redirection. It returns false if the blocker was handled, 
+     * and if present, removes it and emits a 'closed' event with the task id and
+     * the source of the redirection. It returns false if the blocker was handled,
      * and true otherwise.
      *
      * @returns {boolean} Returns false if the 'sessionUrlActionBlocker' was found and handled, true otherwise.


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
When Task Source (default) is selected, the Task should be opened and displayed on the screen with the Claim message

Actual behavior: 
The next task is not displayed and a loop displays the completed task message 

## Solution
- Add a session variable to identify when a Task was claimed

https://github.com/user-attachments/assets/96ae4684-0308-4f8d-baf7-77814deb1a5f

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-17911](https://processmaker.atlassian.net/browse/FOUR-17911)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-17911]: https://processmaker.atlassian.net/browse/FOUR-17911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ