### PR TITLE
FOUR-14970 Replace regex with dot_notation validator

### DIFF
--- a/src/form-control-common-properties.js
+++ b/src/form-control-common-properties.js
@@ -96,8 +96,8 @@ export const keyNameProperty = {
   config: {
     label: 'Variable Name',
     name: 'Variable Name',
-    // Update tests/e2e/specs/Builder.spec.js when changing this
-    validation: 'regex:/^([a-zA-Z]([a-zA-Z0-9_]?)+\\.?)+(?<!\\.)$/|required|not_in:' + javascriptReservedKeywords,
+    // Update tests/e2e/specs/Builder.spec.js when changing dot_notation
+    validation: 'dot_notation|required|not_in:' + javascriptReservedKeywords,
     helper: 'A variable name is a symbolic name to reference information.',
   },
 };

--- a/tests/e2e/specs/Builder.spec.js
+++ b/tests/e2e/specs/Builder.spec.js
@@ -71,7 +71,9 @@ describe("Screen Builder", () => {
       "aaa._.ccc",
       "aaa..ccc",
       "aaa.123.ccc",
-      "aaa.1.ccc"
+      "aaa.1.ccc",
+      ".",
+      ".aaa",
     ].forEach((name) => {
       cy.get("[data-cy=inspector-name]").clear().type(name);
       cy.get("[data-cy=inspector-name]").should("have.class", "is-invalid");


### PR DESCRIPTION
## Issue & Reproduction Steps
A variable with too many nested objects (dots) in the name was causing the screen to freeze. This was because the regex used to validate the string was inefficient.

## Solution
- Replace the regex with a custom validator function

## How to Test
See jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14970
- Requires: https://github.com/ProcessMaker/vue-form-elements/pull/438

ci:next
ci:deploy
ci:vue-form-elements:bugfix/FOUR-14970


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
