### PR TITLE
bugfix/FOUR-19806: Collection columns not selected in Edit Screens are deleted when Draft data is recovered in task using CollectionRecordControl

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -16,6 +16,7 @@
 <script>
 import VueFormRenderer from "../vue-form-renderer.vue";
 import CollectionRecordsList from "../inspector/collection-records-list.vue";
+import _ from 'lodash';
 
 const globalObject = typeof window === "undefined" ? global : window;
 
@@ -184,7 +185,7 @@ export default {
           if(this.taskDraft?.draft?.data == null || this.taskDraft.draft.data === '') {
             this.localData = respData;
           }else{
-            this.localData = this.taskDraft.draft.data;
+            this.localData = _.merge({}, respData, this.taskDraft.draft.data);
           }
           
         })


### PR DESCRIPTION
Expected behavior: 
- When a task with Collection Record Control has data recovered from DRAFT, once Form is submited, only fields displayed in the screen must be updated in Collection's Table.


## Solution
- Only fields on the collection edit screen are updated, and fields that are not displayed remain unchanged in the database.

## How to Test
-Login PM4
- Go to Designer-> screens
- Create or use previous screens
- Drag Collection Record Control
- Choose a collection that does not show all its fields on screen in Edit Mode and with "Update on submit" checked
- Save and Start a case with that screen
-  Change values from collection fields and wait for auto save as Draft.
- Reload the Screen to recover Draft data
- Submit the form
- Go to Collections and review all Collection Fields remain correct (There should be no columns removed after submit)

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19806

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
..