### PR TITLE
FOUR-13441 STORY Paste clipboard items where dropped

### DIFF
--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -46,11 +46,11 @@
                       <clipboard-button
                         :index="index"
                         :config="element.config"
-                        :isInClipboard="isInClipboard(items[row][index])"
+                        :isInClipboard="isInClipboard(element)"
                         :addTitle="$t('Add to clipboard')"
                         :removeTitle="$t('Remove from clipboard')"
-                        @addToClipboard="addToClipboard(items[row][index])"
-                        @removeFromClipboard="removeFromClipboard(items[row][index])"
+                        @addToClipboard="addToClipboard(element)"
+                        @removeFromClipboard="removeFromClipboard(element)"
                       />
                       <button
                         v-if="isAiSection(element) && aiPreview(element)"
@@ -112,11 +112,11 @@
                       <clipboard-button
                         :index="index"
                         :config="element.config"
-                        :isInClipboard="isInClipboard(items[row][index])"
+                        :isInClipboard="isInClipboard(element)"
                         :addTitle="$t('Add to clipboard')"
                         :removeTitle="$t('Remove from clipboard')"
-                        @addToClipboard="addToClipboard(items[row][index])"
-                        @removeFromClipboard="removeFromClipboard(items[row][index])"
+                        @addToClipboard="addToClipboard(element)"
+                        @removeFromClipboard="removeFromClipboard(element)"
                       />
                       <button
                         class="btn btn-sm btn-secondary mr-2"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1109,6 +1109,7 @@ export default {
       });
     },
     updateState() {
+      this.replaceClipboardContent(this.config);
       this.$store.dispatch("undoRedoModule/pushState", {
         config: JSON.stringify(this.config),
         currentPage: this.currentPage

--- a/src/mixins/Clipboard.js
+++ b/src/mixins/Clipboard.js
@@ -64,5 +64,40 @@ export default {
 
       screenConfig.forEach((item) => replaceInPage(item));
     },
+
+    /**
+     * Find { component: "Clipboard" } and replace with the clipboard content.
+     */
+    replaceClipboardContent(screenConfig) {
+      if (
+        !screenConfig
+        || screenConfig instanceof Array === false
+      ) {
+        throw new Error("Expected a screen configuration array");
+      }
+
+      // Navigate each page and replace the clipboard component with the clipboard content
+      const replaceUuids = (item) => {
+        item.uuid = this.generateUUID();
+        if (item.items) {
+          item.items.forEach(replaceUuids);
+        }
+      }
+      const replaceInPage = (page) => {
+        page.items.forEach((item, index) => {
+          if (item.component === clipboardComponentName) {
+            // clone clipboard content to avoid modifying the original
+            const clipboardContent = _.cloneDeep(this.$store.getters["clipboardModule/clipboardItems"]);
+            // replace uuids in clipboard content
+            clipboardContent.forEach(replaceUuids);
+            page.items.splice(index, 1, ...clipboardContent);
+          }
+          if (item.items) {
+            replaceInPage(item);
+          }
+        });
+      }
+      screenConfig.forEach((item) => replaceInPage(item));
+    },
   },
 };

--- a/src/store/modules/clipboardModule.js
+++ b/src/store/modules/clipboardModule.js
@@ -98,15 +98,15 @@ const clipboardModule = {
    * Actions are used to commit mutations and can contain asynchronous operations.
    */
   actions: {
-    addToClipboard({ commit }, items) {
-      commit('ADD_TO_CLIPBOARD', items);
-    },
     /**
      * Adds an item to the clipboard by committing the corresponding mutation.
      * @param {Object} context - The context object containing commit.
      * @param {any} item - The item to add to the clipboard.
      */
     addToClipboard({ commit }, item) {
+      if (!item) {
+        throw new Error('Item is missing');
+      }
       commit('ADD_TO_CLIPBOARD', item);
     },
 

--- a/tests/e2e/specs/ClipboardDragPaste.spec.js
+++ b/tests/e2e/specs/ClipboardDragPaste.spec.js
@@ -180,4 +180,53 @@ describe("Clipboard Drag and Paste", () => {
     cy.get('[data-cy="screen-element-container"]').click();
   });
 
+  it("Copy two input element to clipboard", () => {
+    cy.window().then((win) => {
+      // Clear storage to remove any previous clipboard items
+      win.localStorage.clear();
+
+      // Step 1: Visit the homepage and open the 'Input Fields' accordion
+      cy.visit("/");
+      cy.openAcordeonByLabel("Input Fields");
+
+      // Step 2: Drag FormInput control to the screen's drop zone
+      cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", {
+        position: "bottom"
+      });
+
+      // Step 3: Click on the screen element container to select it
+      cy.get('[data-cy="screen-element-container"]').click();
+
+      // Step 4: Copy the selected element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+
+      // Step 5: Drag a second FormInput control to the screen's drop zone
+      cy.get("[data-cy=controls-FormInput]").drag("[data-cy=editor-content]", {
+      });
+
+      // Step 6: Click on the screen element container to select it
+      cy.get('[data-cy="screen-element-container"]').eq(1).click();
+
+      // Step 7: Copy the selected element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    });
+  });
+
+  it("Paste clipboard items to a different screen", () => {
+    // Step 1: Visit the homepage and open the 'Clipboard' accordion
+    cy.visit("/");
+    cy.openAcordeonByLabel("Clipboard");
+
+    // Step 2: Drag clipboard item to the screen's drop zone
+    cy.get('[data-cy="controls-Clipboard"]').drag('[data-cy=screen-drop-zone]');
+
+    // Step 3: Verify that there are two input elements pasted
+    cy.get('[data-cy="screen-element-container"]').should('have.length', 2);
+    cy.get('[data-cy="screen-element-container"]').eq(0).find('input').should('exist');
+    cy.get('[data-cy="screen-element-container"]').eq(1).find('input').should('exist');
+  });
 });

--- a/tests/e2e/specs/ClipboardDragPaste.spec.js
+++ b/tests/e2e/specs/ClipboardDragPaste.spec.js
@@ -1,0 +1,183 @@
+import {
+  addControlInsideLoop,
+  addControlInsideTable,
+} from "../support/utils.js";
+import { nodeControls } from "../support/constants.js";
+
+describe("Clipboard Drag and Paste", () => {
+
+  it("Copy input element to clipboard", () => {
+    cy.window().then((win) => {
+      // Clear storage to remove any previous clipboard items
+      win.localStorage.clear();
+
+      // Step 1: Visit the homepage and open the 'Input Fields' accordion
+      cy.visit("/");
+      cy.openAcordeonByLabel("Input Fields");
+
+      // Step 2: Drag FormInput control to the screen's drop zone
+      cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", {
+        position: "bottom"
+      });
+
+      // Step 3: Click on the screen element container to select it
+      cy.get('[data-cy="screen-element-container"]').click();
+
+      // Step 4: Copy the selected element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    });
+  });
+
+  it("Paste clipboard item to a different screen", () => {
+    // Step 1: Visit the homepage and open the 'Clipboard' accordion
+    cy.visit("/");
+    cy.openAcordeonByLabel("Clipboard");
+
+    // Step 2: Drag clipboard item to the screen's drop zone
+    cy.get('[data-cy="controls-Clipboard"]').drag('[data-cy=screen-drop-zone]');
+
+    // Step 3: Verify that the item has been pasted correctly (1 element should be present)
+    cy.get('[data-cy="screen-element-container"]').should('have.length', 1);
+
+    // Step 4: Click on the pasted element to activate it
+    cy.get('[data-cy="screen-element-container"]').click();
+  });
+
+  it("Copy multicolumn element to clipboard", () => {
+    cy.window().then((win) => {
+      // Clear storage to remove any previous clipboard items
+      win.localStorage.clear();
+
+      // Step 1: Visit the homepage and open the 'Input Fields' and 'Content Fields' accordions
+      cy.visit("/");
+      cy.openAcordeonByLabel("Input Fields");
+      cy.openAcordeonByLabel("Content Fields");
+
+      // Step 2: Drag FormMultiColumn control to the screen's drop zone
+      cy.get("[data-cy=controls-FormMultiColumn]").drag("[data-cy=screen-drop-zone]", {
+        position: "bottom"
+      });
+
+      // Step 3: Add a TextArea control inside the multicolumn table
+      addControlInsideTable(1, nodeControls.formTextArea);
+
+      // Step 4: Click on the screen element container to select it
+      cy.get('[data-cy="screen-element-container"]').click();
+
+      // Step 5: Copy the multicolumn element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    });
+  });
+
+  it("Paste multicolumn clipboard item to a different screen", () => {
+    // Step 1: Visit the homepage and open the 'Clipboard' accordion
+    cy.visit("/");
+    cy.openAcordeonByLabel("Clipboard");
+
+    // Step 2: Drag clipboard item to the screen's drop zone
+    cy.get('[data-cy="controls-Clipboard"]').drag('[data-cy=screen-drop-zone]');
+
+    // Step 3: Verify the multicolumn element with TextArea exists (2 columns)
+    cy.get('[data-cy="screen-element-container"]').should('have.length', 1);
+    cy.get('[data-cy="screen-element-container"] .column-draggable').should('have.length', 2);
+    cy.get('[data-cy="screen-element-container"] .column-draggable').eq(1).find('textarea').should('exist');
+
+    // Step 4: Click on the screen element container to activate it
+    cy.get('[data-cy="screen-element-container"]').click();
+  });
+
+  it("Copy loop element to clipboard", () => {
+    cy.window().then((win) => {
+      // Clear storage to remove any previous clipboard items
+      win.localStorage.clear();
+
+      // Step 1: Visit the homepage and open the 'Input Fields' and 'Content Fields' accordions
+      cy.visit("/");
+      cy.openAcordeonByLabel("Input Fields");
+      cy.openAcordeonByLabel("Content Fields");
+
+      // Step 2: Drag FormLoop control to the screen's drop zone
+      cy.get("[data-cy=controls-FormLoop]").drag("[data-cy=screen-drop-zone]", {
+        position: "bottom"
+      });
+
+      // Step 3: Add a TextArea control inside the loop
+      addControlInsideLoop(1, nodeControls.formTextArea);
+
+      // Step 4: Click on the screen element container to select it
+      cy.get('[data-cy="screen-element-container"]').click({
+        position: "top"
+      });
+
+      // Step 5: Copy the loop element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    });
+  });
+
+  it("Paste loop clipboard item to a different screen", () => {
+    // Step 1: Visit the homepage and open the 'Clipboard' accordion
+    cy.visit("/");
+    cy.openAcordeonByLabel("Clipboard");
+
+    // Step 2: Drag clipboard item to the screen's drop zone
+    cy.get('[data-cy="controls-Clipboard"]').drag('[data-cy=screen-drop-zone]');
+
+    // Step 3: Verify the loop element with TextArea exists
+    cy.get('[data-cy="screen-element-container"]').should('have.length', 1);
+    cy.get('[data-cy="screen-element-container"] .column-draggable').should('have.length', 1);
+    cy.get('[data-cy="screen-element-container"] .column-draggable').eq(0).find('textarea').should('exist');
+
+    // Step 4: Click on the screen element container to activate it
+    cy.get('[data-cy="screen-element-container"]').click();
+  });
+
+  it("Copy element from inside multicolumn to clipboard", () => {
+    cy.window().then((win) => {
+      // Clear storage to remove any previous clipboard items
+      win.localStorage.clear();
+
+      // Step 1: Visit the homepage and open the 'Input Fields' and 'Content Fields' accordions
+      cy.visit("/");
+      cy.openAcordeonByLabel("Input Fields");
+      cy.openAcordeonByLabel("Content Fields");
+
+      // Step 2: Drag Multicolumn control to the screen's drop zone and add a TextArea inside
+      cy.get("[data-cy=controls-FormMultiColumn]").drag("[data-cy=screen-drop-zone]", {
+        position: "bottom"
+      });
+      addControlInsideTable(1, nodeControls.formTextArea);
+
+      // Step 3: Click on the textarea element inside the multicolumn to select it
+      cy.get('[data-cy="screen-element-container"] [class="control-item"]').click();
+
+      // Step 4: Copy the textarea element to the clipboard
+      cy.get('[data-cy="addToClipboard"]').should("be.visible");
+      cy.get('[data-cy="addToClipboard"]').click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    });
+  });
+
+  it("Paste clipboard item from inside multicolumn to a different screen", () => {
+    // Step 1: Visit the homepage and open the 'Clipboard' accordion
+    cy.visit("/");
+    cy.openAcordeonByLabel("Clipboard");
+
+    // Step 2: Drag clipboard item to the screen's drop zone
+    cy.get('[data-cy="controls-Clipboard"]').drag('[data-cy=screen-drop-zone]');
+
+    // Step 3: Verify that only a textarea was pasted (no multicolumn)
+    cy.get('[data-cy="screen-element-container"]').should('have.length', 1);
+    cy.get('[data-cy="screen-element-container"] .column-draggable').should('have.length', 0);
+    cy.get('[data-cy="screen-element-container"]').find('textarea').should('exist');
+
+    // Step 4: Click on the screen element container to activate it
+    cy.get('[data-cy="screen-element-container"]').click();
+  });
+
+});


### PR DESCRIPTION
## Solution
- Implement the paste funcionality using the vuedraggable events
- Creates a clone of the clipboard items with new uuids

## How to Test
- Create a screen
- Add some elements and controls
- Select each control and add it to the clipboard
- Open a new screen with the same user Or in the same screen
- Open the clipboard section
- Drag and paste the clipboard content into the screen

https://github.com/user-attachments/assets/3505ec69-be8a-43d1-99cd-066cb12b8012

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13441

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
