### PR TITLE
Bugfix/FOUR-19847: `column` field is not reset when `single field of record` is changed by `single record`

### DIFF
--- a/src/components/inspector/collection-data-source.vue
+++ b/src/components/inspector/collection-data-source.vue
@@ -194,6 +194,9 @@
         },
         deep: true
       },
+      dataSelectionOptions() {
+        this.singleField = null;
+      }
     },
   };
   </script>

--- a/src/components/inspector/collection-designer-mode.vue
+++ b/src/components/inspector/collection-designer-mode.vue
@@ -36,6 +36,9 @@
       ],
       };
     },
+    mounted () {
+      this.callBuilder(this.designerOptions);
+    },
     computed: {
       options() {
         return Object.fromEntries(
@@ -56,10 +59,15 @@
       options: {
         handler() {
           this.$emit("input", this.options);
-          this.$root.$emit("style-mode", this.options.designerOptions);
+          this.callBuilder(this.options.designerOptions);
         },
         deep: true
       },
     },
+    methods: {
+      callBuilder(option) {
+        this.$root.$emit("style-mode", option);
+      }
+    }
   };
   </script>

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -888,7 +888,7 @@ export default {
     },
     shouldShow(item, accordion) {
       const sourceOptions = this.inspection.config[item.field]?.sourceOptions;
-      //console.log("INICIO this.styleMode: ", this.styleMode);
+
       if (sourceOptions === 'Variable') {
         this.enableOption = true;
         return true;

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -245,7 +245,9 @@
                   v-model="element.items"
                   :validation-errors="validationErrors"
                   class="card-body"
-                  :class="styleMode === 'Modern' ? elementCssClassModern(element) : elementCssClass(element)"
+                  :class="styleMode === 'Modern' && element.component === 'FormRecordList' 
+                    ? elementCssClassModern(element) 
+                    : elementCssClass(element)"
                   :selected="selected"
                   :config="element.config"
                   :ai-element="element"
@@ -299,7 +301,9 @@
                   :tabindex="element.config.interactive ? 0 : -1"
                   class="card-body m-0 pb-4 pt-4"
                   :class="[
-                    styleMode === 'Modern' ? elementCssClassModern(element) : elementCssClass(element),
+                    styleMode === 'Modern' && element.component === 'FormRecordList' 
+                    ? elementCssClassModern(element) 
+                    : elementCssClass(element),
                     { 'prevent-interaction': !element.config.interactive }
                   ]"
                   @input="
@@ -883,7 +887,7 @@ export default {
     },
     shouldShow(item, accordion) {
       const sourceOptions = this.inspection.config[item.field]?.sourceOptions;
-
+      //console.log("INICIO this.styleMode: ", this.styleMode);
       if (sourceOptions === 'Variable') {
         this.enableOption = true;
         return true;


### PR DESCRIPTION
## Solution
- Column field is reset when Data selection options are changed
- Design option in Inspector shows the respective colors of the selected option in Table Style Dropdown
## How to Test

TEST 1

-Login PM4
- Go to Designer-> screens
- Create or use previous screens
- Drag Collection Record List and change name to "list"
- Select some Collection and create some Columns to display
- In configuration option, Select 'Single field of record' in Data Selection Dropdown
- Select some column in dropdown Column
- Select a Rich Text and wrap in mustache syntax {{list}}
- Click on preview, and select one row. The value of column selected should be displayed on rich text
- Now change Data Selection dropdown to "Single Record" option
- Change Rich Text mustache syntax to {{list.NameOfCollectionColumn}}
- Click on Preview and select one row. The value of column selected should be displayed on rich text

TEST 2

- In the same Screen, keeping test 1 changes, click on Record List
- Go to Design and select "MODERN"
- Choose one color
- Header background color of Record List must change
- Save the screen, and refresh the page.
- Once Screen loads again, click on Record List, go to Design.
- Dropdown must display MODERN option.
- Add a Input Field to the screen
- Go to Design. There should be no any dropdown to select Modern or Classic.
- Chose some Text and Background colors for input field. Record List and Input field styles should be independent.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19847

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
