### PR TITLE
bugfix/FOUR-19681: Add a message to indicates user that Collections won´t be available for Anonymous Web Entry

### DIFF
--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -1,13 +1,18 @@
 <template>
   <div>
     <div>
-      <label for="collection">{{ $t("Collection") }}</label>
-      <b-form-select
-        id="collection"
-        v-model="collectionId"
-        :options="collections"
-        data-cy="inspector-collection"
-      />
+      <label for="collection">{{ $t("Collection Name") }}</label>
+      <b-form-group>
+        <b-form-select
+          id="collection"
+          v-model="collectionId"
+          :options="collections"
+          data-cy="inspector-collection"
+        />
+        <b-form-text class="mt-2">
+        {{ $t("Collection Record Control is not available for Anonymous Web Entry") }} 
+        </b-form-text>
+    </b-form-group>
     </div>
     <div v-if="collectionId > 0" class="screen-link mt-2">
       <a 


### PR DESCRIPTION
## Solution
- The required tooltip was added to Collection name dropdown.

## How to Test
- Login PM4
- Go to Designer -> Screens
- Create or open a screen
- Drag Collection Record Control
- Click on Variable section in the inspector, and check the tooltip.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19681

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
