### PR TITLE
FOUR-18860: User completes a task and is assigned the next one is not redirected to form the next task

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -516,6 +516,8 @@ export default {
             this.loadTask();
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
+          } else if (!this.taskPreview) {
+            this.emitClosedEvent();
           }
         });
     },

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -516,8 +516,6 @@ export default {
             this.loadTask();
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
-          } else if (!this.taskPreview) {
-            this.emitClosedEvent();
           }
         });
     },
@@ -827,8 +825,11 @@ export default {
      * @param {Object} redirectData - The redirect data object.
      */
     isSameUser(currentTask, redirectData) {
-      return (currentTask.user?.id === redirectData.params[0].userId)
-        && (currentTask.elementDestination?.type === 'taskSource');
+      const userIdMatch = currentTask.user?.id === redirectData.params[0].userId;
+      const typeMatch = currentTask.elementDestination?.type === null 
+                      || currentTask.elementDestination?.type === 'taskSource';
+      
+      return userIdMatch && typeMatch;
     },
 
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The user should be redirected to form of the next task
Actual behavior: 
The user is redirected to next task (TCP43716TC)
## Solution
- add support for currentTask.elementDestination type equal to null


https://github.com/user-attachments/assets/a1c3eedd-2c78-4ed8-9666-d0eacbafc4bd

ci:next

## How to Test
Test the steps above
Described in the related ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18860

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
