### PR TITLE
Filter Screen Templates Based on Screen Type in Screen Builder

### DIFF
--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -87,8 +87,19 @@
     components: {
       ScreenTemplateCard,
     },
-    props: ['screenId', 'currentScreenPage', 'screenType'],
-    mounted() {
+    props: {
+      screenId: {
+        type: Number,
+        required: true,
+      },
+      currentScreenPage: {
+        type: Number,   
+        default: 0,
+      },
+      screenType: {
+        type: String,   
+        default: 'FORM',
+      }
     },
     data() {
       return {

--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -87,7 +87,7 @@
     components: {
       ScreenTemplateCard,
     },
-    props: ['screenId', 'currentScreenPage'],
+    props: ['screenId', 'currentScreenPage', 'screenType'],
     mounted() {
     },
     data() {
@@ -109,7 +109,7 @@
       fetchMyTemplates() {
         ProcessMaker.apiClient
         .get(
-          "templates/screen?is_public=0",
+          `templates/screen?is_public=0&screen_type=${this.screenType}`,
         )
         .then((response) => {
           this.myTemplatesData = response.data.data;
@@ -124,7 +124,7 @@
       fetchSharedTemplates() {
       ProcessMaker.apiClient
         .get(
-          "templates/screen?is_public=1",
+          `templates/screen?is_public=1&screen_type=${this.screenType}`,
         )
         .then((response) => {
           this.sharedTemplatesData = response.data.data;

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -303,6 +303,7 @@
               :shared-templates-data="sharedTemplatesData"
               @close-templates-panel="closeTemplatesPanel"
               :screen-id="screen.id"
+              :screen-type="screen.type"
               :currentScreenPage="currentPage"
             />
           </b-card-body>

--- a/tests/e2e/specs/ScreenTemplateSection.spec.js
+++ b/tests/e2e/specs/ScreenTemplateSection.spec.js
@@ -25,10 +25,9 @@ it("Displays My Templates when My Templates button is clicked", () => {
 
   cy.get("[data-cy=screen-templates]").click();
   cy.get("[data-cy=screen-templates-section]").should("be.visible");
-  
   cy.intercept(
     "GET",
-    "/api/1.0/templates/screen?is_public=0",
+    "/api/1.0/templates/screen?is_public=0&screen_type=FORM",
     {
       statusCode: 200,
       body: {
@@ -44,7 +43,7 @@ it("Displays My Templates when My Templates button is clicked", () => {
           media: [],
           name: "My Templates Test",
           screen_custom_css: null,
-          screen_type: "EMAIL",
+          screen_type: "FORM",
           template_media: [],
           updated_at: "2024-09-10T18:18:27+00:00",
           user_id: 1,
@@ -73,7 +72,7 @@ it("Displays Shared Templates when Shared Templates button is clicked", () => {
   
   cy.intercept(
     "GET",
-    "/api/1.0/templates/screen?is_public=1",
+    "/api/1.0/templates/screen?is_public=1&screen_type=FORM",
     {
       statusCode: 200,
       body: {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR updates the filtering of screen templates to ensure that only templates compatible with the current screen type (e.g., FORM, DISPLAY, EMAIL) are visible in the "My Templates" and "Shared Templates" sections of Screen Builder. This helps users by showing only relevant templates based on the type of screen they are working on.

## Solution
- Added the `screen-type` property to the `screen-templates` component.
- Implemented the `screenType` filter in API requests for both "My Templates" and "Shared Templates".

## How to Test
1. Create Screen Templates
2. Ensure screen templates are available for various screen types such as FORM, DISPLAY, EMAIL, etc.
3. Create or navigate to a screen using a specific screen type (e.g., DISPLAY).
4. Select the "Templates" option in the navigation bar.
5. In the "My Templates" section, confirm that only templates created for the current screen type (e.g., DISPLAY) are listed.
6. Select the "Shared Templates" tab and confirm that only templates created for the same screen type are displayed.
7. Repeat the above steps for other screen types (e.g., FORM, EMAIL) to ensure the filtering works across all types.


## Related Tickets & Packages
-  [FOUR-19177](https://processmaker.atlassian.net/browse/FOUR-19177)

ci:next
ci:processmaker:epic/FOUR-18012
ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-19177]: https://processmaker.atlassian.net/browse/FOUR-19177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ