### PR TITLE
FOUR-18861 Fix Webentry issue routing to form task

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -808,7 +808,7 @@ export default {
       if (data?.params[0]?.tokenId) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.
-        if (!this.task.allow_interstitial) {
+        if (this.task && !this.task.allow_interstitial) {
            // The getDestinationUrl() function is called asynchronously to retrieve the URL
           window.location.href = await this.getDestinationUrl();
           return;


### PR DESCRIPTION
## Webentry issue routing to form task

- When redirecting to a new place there is a case when the task is not yet loaded after submitting a web entry to a second task after script tasks. 
- When refreshing a task with a nested screen in web entry SB is not passing the request_id for a validation.

## Solution
- Add a check to verify if the task was loaded
- Remove the validation of request_id in the web-entry screen endpoint

## How to Test
- Run the Expences Process template.
- Load a receipe
- The scripts are executed
- The expences are loaded
- Refresh the screen

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18861

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
