### PR TITLE
FOUR-19102 Fix Redirect when the process ends before load the request

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -307,7 +307,7 @@ export default {
             // get end event element destination config
             window.ProcessMaker.apiClient.get(`/requests/${this.requestId}/end-event-destination`)
               .then((response) => {
-                if (!response.data.data.endEventDestination) {
+                if (!response.data?.data?.endEventDestination) {
                   // by default it goes to summary
                   window.location.href = `/requests/${this.requestId}`;
                   return;


### PR DESCRIPTION
## Issue & Reproduction Steps

- When the process run, it ends before the request page is loaded
- The page missed all the redirection events so it stays in white

## Solution
- Catch when the process ends during the Task component mounting and execute the end event redirection.
- Requires: Core branch FOUR-19102

## How to Test
- Run the processes described in the ticket
- The script could something like:
```
<?php
return [];
```
- Usa nayra executor (runs a bit faster that php executor)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19102

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:connector-idp:bugfix/FOUR-19124
