### PR TITLE
FOUR-19784: Clipboard Pasted Successfully message isn't displayed

### DIFF
--- a/src/mixins/Clipboard.js
+++ b/src/mixins/Clipboard.js
@@ -115,6 +115,9 @@ export default {
             // replace uuids in clipboard content
             clipboardContent.forEach(this.updateUuids);
             page.items.splice(index, 1, ...clipboardContent);
+            if (clipboardContent.length) {
+              window.ProcessMaker.alert(this.$t("Clipboard Pasted Succesfully"), "success");
+            }
           }
           if (item.items) {
             replaceInPage(item);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The Clipboard Pasted Successfully message should be displayed after d&d the Clipboard control according to the Figma
Actual behavior: 
The Clipboard Pasted Successfully message isn’t displayed
## Solution
- add  window.ProcessMaker.alert to display the message

https://github.com/user-attachments/assets/0868cc45-52b8-4751-8fa3-f633dea8e9b2


## How to Test
described in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19784

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
