### PR TITLE
FOUR-19756: Message COPIED doesn't appear when a control is added to Clipboard

### DIFF
--- a/src/components/editor/loop.vue
+++ b/src/components/editor/loop.vue
@@ -27,6 +27,15 @@
                 class="mr-2 ml-1"
               />
               {{ element.config.name || $t("Variable Name") }}
+              <b-badge
+                v-if="isInClipboard(items[index])"
+                data-cy="copied-badge"
+                class="m-2 custom-badge"
+                pill
+              >
+                <i class="far fa-check-circle"></i>
+                <span class="pl-2">{{ $t('Copied')}}</span>
+              </b-badge>
               <div class="ml-auto">
                 <clipboard-button
                   :index="index"
@@ -91,6 +100,15 @@
                 class="mr-2 ml-1"
               />
               {{ element.config.name || $t("Variable Name") }}
+              <b-badge
+                v-if="isInClipboard(items[index])"
+                data-cy="copied-badge"
+                class="m-2 custom-badge"
+                pill
+              >
+                <i class="far fa-check-circle"></i>
+                <span class="pl-2">{{ $t('Copied')}}</span>
+              </b-badge>
               <div class="ml-auto">
                 <clipboard-button
                   :index="index"
@@ -333,5 +351,13 @@ export default {
   100% {
     box-shadow: 0 0 0 13px rgba(0, 0, 0, 0);
   }
+}
+.custom-badge {
+  background-color: #D1F4D7 !important;
+  color: #06723A !important;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 14px;
 }
 </style>

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -42,6 +42,15 @@
                       class="mr-2 ml-1"
                     />
                     {{ element.config.name || $t("Variable Name") }}
+                    <b-badge
+                      v-if="isInClipboard(element)"
+                      data-cy="copied-badge"
+                      class="m-2 custom-badge"
+                      pill
+                    >
+                      <i class="far fa-check-circle"></i>
+                      <span class="pl-2">{{ $t('Copied')}}</span>
+                    </b-badge>
                     <div class="ml-auto">
                       <clipboard-button
                         :index="index"
@@ -108,6 +117,15 @@
                       class="mr-2 ml-1"
                     />
                     {{ element.config.name || $t("Variable Name") }}
+                    <b-badge
+                      v-if="isInClipboard(element)"
+                      data-cy="copied-badge"
+                      class="m-2 custom-badge"
+                      pill
+                    >
+                      <i class="far fa-check-circle"></i>
+                      <span class="pl-2">{{ $t('Copied')}}</span>
+                    </b-badge>
                     <div class="ml-auto">
                       <clipboard-button
                         :index="index"
@@ -374,5 +392,13 @@ export default {
   100% {
     box-shadow: 0 0 0 13px rgba(0, 0, 0, 0);
   }
+}
+.custom-badge {
+  background-color: #D1F4D7 !important;
+  color: #06723A !important;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 14px;
 }
 </style>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -202,7 +202,7 @@
                   />
                   {{ element.config.name || element.label || $t("Field Name") }}
                   <b-badge
-                    v-if="isInClipboard(extendedPages[tabPage].items[index])"
+                    v-if="!isClipboardPage(tabPage) && isInClipboard(extendedPages[tabPage].items[index])"
                     data-cy="copied-badge"
                     class="m-2 custom-badge"
                     pill
@@ -276,7 +276,7 @@
                   />
                   {{ element.config.name || $t("Variable Name") }}
                   <b-badge
-                    v-if="isInClipboard(extendedPages[tabPage].items[index])"
+                    v-if="!isClipboardPage(tabPage) && isInClipboard(extendedPages[tabPage].items[index])"
                     data-cy="copied-badge"
                     class="m-2 custom-badge"
                     pill

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -201,6 +201,15 @@
                     class="mr-2 ml-1"
                   />
                   {{ element.config.name || element.label || $t("Field Name") }}
+                  <b-badge
+                    v-if="isInClipboard(extendedPages[tabPage].items[index])"
+                    data-cy="copied-badge"
+                    class="m-2 custom-badge"
+                    pill
+                  >
+                    <i class="far fa-check-circle"></i>
+                    <span class="pl-2">{{ $t('Copied')}}</span>
+                  </b-badge>
                   <div class="ml-auto">
                     <clipboard-button
                       v-if="!isClipboardPage(tabPage)"
@@ -266,6 +275,15 @@
                     class="mr-2 ml-1"
                   />
                   {{ element.config.name || $t("Variable Name") }}
+                  <b-badge
+                    v-if="isInClipboard(extendedPages[tabPage].items[index])"
+                    data-cy="copied-badge"
+                    class="m-2 custom-badge"
+                    pill
+                  >
+                    <i class="far fa-check-circle"></i>
+                    <span class="pl-2">{{ $t('Copied')}}</span>
+                  </b-badge>
                   <div class="ml-auto">
                     <clipboard-button
                       v-if="!isClipboardPage(tabPage)"
@@ -1744,5 +1762,13 @@ $side-bar-font-size: 0.875rem;
 .gray-text.disabled {
   cursor: not-allowed; /* Cambia el cursor cuando se pasa por encima */
   pointer-events: all; /* Permite que el pseudo-elemento reciba eventos del ratón */
+}
+.custom-badge {
+  background-color: #D1F4D7 !important;
+  color: #06723A !important;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  font-weight: 500;
+  font-size: 14px;
 }
 </style>

--- a/tests/e2e/specs/Clipboard.spec.js
+++ b/tests/e2e/specs/Clipboard.spec.js
@@ -102,7 +102,7 @@ describe("Clipboard Button Actions", () => {
 
     // Step 4: Remove the form input from the clipboard
     cy.get('[data-cy="removeFromClipboard"]').should("be.visible");
-    cy.get('[data-cy="removeFromClipboard"]').click();
+    cy.get('[data-cy="removeFromClipboard"]').click({force: true});
     cy.get('[data-cy="removeFromClipboard"]').should("not.exist");
   });
 

--- a/tests/e2e/specs/Clipboard.spec.js
+++ b/tests/e2e/specs/Clipboard.spec.js
@@ -28,7 +28,7 @@ describe("Clipboard Button Actions", () => {
 
     // Step 4: Verify 'Remove from Clipboard' button is visible after adding to clipboard and then click it
     cy.get('[data-cy="removeFromClipboard"]').should("be.visible");
-    cy.get('[data-cy="removeFromClipboard"]').click();
+    cy.get('[data-cy="removeFromClipboard"]').click({force: true});
     cy.get('[data-cy="removeFromClipboard"]').should("not.exist");
   });
 

--- a/tests/e2e/specs/Clipboard.spec.js
+++ b/tests/e2e/specs/Clipboard.spec.js
@@ -73,7 +73,7 @@ describe("Clipboard Button Actions", () => {
 
     // Step 5: Remove the form input from the clipboard
     cy.get('[data-cy="removeFromClipboard"]').should("be.visible");
-    cy.get('[data-cy="removeFromClipboard"]').click();
+    cy.get('[data-cy="removeFromClipboard"]').click({force: true});
     cy.get('[data-cy="removeFromClipboard"]').should("not.exist");
   });
 

--- a/tests/e2e/specs/ClipboardTestCases.spec.js
+++ b/tests/e2e/specs/ClipboardTestCases.spec.js
@@ -61,31 +61,37 @@ describe("Clipboard Button Actions", () => {
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(2) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(3) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(4) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(5) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(6) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get("[data-test=page-dropdown").click();
     cy.get("[data-test=clipboard]").should("exist").click({ force: true });
@@ -111,32 +117,37 @@ describe("Clipboard Button Actions", () => {
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(2) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(3) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(4) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(5) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(6) > [data-cy="screen-element-container"]').click({ force: true });
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
-
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get("[data-test=page-dropdown").click();
     cy.get("[data-test=clipboard]").should("exist").click({ force: true });
@@ -158,6 +169,7 @@ describe("Clipboard Button Actions", () => {
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get("[data-test=page-dropdown").click();
     cy.get("[data-test=clipboard]").should("exist").click({ force: true });
@@ -178,11 +190,13 @@ describe("Clipboard Button Actions", () => {
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
     cy.get(':nth-child(2) > [data-cy="screen-element-container"]').click();
     cy.get('[data-cy="addToClipboard"]').should("be.visible");
     cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
+    cy.get('[data-cy="copied-badge"]').should("exist");
 
 
     cy.get("[data-test=page-dropdown").click();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The message “Copied“ should be displayed once a control is added to the Clipboard
Actual behavior: 
The message “Copied“ doesn’t appear when a control is added to the Clipboard
## Solution
- add Copied badge 

https://github.com/user-attachments/assets/c22be2a9-63f6-467a-b43d-9fc57f956577


## How to Test
defined in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19756

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:processmaker:release-2024-fall