### PR TITLE
FOUR-18860 Fix User completes a task and is assigned the next one is not redirected to form the next task

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -808,7 +808,7 @@ export default {
       if (data?.params[0]?.tokenId) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.
-        if (this.task && !this.task.allow_interstitial) {
+        if (this.task && !(this.task.allow_interstitial || this.isSameUser(this.task, data))) {
            // The getDestinationUrl() function is called asynchronously to retrieve the URL
           window.location.href = await this.getDestinationUrl();
           return;
@@ -817,6 +817,16 @@ export default {
         this.taskId = data.params[0].tokenId;
         this.reload();
       }
+    },
+
+    /**
+     * Checks if the current task and the redirect data belong to the same user.
+     *
+     * @param {Object} currentTask - The current task object.
+     * @param {Object} redirectData - The redirect data object.
+     */
+    isSameUser(currentTask, redirectData) {
+      return currentTask.user?.id === redirectData.params[0].userId;
     },
 
     /**

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -821,12 +821,14 @@ export default {
 
     /**
      * Checks if the current task and the redirect data belong to the same user.
+     * and the destination is taskSource.
      *
      * @param {Object} currentTask - The current task object.
      * @param {Object} redirectData - The redirect data object.
      */
     isSameUser(currentTask, redirectData) {
-      return currentTask.user?.id === redirectData.params[0].userId;
+      return (currentTask.user?.id === redirectData.params[0].userId)
+        && (currentTask.elementDestination?.type === 'taskSource');
     },
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

The redirect to next task was working only with interstitial enabled

## Solution
- Enable redirect to next task when the next assigned user is the same of the current task as defined in the PRD

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18860

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
