### PR TITLE
FOUR-17581 Fix Processes that are started with another thread do not display the screen

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -780,13 +780,13 @@ export default {
      */
     handleRedirect(data) {
       switch (data.method) {
-        case 'javascript:redirectToTask':
+        case 'redirectToTask':
           this.handleRedirectToTask(data);
           break;
-        case 'javascript:processUpdated':
+        case 'processUpdated':
           this.handleProcessUpdated(data);
           break;
-        case 'javascript:processCompletedRedirect':
+        case 'processCompletedRedirect':
           this.processCompletedRedirect(
             data.params[0],
             this.userId,

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -427,6 +427,7 @@ export default {
      */
     // eslint-disable-next-line consistent-return
     async getDestinationUrl() {
+      debugger;
       const { elementDestination, allow_interstitial: allowInterstitial } = this.task || {};
 
       if (!elementDestination) {
@@ -805,9 +806,10 @@ export default {
      * @param {Object} data - The event data containing the tokenId of the task.
      */
     handleRedirectToTask(data) {
+
       if (data?.params[0]?.tokenId) {
         this.loadingTask = true;
-        this.loadTask(data.params[0].tokenId);
+        // this.loadTask(data.params[0].tokenId);
         this.taskId = data.params[0].tokenId;
         this.reload();
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -676,11 +676,8 @@ export default {
         // Handle the first task from the response
         const firstTask = response.data.data[0];
         if (firstTask && firstTask.user_id === userId) {
-          // this.$emit("completed", requestId, `/tasks/${firstTask.id}/edit`);
-          // window.location.href = `/tasks/${firstTask.id}/edit`;
           this.redirectToTask(firstTask.id);
         } else {
-          // this.$emit("completed", requestId);
           this.redirectToRequest(requestId);
         }
       } catch (error) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -262,7 +262,6 @@ export default {
       }
     },
     loadTask() {
-      debugger;
       if (!this.taskId) {
         return;
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -808,7 +808,6 @@ export default {
 
       if (data?.params[0]?.tokenId) {
         this.loadingTask = true;
-        // this.loadTask(data.params[0].tokenId);
         this.taskId = data.params[0].tokenId;
         this.reload();
       }

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -484,7 +484,7 @@ export default {
               }
               this.unsubscribeSocketListeners();
               this.redirecting = task.process_request_id;
-              this.$emit('redirect', task.id, true);
+              // this.$emit('redirect', task.id, true);
               return;
             } else {
               this.emitIfTaskCompleted(requestId);
@@ -677,9 +677,12 @@ export default {
         // Handle the first task from the response
         const firstTask = response.data.data[0];
         if (firstTask && firstTask.user_id === userId) {
-          this.$emit("completed", requestId, `/tasks/${firstTask.id}/edit`);
+          // this.$emit("completed", requestId, `/tasks/${firstTask.id}/edit`);
+          // window.location.href = `/tasks/${firstTask.id}/edit`;
+          this.redirectToTask(firstTask.id);
         } else {
-          this.$emit("completed", requestId);
+          // this.$emit("completed", requestId);
+          this.redirectToRequest(requestId);
         }
       } catch (error) {
         console.error("Error processing completed redirect:", error);
@@ -691,6 +694,12 @@ export default {
       const permission = permissions.find(item => item.process_request_id === this.parentRequest)
       const allowed = permission && permission.allowed;
       return allowed ? this.parentRequest : this.requestId
+    },
+    redirectToTask(tokenId) {
+      this.$emit('redirect', tokenId);
+    },
+    redirectToRequest(requestId) {
+      window.location.href = `/requests/${requestId}`;
     },
     processUpdated: _.debounce(function(data) {
       if (
@@ -724,6 +733,14 @@ export default {
         '.ProcessUpdated',
         (data) => {
           this.processUpdated(data);
+        }
+      );
+      this.addSocketListener(
+        `redirect-${this.requestId}`,
+        `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
+        '.RedirectTo',
+        (data) => {
+          console.log(data);
         }
       );
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -262,6 +262,7 @@ export default {
       }
     },
     loadTask() {
+      debugger;
       if (!this.taskId) {
         return;
       }
@@ -487,7 +488,7 @@ export default {
               }
               this.unsubscribeSocketListeners();
               this.redirecting = task.process_request_id;
-              // this.$emit('redirect', task.id, true);
+              this.$emit('redirect', task.id, true);
               return;
             } else {
               this.emitIfTaskCompleted(requestId);
@@ -731,6 +732,7 @@ export default {
             case 'javascript:redirectToTask':
               if (data?.params[0]?.tokenId) {
                 this.loadingTask = true;
+                debugger;
                 this.loadTask(data.params[0].tokenId);
                 this.taskId = data.params[0].tokenId;
                 this.reload();

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -717,67 +717,6 @@ export default {
     redirectToRequest(requestId) {
       window.location.href = `/requests/${requestId}`;
     },
-    // initSocketListeners() {
-    //   this.addSocketListener(
-    //     `updated-${this.requestId}`,
-    //     `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
-    //     '.ProcessUpdated',
-    //     (data) => {
-    //       if (data.event === 'ACTIVITY_EXCEPTION') {
-    //         this.$emit('error', this.requestId);
-    //       }
-    //     }
-    //   );
-    //   // v2 redirect to listener
-    //   this.addSocketListener(
-    //     `redirect-${this.requestId}`,
-    //     `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
-    //     '.RedirectTo',
-    //     (data) => {
-    //       switch (data.method) {
-    //         case 'javascript:redirectToTask':
-    //           if (data?.params[0]?.tokenId) {
-    //             this.loadingTask = true;
-    //             this.loadTask(data.params[0].tokenId);
-    //             this.taskId = data.params[0].tokenId;
-    //             this.reload();
-    //           }
-    //           break;
-    //         case 'javascript:processUpdated':
-    //           if (
-    //             ['ACTIVITY_ACTIVATED', 'ACTIVITY_COMPLETED'].includes(data.event)
-    //             && data.elementType === 'task'
-    //           ) {
-    //             if (!this.task.elementDestination?.type) {
-    //               this.taskId = data.taskId;
-    //             }
-    //             this.reload();
-    //           }
-    //           if (data.event === 'ACTIVITY_EXCEPTION') {
-    //             this.$emit('error', this.requestId);
-    //           }
-    //           break;
-    //         case 'javascript:processCompletedRedirect':
-    //           this.processCompletedRedirect(
-    //             data.params[0],
-    //             this.userId,
-    //             this.requestId
-    //           );
-    //           break;
-    //         default:
-    //           console.warn('redirect', data);
-    //           window.location.href = `/requests/${this.requestId}`;
-    //       }
-    //     }
-    //   );
-    //   this.loadingListeners = false;
-
-    //   // We might have missed an event before initSocketListeners
-    //   // was called so reload to check if there's a task waiting
-    //   if (!this.taskId) {
-    //     this.reload();
-    //   }
-    // },
     /**
      * Initializes socket listeners for process updates and redirects.
      * This method sets up listeners to handle specific events and reloads

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -759,6 +759,7 @@ export default {
               break;
             default:
               console.warn('redirect', data);
+              window.location.href = `/requests/${this.requestId}`;
           }
         }
       );

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -732,7 +732,6 @@ export default {
             case 'javascript:redirectToTask':
               if (data?.params[0]?.tokenId) {
                 this.loadingTask = true;
-                debugger;
                 this.loadTask(data.params[0].tokenId);
                 this.taskId = data.params[0].tokenId;
                 this.reload();

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -427,7 +427,6 @@ export default {
      */
     // eslint-disable-next-line consistent-return
     async getDestinationUrl() {
-      debugger;
       const { elementDestination, allow_interstitial: allowInterstitial } = this.task || {};
 
       if (!elementDestination) {

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -163,6 +163,7 @@ export default {
       handler() {
         if (this.requestId) {
           this.setMetaValue();
+          console.log('init socket');
           this.initSocketListeners();
         } else {
           this.unsubscribeSocketListeners();
@@ -701,22 +702,22 @@ export default {
     redirectToRequest(requestId) {
       window.location.href = `/requests/${requestId}`;
     },
-    processUpdated: _.debounce(function(data) {
-      if (
-        ['ACTIVITY_ACTIVATED', 'ACTIVITY_COMPLETED'].includes(data.event)
-        && data.elementType === 'task'
-      ) {
-        if (!this.task.elementDestination?.type) {
-          this.taskId = data.taskId;
-        }
+    // processUpdated: _.debounce(function(data) {
+    //   if (
+    //     ['ACTIVITY_ACTIVATED', 'ACTIVITY_COMPLETED'].includes(data.event)
+    //     && data.elementType === 'task'
+    //   ) {
+    //     if (!this.task.elementDestination?.type) {
+    //       this.taskId = data.taskId;
+    //     }
 
-        this.reload();
-      }
+    //     this.reload();
+    //   }
 
-      if (data.event === 'ACTIVITY_EXCEPTION') {
-        this.$emit('error', this.requestId);
-      }
-    }, 100),
+    //   if (data.event === 'ACTIVITY_EXCEPTION') {
+    //     this.$emit('error', this.requestId);
+    //   }
+    // }, 100),
     initSocketListeners() {
       this.loadingListeners = false;
       this.addSocketListener(
@@ -724,7 +725,8 @@ export default {
         `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
         '.ProcessCompleted',
         (data) => {
-          this.processCompleted(data);
+          console.log('ProcessCompleted', data);
+          // this.processCompleted(data);
         }
       );
       this.addSocketListener(
@@ -732,15 +734,31 @@ export default {
         `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
         '.ProcessUpdated',
         (data) => {
-          this.processUpdated(data);
+          console.log('ProcessUpdated', data);
+          // this.processUpdated(data);
+
         }
       );
+      // v2 redirect to listener
       this.addSocketListener(
         `redirect-${this.requestId}`,
         `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
         '.RedirectTo',
         (data) => {
+          debugger;
           console.log(data);
+          console.log('previous task', this.task);
+          switch (data.method) {
+            case 'javascript:redirectToTask':
+              
+              if (data?.params[0]?.tokenId) {
+                this.loadTask(data.params[0].tokenId)
+                this.taskId = data.params[0].tokenId;
+                this.reload();
+              //   // window.location.href = data.params[0].payloadUrl;
+              }
+              break;
+          }
         }
       );
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -165,7 +165,6 @@ export default {
       handler() {
         if (this.requestId) {
           this.setMetaValue();
-          console.log('init socket');
           this.initSocketListeners();
         } else {
           this.unsubscribeSocketListeners();
@@ -702,15 +701,6 @@ export default {
       window.location.href = `/requests/${requestId}`;
     },
     initSocketListeners() {
-      this.addSocketListener(
-        `completed-${this.requestId}`,
-        `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
-        '.ProcessCompleted',
-        (data) => {
-          console.log('ProcessCompleted', data);
-          // this.processCompleted(data);
-        }
-      );
       this.addSocketListener(
         `updated-${this.requestId}`,
         `ProcessMaker.Models.ProcessRequest.${this.requestId}`,

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -718,7 +718,7 @@ describe("Task component", () => {
       }
     );
 
-    cy.socketEvent("ProcessMaker\\Events\\ProcessUpdated", {
+    cy.socketEvent("ProcessMaker\\Events\\RedirectTo", {
       requestId: 1,
       event: "ACTIVITY_COMPLETED"
     });


### PR DESCRIPTION
## Issue & Reproduction Steps
Fix Processes that are started with another thread do not display the screen

## Solution
- Use an specific event to handle the redirection.

## How to Test
Review the steps in ticket: https://processmaker.atlassian.net/browse/FOUR-17581

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17581

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
