### PR TITLE
FOUR-18988: Display message if file upload fails (for 4.10.2)

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -504,9 +504,22 @@ export default {
         e.target.click();
       }
     },
-    fileError(rootFile, file, message, chunk)
+    fileError(rootFile, file, messages, chunk)
     {
-      this.$emit('file-error', message);
+      let displayMessage = '';
+      try {
+        const messagesArray = JSON.parse(messages);
+        displayMessage = messagesArray.join(', ');
+      }
+      catch (e) {
+        displayMessage = messages;
+      }
+
+      if (displayMessage.length > 0) {
+        window.ProcessMaker.alert(`${this.$t('File Upload Error:')}  ${displayMessage}`, 'danger');
+      }
+
+      this.$emit('file-error', messages);
     },
     fileUploaded(rootFile, file, message) {
       this.uploading = false;


### PR DESCRIPTION
## Issue & Reproduction Steps

To reproduce:

    Create as screen with a file upload

    Use the screen in a process

    Upload a PDF with malicious code: 

     


Current behavior:
The PDF upload returns an error but no additional info is displayed
image-20240905-142801.png

 

Expected behavior
A more descriptive message should be displayed to users, like when uploading a PDF file in files/public

## Solution
- File errors handled in screen builder file upload component

## How to Test
Test the steps above

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-18988

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
