### PR TITLE
Bugfix/FOUR-19277: Collection Record control displays different errors when mustache variable is assigned in the `record ID` field

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -156,6 +156,7 @@ export default {
     },
     callbackRecord() {
       this.hasMustache = true;
+      //console.log("en callbackRecord this.selCollectionId: ", this.selCollectionId);
       this.loadRecordCollection(this.selCollectionId, 1, this.selDisplayMode);
     },
     errors() {
@@ -212,9 +213,9 @@ export default {
     },
     record(record) {
       this.hasMustache = false;
-      if (record && !isNaN(record) && record > 0 && this.collection) {
+      if (record && !isNaN(record) && record > 0 && this.collection.collectionId) {
         this.selRecordId = record;
-        this.loadRecordCollection(this.selCollectionId, record, this.collectionmode);
+        this.loadRecordCollection(this.collection.collectionId, record, this.collectionmode);
       } else {
         if (this.isMustache(record)) {
           this.callbackRecord();
@@ -226,6 +227,7 @@ export default {
       if(collectionmode) {
         this.selDisplayMode = collectionmode.modeId;
       }
+      //console.log("en collectionmode: ", this.selCollectionId);
       this.loadRecordCollection(this.selCollectionId, this.selRecordId, this.selDisplayMode);
     },
   },
@@ -235,6 +237,7 @@ export default {
     });
 
     if (this.collection && this.record) {
+      //console.log("en mounted this.collection.collectionId: ", this.collection.collectionId);
       this.loadRecordCollection(this.collection.collectionId, this.record, this.collectionmode.modeId);
     }
   },

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -16,7 +16,7 @@
 <script>
 import VueFormRenderer from "../vue-form-renderer.vue";
 import CollectionRecordsList from "../inspector/collection-records-list.vue";
-
+import _ from 'lodash';
 const globalObject = typeof window === "undefined" ? global : window;
 
 const defaultConfig = [
@@ -156,7 +156,6 @@ export default {
     },
     callbackRecord() {
       this.hasMustache = true;
-      //console.log("en callbackRecord this.selCollectionId: ", this.selCollectionId);
       this.loadRecordCollection(this.selCollectionId, 1, this.selDisplayMode);
     },
     errors() {
@@ -180,7 +179,7 @@ export default {
               this.selDisplayMode === "View" ? viewScreen : editScreen;
           
           this.loadScreen(this.screenCollectionId);
-
+         
           //This section validates if Collection has draft data
           if(this.taskDraft?.draft?.data == null || this.taskDraft.draft.data === '') {
             this.localData = respData;
@@ -215,7 +214,7 @@ export default {
       this.hasMustache = false;
       if (record && !isNaN(record) && record > 0 && this.collection.collectionId) {
         this.selRecordId = record;
-        this.loadRecordCollection(this.collection.collectionId, record, this.collectionmode);
+        this.loadRecordCollection(this.collection.collectionId, record, this.selDisplayMode);
       } else {
         if (this.isMustache(record)) {
           this.callbackRecord();
@@ -227,7 +226,6 @@ export default {
       if(collectionmode) {
         this.selDisplayMode = collectionmode.modeId;
       }
-      //console.log("en collectionmode: ", this.selCollectionId);
       this.loadRecordCollection(this.selCollectionId, this.selRecordId, this.selDisplayMode);
     },
   },
@@ -237,7 +235,6 @@ export default {
     });
 
     if (this.collection && this.record) {
-      //console.log("en mounted this.collection.collectionId: ", this.collection.collectionId);
       this.loadRecordCollection(this.collection.collectionId, this.record, this.collectionmode.modeId);
     }
   },

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -16,7 +16,7 @@
 <script>
 import VueFormRenderer from "../vue-form-renderer.vue";
 import CollectionRecordsList from "../inspector/collection-records-list.vue";
-import _ from 'lodash';
+
 const globalObject = typeof window === "undefined" ? global : window;
 
 const defaultConfig = [

--- a/src/components/renderer/form-collection-view-control.vue
+++ b/src/components/renderer/form-collection-view-control.vue
@@ -206,9 +206,9 @@ export default {
     },
     record(record) {
       this.hasMustache = false;
-      if (record && !isNaN(record) && record > 0 && this.collection) {
+      if (record && !isNaN(record) && record > 0 && this.collection.collectionId) {
         this.selRecordId = record;
-        this.loadRecordCollection(this.selCollectionId, record, this.collectionmode);
+        this.loadRecordCollection(this.collection.collectionId, record, this.collectionmode);
       } else {
         if (this.isMustache(record)) {
           this.callbackRecord();


### PR DESCRIPTION


## Solution
- Record ID field support mustache syntax

## How to Test
- Login PM4
- Go to Designer->screens
- Select an existing screen or create one in mode FORM
- Drag Collection Record Control
- Select a Collection
- In Record ID field enter {{ id_record }}
- Drag an input field and rename as id_record
- Go to Preview Button, and type some Number in the input field
- The Collections fields must be shown

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19277

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
