### PR TITLE
FOUR-19767: Clipboard isn't cleared after add a new control

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -127,6 +127,7 @@
             v-if="isClipboardPage(tabPage)"
             variant="link"
             @click="clearClipboard"
+            class="no-text-transform"
           >
             {{ $t('Clear All') }}
           </b-button>
@@ -1744,5 +1745,8 @@ $side-bar-font-size: 0.875rem;
 .gray-text.disabled {
   cursor: not-allowed; /* Cambia el cursor cuando se pasa por encima */
   pointer-events: all; /* Permite que el pseudo-elemento reciba eventos del ratón */
+}
+.no-text-transform {
+    text-transform: none;
 }
 </style>

--- a/src/mixins/Clipboard.js
+++ b/src/mixins/Clipboard.js
@@ -144,6 +144,7 @@ export default {
         }
       );
       if (confirm) {
+        this.clipboardPage.items = [];
         this.$store.dispatch("clipboardModule/clearClipboard");
         this.$root.$emit('update-clipboard');
       }

--- a/tests/e2e/specs/ClipboardTabClearAll.spec.js
+++ b/tests/e2e/specs/ClipboardTabClearAll.spec.js
@@ -1,0 +1,38 @@
+describe("Clipboard Page and clear all", () => {
+
+  
+
+  it("Verify that the controls created in the clipboard page were removed with clear all option", () => {
+    // Clear local storage
+    cy.clearLocalStorage();
+    cy.visit("/");
+    cy.openAcordeonByLabel("Input Fields");
+    
+    cy.get("[data-test=page-dropdown").click();
+    cy.get("[data-test=clipboard]").should("exist").click({ force: true });
+    // Step 1: Dragging controls to screen drop zone
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=editor-content]", { position: "bottom" });
+    cy.get("[data-cy=controls-FormSelectList]").drag("[data-cy=screen-element-container]", { position: "top" });
+    cy.get("[data-cy=controls-FormButton]").drag("[data-cy=screen-element-container]", { position: "top" });
+    cy.get("[data-cy=controls-FormTextArea]").drag("[data-cy=screen-element-container]", { position: "top" });
+    cy.get("[data-cy=controls-FormDatePicker]").drag("[data-cy=screen-element-container]", { position: "top" });
+    cy.get("[data-cy=controls-FormCheckbox]").drag("[data-cy=screen-element-container]", { position: "top" });
+
+  
+    cy.get('[data-cy="screen-element-container"]')
+      .children()
+      .should('have.length', 6);
+    cy.contains('button', 'Clear All').click();
+    cy.contains('button', 'Cancel').click();
+    cy.get('[data-cy="screen-element-container"]')
+      .children()
+      .should('have.length', 6);
+    cy.contains('button', 'Clear All').click();
+    cy.contains('button', 'Confirm').click();
+
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 0);
+  });
+
+});

--- a/tests/e2e/specs/ClipboardTabClearAll.spec.js
+++ b/tests/e2e/specs/ClipboardTabClearAll.spec.js
@@ -1,16 +1,20 @@
-describe("Clipboard Page and clear all", () => {
+describe("Clipboard Page and Clear All Functionality", () => {
 
-  
-
-  it("Verify that the controls created in the clipboard page were removed with clear all option", () => {
-    // Clear local storage
+  it("should remove all controls in the clipboard page when 'Clear All' is confirmed", () => {
+    // Clear local storage to ensure a clean test environment
     cy.clearLocalStorage();
+
+    // Visit the home page
     cy.visit("/");
+
+    // Open the 'Input Fields' accordion section
     cy.openAcordeonByLabel("Input Fields");
-    
-    cy.get("[data-test=page-dropdown").click();
+
+    // Navigate to the clipboard page
+    cy.get("[data-test=page-dropdown]").click();
     cy.get("[data-test=clipboard]").should("exist").click({ force: true });
-    // Step 1: Dragging controls to screen drop zone
+
+    // Step 1: Dragging controls to the screen drop zone in the clipboard
     cy.get("[data-cy=controls-FormInput]").drag("[data-cy=editor-content]", { position: "bottom" });
     cy.get("[data-cy=controls-FormSelectList]").drag("[data-cy=screen-element-container]", { position: "top" });
     cy.get("[data-cy=controls-FormButton]").drag("[data-cy=screen-element-container]", { position: "top" });
@@ -18,21 +22,21 @@ describe("Clipboard Page and clear all", () => {
     cy.get("[data-cy=controls-FormDatePicker]").drag("[data-cy=screen-element-container]", { position: "top" });
     cy.get("[data-cy=controls-FormCheckbox]").drag("[data-cy=screen-element-container]", { position: "top" });
 
-  
-    cy.get('[data-cy="screen-element-container"]')
-      .children()
-      .should('have.length', 6);
+    // Verify that all controls have been successfully added
+    cy.get('[data-cy="screen-element-container"]').children().should('have.length', 6);
+
+    // Step 2: Attempt to clear all controls but cancel the action
     cy.contains('button', 'Clear All').click();
     cy.contains('button', 'Cancel').click();
-    cy.get('[data-cy="screen-element-container"]')
-      .children()
-      .should('have.length', 6);
+
+    // Ensure controls are still present after canceling
+    cy.get('[data-cy="screen-element-container"]').children().should('have.length', 6);
+
+    // Step 3: Confirm clearing all controls
     cy.contains('button', 'Clear All').click();
     cy.contains('button', 'Confirm').click();
 
-    cy.get('[data-cy="editor-content"]')
-      .children()
-      .should('have.length', 0);
+    // Validate that all controls have been removed
+    cy.get('[data-cy="editor-content"]').children().should('have.length', 0);
   });
-
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The Clipboard should be cleared according to the PRD
Actual behavior: 
The Clipboard isn’t cleared after adding some controls to the Clipboard page
## Solution
- Clean clipboard page items after the user press clear all link

https://github.com/user-attachments/assets/22efd489-af43-4464-b947-d3fa9f3c7483


## How to Test
defined in the related ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19767

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
