### PR TITLE
FOUR-19110: [40531] changes on screen are not reflected in ongoing cases

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -81,6 +81,10 @@ export default {
     const hasIncludeScreen = params.match(/include=.*,screen,/);
     const hasIncludeNested = params.match(/include=.*,nested,/);
 
+    // Extract screen_version from params.
+    const screenVersionMatch = params.match(/screen_version=([^&]+)/);
+    const screenVersion = screenVersionMatch ? screenVersionMatch[1] : "";
+
     // remove params ?...
     promises.push(
       this.get(endpoint + params.replace(/,screen,|,nested,/g, ","))
@@ -90,7 +94,7 @@ export default {
       const screenEndpoint = `${(endpoint + params).replace(
         /\?.+$/,
         ""
-      )}/screen?include=screen${hasIncludeNested ? ",nested" : ""}`;
+      )}/screen?include=screen${hasIncludeNested ? ",nested" : ""}&screen_version=${screenVersion}`;
       promises.push(this.get(screenEndpoint));
     }
     // Await for both promises to resolve

--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -83,7 +83,7 @@ export default {
 
     // Extract screen_version from params.
     const screenVersionMatch = params.match(/screen_version=([^&]+)/);
-    const screenVersion = screenVersionMatch ? screenVersionMatch[1] : "";
+    const screenVersion = screenVersionMatch ? screenVersionMatch[1] : null;
 
     // remove params ?...
     promises.push(
@@ -91,10 +91,16 @@ export default {
     );
     // Get the screen from a separated cached endpoint
     if (hasIncludeScreen) {
-      const screenEndpoint = `${(endpoint + params).replace(
+      let screenEndpoint = `${(endpoint + params).replace(
         /\?.+$/,
         ""
-      )}/screen?include=screen${hasIncludeNested ? ",nested" : ""}&screen_version=${screenVersion}`;
+      )}/screen?include=screen${hasIncludeNested ? ",nested" : ""}`;
+
+      // Append screen_version only if screenVersion is not empty.
+      if (screenVersion) {
+        screenEndpoint += `&screen_version=${screenVersion}`;
+      }
+
       promises.push(this.get(screenEndpoint));
     }
     // Await for both promises to resolve

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -94,6 +94,7 @@ export default {
     initialRequestId: { type: Number, default: null },
     initialProcessId: { type: Number, default: null },
     initialNodeId: { type: String, default: null },
+    screenVersion: { type: Number, default: null },
     userId: { type: Number, default: null },
     csrfToken: { type: String, default: null },
     value: { type: Object, default: () => {} },
@@ -265,7 +266,7 @@ export default {
         return;
       }
 
-      const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`;
+      const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination&screen_version=${this.screenVersion}`;
       // For Vocabularies
       if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
         window.ProcessMaker.VocabulariesSchemaUrl = `vocabularies/task_schema/${this.taskId}`;

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -266,7 +266,12 @@ export default {
         return;
       }
 
-      const url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination&screen_version=${this.screenVersion}`;
+      let url = `/${this.taskId}?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination`;
+
+      if (this.screenVersion) {
+        url += `&screen_version=${this.screenVersion}`;
+      }
+
       // For Vocabularies
       if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
         window.ProcessMaker.VocabulariesSchemaUrl = `vocabularies/task_schema/${this.taskId}`;


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR is part of: https://github.com/ProcessMaker/processmaker/pull/7427

**Current behavior**
- Changes applied on a screen and published are only reflected in new cases. in 4.10 the changes were reflected in new and also ongoing cases

**Expected behavior**
- Change should be reflected in ongoing cases.

## Solution
- Added a version parameter (screen_version) to screen URLs, generated based on the latest published id of the screen.
- This approach forces the browser to treat each updated published screen as a new resource, preventing the use of outdated cached versions.

## How to Test
- Verify that screen updates generate new URLs with different version parameters, ensuring that changes are correctly fetched.
- Test across different browsers to confirm that old cached versions are not used.

## Related Tickets & Packages
- [FOUR-19110](https://processmaker.atlassian.net/browse/FOUR-19110)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/7427)

ci:next

[FOUR-19110]: https://processmaker.atlassian.net/browse/FOUR-19110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ