### PR TITLE
FOUR-18859: User not assigned to the next task is redirected to task …

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -483,8 +483,8 @@ export default {
         // Emit the source of the redirection
         return urlSelfService;
       }
-
-      return document.referrer || null;
+      // If the task has not an origin source it should re redirected top the tasks List as default.
+      return document.referrer || '/tasks';
     },
     loadNextAssignedTask(requestId = null) {
       if (!requestId) {


### PR DESCRIPTION
…list by default

## Issue & Reproduction Steps

Expected behavior: 
The user who created the case should be redirected to the task list
Actual behavior: 
The page has broken
## Solution
- add logic "If the task has not an origin source it should re redirected top the tasks List as default."


https://github.com/user-attachments/assets/d298a821-2c2d-4a0e-b069-71109d989f40


## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18859

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
