### PR TITLE
FOUR-18326 | Implement Layout Application Logic

### DIFF
--- a/src/components/ScreenTemplateCard.vue
+++ b/src/components/ScreenTemplateCard.vue
@@ -87,7 +87,7 @@ export default {
     CssIcon,
   },
   mixins: [],
-  props: ['template', 'screenId'],
+  props: ['template', 'screenId', 'currentScreenPage'],
   data() {
     return {
       showApplyOptions: false,
@@ -120,6 +120,7 @@ export default {
         .post(`/template/screen/${this.template.id}/apply`, {
           screenId: this.screenId,
           templateOptions: this.selected,
+          currentScreenPage: this.currentScreenPage,
         })
         .then((response) => {
           ProcessMaker.alert(this.$t("The template options have been applied."), "success");

--- a/src/components/ScreenTemplateCard.vue
+++ b/src/components/ScreenTemplateCard.vue
@@ -36,7 +36,7 @@
                 class="col apply-options-container d-flex align-items-baseline flex-column"
               >
                 <div class="icon-container">
-                  <div v-if="option.value === 'Css'">
+                  <div v-if="option.value === 'CSS'">
                     <css-icon />
                   </div>
                   <div v-else>
@@ -67,7 +67,7 @@
                 type="button"
                 size="sm"
                 class="btn btn-primary ml-2 card-btn"
-                @click="onApply"
+                @click="applyTemplate"
               >
                 {{ $t("Apply") }}
               </button>
@@ -87,13 +87,13 @@ export default {
     CssIcon,
   },
   mixins: [],
-  props: ['template'],
+  props: ['template', 'screenId'],
   data() {
     return {
       showApplyOptions: false,
       selected: [],
       applyOptions: [
-        { text: 'CSS', value: 'Css' },
+        { text: 'CSS', value: 'CSS' },
         { text: 'Fields', value: 'Fields', icon: 'fp-fields-icon' },
         { text: 'Layout', value: 'Layout', icon: 'fp-layout-icon' },
       ],
@@ -115,8 +115,20 @@ export default {
     showDetails() {
       this.showApplyOptions = !this.showApplyOptions;
     },
-    onApply() {
-      // TODO: apply selected options
+    applyTemplate() {
+      ProcessMaker.apiClient
+        .post(`/template/screen/${this.template.id}/apply`, {
+          screenId: this.screenId,
+          templateOptions: this.selected,
+        })
+        .then((response) => {
+          ProcessMaker.alert(this.$t("The template options have been applied."), "success");
+          window.location.reload();
+        })
+        .catch((error) => {
+          const errorMessage = error.response?.data?.message || error.message;
+          ProcessMaker.alert(errorMessage, "danger");
+        });
     },
     onCancel() {
       this.showApplyOptions = false;

--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -49,6 +49,7 @@
             v-for="template in myTemplatesData"
             :key="template.id"
             :template="template"
+            :screen-id="screenId"
           />
         </b-card-group>
       </div>
@@ -83,6 +84,7 @@
     components: {
       ScreenTemplateCard,
     },
+    props: ['screenId'],
     mounted() {
     },
     data() {

--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -50,6 +50,7 @@
             :key="template.id"
             :template="template"
             :screen-id="screenId"
+            :currentScreenPage="currentScreenPage"
           />
         </b-card-group>
       </div>
@@ -70,6 +71,7 @@
             v-for="template in sharedTemplatesData"
             :key="template.id"
             :template="template"
+            :currentScreenPage="currentScreenPage"
           />
         </b-card-group>
       </div>
@@ -84,7 +86,7 @@
     components: {
       ScreenTemplateCard,
     },
-    props: ['screenId'],
+    props: ['screenId', 'currentScreenPage'],
     mounted() {
     },
     data() {

--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -71,6 +71,7 @@
             v-for="template in sharedTemplatesData"
             :key="template.id"
             :template="template"
+            :screen-id="screenId"
             :currentScreenPage="currentScreenPage"
           />
         </b-card-group>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -302,6 +302,7 @@
               ref="screenTemplates"
               :shared-templates-data="sharedTemplatesData"
               @close-templates-panel="closeTemplatesPanel"
+              :screen-id="screen.id"
             />
           </b-card-body>
         </div>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -303,6 +303,7 @@
               :shared-templates-data="sharedTemplatesData"
               @close-templates-panel="closeTemplatesPanel"
               :screen-id="screen.id"
+              :currentScreenPage="currentPage"
             />
           </b-card-body>
         </div>


### PR DESCRIPTION
# Feature
Tickets:
[FOUR-18326](https://processmaker.atlassian.net/browse/FOUR-18326)
[FOUR-18328](https://processmaker.atlassian.net/browse/FOUR-18328)
[FOUR-18329](https://processmaker.atlassian.net/browse/FOUR-18329)

This PR introduces logic for Applying Layouts and Fields to Screens via the Screen Templates Panel in `screen-builder`.

When a user chooses to only apply the layout from a template to their screen:
- The layout is added to the bottom of the screen, enabling the user to arrange the existing information as needed.
- When the screen has more than one page, the changes will be added to the bottom of the current page.

When a user applies only the fields:
- The fields are added to the bottom of the screen, providing the user with flexibility to reposition them as required.
- When the screen has more than one page, the changes will be added to the bottom of the current page.

When applying the complete template:
- The entire template is placed at the bottom of the screen, allowing the user to make further adjustments as necessary.
- When the screen has more than one page, the changes will be added to the bottom of the current page.

# How to Test
1. Go to branch `task/FOUR-18326` in `screen-builder` and `processmaker`.
2. Ensure you have a Screen Template with Custom CSS, Layouts, and Fields in your environment.
3. Create a new screen in the Screen Builder.
4. Select 'Templates'. Select the template card for the Screen Template that has CSS, Layouts, and Fields.
5. Select 'Layout'.
 - When the page reloads, check that the Layout of the screen meets the following requirements:
    - The layout is added to the bottom of the screen, enabling the user to arrange the existing information as needed.
    - When the screen has more than one page, the changes will be added to the bottom of the current page.
6. Select 'Templates'. Select the template card for the Screen Template that has CSS, Layouts, and Fields.
7. Select 'Fields'.
 - When the page reloads, check that the Fields of the screen meet the following requirements:
    - The fields are added to the bottom of the screen, providing the user with flexibility to reposition them as required.
    - When the screen has more than one page, the changes will be added to the bottom of the current page.
8. Select 'Templates'. Select the template card for the Screen Template that has CSS, Layouts, and Fields.
9. Select 'CSS', 'Layout', and 'Fields'.
- When the page reloads, check that the CSS, Layout, and Fields of the screen meet the following requirements:
    - The entire template is placed at the bottom of the screen, allowing the user to make further adjustments as necessary.
    - When the screen has more than one page, the changes will be added to the bottom of the current page.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-18326]: https://processmaker.atlassian.net/browse/FOUR-18326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-18328]: https://processmaker.atlassian.net/browse/FOUR-18328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-18329]: https://processmaker.atlassian.net/browse/FOUR-18329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ