### PR TITLE
Set self-service property on mounted

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -1001,6 +1001,7 @@ export default {
     this.requestData = this.value;
     this.loopContext = this.initialLoopContext;
     this.loadTask(true);
+    this.setSelfService();
   },
   destroyed() {
     this.unsubscribeSocketListeners();


### PR DESCRIPTION
## Issue & Reproduction Steps
See Jira Issue

Expected behavior: 
Unclaimed self-service tasks should not be editable

Actual behavior: 
Thee self -serve task allowed editing before being claimed

## Solution
- Call setSelfService on mounted

## How to Test
See jira issue

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19478

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
