### PR TITLE
[40754] Links added to a Display screen set as a "screen for completed" in Web entries are not working

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -532,6 +532,7 @@ export default {
           } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
           }
+          this.disabled = false;
         });
     },
     emitIfTaskCompleted(requestId) {


### PR DESCRIPTION
## Issue & Reproduction Steps
The Disabled variable remained set to true after clicking submit.

Expected behavior: 
Links should be clickable
Actual behavior: 
Can't click on links
## Solution
- Set disabled after load next assigned task

## How to Test
step in ticket
## Related Tickets & Packages
- [FOUR-19407](https://processmaker.atlassian.net/browse/FOUR-19407)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy
[FOUR-19407]: https://processmaker.atlassian.net/browse/FOUR-19407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ