### PR TITLE
FOUR-19135 | Add Loading Spinner to Screen Templates Panel During Templates Fetch

### DIFF
--- a/src/components/ScreenTemplates.vue
+++ b/src/components/ScreenTemplates.vue
@@ -38,6 +38,9 @@
         data-cy="my-templates-list"
       >
         <b-card-group>
+          <b-card-body v-if="loading" class="d-flex justify-content-center">
+            <b-spinner variant="primary" label="Spinning"></b-spinner>
+          </b-card-body>
           <b-card-body
             v-if="noMyTemplatesFound"
             class="p-2 h-100 overflow-auto"
@@ -60,6 +63,9 @@
         data-cy="shared-templates-list"
       >
         <b-card-group>
+          <b-card-body v-if="loading" class="d-flex justify-content-center">
+            <b-spinner variant="primary" label="Spinning"></b-spinner>
+          </b-card-body>
           <b-card-body
             v-if="noSharedTemplatesFound"
             class="p-2 h-100 overflow-auto"
@@ -109,6 +115,7 @@
         sharedTemplatesSelected: false,
         noMyTemplatesFound: false,
         noSharedTemplatesFound: false,
+        loading: false,
       };
     },
     methods: {
@@ -118,34 +125,42 @@
         this.fetchMyTemplates();
       },
       fetchMyTemplates() {
+        this.loading = true;
         ProcessMaker.apiClient
-        .get(
-          `templates/screen?is_public=0&screen_type=${this.screenType}`,
-        )
-        .then((response) => {
-          this.myTemplatesData = response.data.data;
-          if (this.myTemplatesData.length === 0 || this.myTemplatesData === undefined) {
-            this.noMyTemplatesFound = true;
+          .get(
+            `templates/screen?is_public=0&screen_type=${this.screenType}`,
+          )
+          .then((response) => {
+            this.myTemplatesData = response.data.data;
+            if (this.myTemplatesData.length === 0 || this.myTemplatesData === undefined) {
+              this.noMyTemplatesFound = true;
           }
         })
         .catch((error) => {
           console.error(error);
+        })
+        .finally(() => {
+          this.loading = false;
         });
       },
       fetchSharedTemplates() {
-      ProcessMaker.apiClient
-        .get(
-          `templates/screen?is_public=1&screen_type=${this.screenType}`,
-        )
-        .then((response) => {
-          this.sharedTemplatesData = response.data.data;
-          if (this.sharedTemplatesData.length === 0 || this.sharedTemplatesData === undefined) {
-            this.noSharedTemplatesFound = true;
-          }
-        })
-        .catch((error) => {
-          console.error(error);
-        });
+        this.loading = true;
+        ProcessMaker.apiClient
+          .get(
+            `templates/screen?is_public=1&screen_type=${this.screenType}`,
+          )
+          .then((response) => {
+            this.sharedTemplatesData = response.data.data;
+            if (this.sharedTemplatesData.length === 0 || this.sharedTemplatesData === undefined) {
+              this.noSharedTemplatesFound = true;
+            }
+          })
+          .catch((error) => {
+            console.error(error);
+          })
+          .finally(() => {
+            this.loading = false;
+          });
       },
       showSharedTemplates() {
         this.myTemplatesSelected = false;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-19135](https://processmaker.atlassian.net/browse/FOUR-19135)

When fetching My Templates and Shared Templates via the Templates Panel, there is no indicator to show that the templates are loading or being fetched. If a user has a large number of templates, they may see a blank panel before the templates are loaded.


# Solution
Add a `<b-spinner>` component to the My Templates and Shared Templates Panels, indicating that templates are being fetched/loaded.

# How to Test
1. Go to branch `observation/FOUR-19135` in `screen-builder`.
2. Go to Designer → Screens. Open a Screen to edit.
3. Select 'Templates' from the top menu bar.
4. When 'My Templates' are loading, a spinner should appear.
5. Select 'Shared Templates'. 
	- When the Shared Templates are loading, a spinner should appear.

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.