### PR TITLE
FOUR-19749 Missed label 'Users/Groups to View Encrypted Fields'

### DIFF
--- a/src/components/inspector/encrypted-config.vue
+++ b/src/components/inspector/encrypted-config.vue
@@ -13,7 +13,7 @@
       <div v-if="settings.encrypted">
         <select-user-group
           :key="componentKey"
-          :label="$t('Users/Groups to View')"
+          :label="$t('Users/Groups to View Encrypted Fields')"
           v-model="settings.assignments"
           :multiple="true"
           @input="emitChanges"


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to screen designer
- Add or edit a line input field
- Enable "encrypted" in "Advanced" section

Expected behavior: 
Should be displayed the label "Users/Groups to View Encrypted Fields"

Actual behavior: 
Is displayed the label "Users/Groups to View"

## Solution
Update label

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19749

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
