### PR TITLE
FOUR-18984 Parallel Task is not redirected according element destination configuration once completed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -826,9 +826,9 @@ export default {
      */
     isSameUser(currentTask, redirectData) {
       const userIdMatch = currentTask.user?.id === redirectData.params[0].userId;
-      const typeMatch = currentTask.elementDestination?.type === null 
+      const typeMatch = currentTask.elementDestination?.type === null
                       || currentTask.elementDestination?.type === 'taskSource';
-      
+
       return userIdMatch && typeMatch;
     },
 
@@ -839,6 +839,17 @@ export default {
      * @param {Object} data - The event data containing the process update information.
      */
     handleProcessUpdated(data) {
+      const elementDestinationValue = this.task.elementDestination?.value;
+
+      if (
+        elementDestinationValue &&
+        data?.params[0]?.tokenId === this.taskId &&
+        data?.params[0]?.requestStatus === 'ACTIVE'
+      ) {
+        window.location.href = elementDestinationValue;
+        return;
+      }
+
       if (
         ['ACTIVITY_ACTIVATED', 'ACTIVITY_COMPLETED'].includes(data.event)
         && data.elementType === 'task'


### PR DESCRIPTION
## Issue & Reproduction Steps

Redirect to Summary Screen from End Event with Multiple Tasks Parallel Assigned

Expected behavior: 
Task TCP4-4247-A completed should redirect to Task List
Task TCP4-4247-B completed should redirect to Welcome Screen
Task TCP4-4247-C completed should redirect to Summary Screen

Actual behavior: 
Task TCP4-4247-A completed is not redirected according to the Element Destination configuration
Task TCP4-4247-B completed is not redirected according to the Element Destination configuration 

## Solution
- Verify if the request is active once the parallel task is completed

https://github.com/user-attachments/assets/38663ece-3443-42d6-b47f-20e777153329

## How to Test
see the ticket

## Related Tickets & Packages
[FOUR-18984](https://processmaker.atlassian.net/browse/FOUR-18984)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-18984]: https://processmaker.atlassian.net/browse/FOUR-18984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ