### PR TITLE
FOUR-18858 Fix The create request doesn’t open the screen

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -516,8 +516,6 @@ export default {
             this.loadTask();
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
-          } else if (!this.taskPreview) {
-            this.emitClosedEvent();
           }
         });
     },


### PR DESCRIPTION
## The create request doesn’t open the screen

- When the endpoint to get the tasks returns before the script execution it causes to emit a close task preview since the next task is not yet assigned, then it redirects to task list.

## Solution
- The event close task preview is not required anymore, and wait for the new redirect/interstitial handler.

## How to Test
- Import the processes
- Run the process
- Interstitial waits for script conclusion
- Opens the next task screen

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18858

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
