### PR TITLE
FOUR-19011: Case completed message is not displayed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -843,7 +843,6 @@ export default {
      * @param {Object} data - The event data received from the socket listener.
      */
     handleRedirect(data) {
-      debugger;
       switch (data.method) {
         case 'redirectToTask':
           this.handleRedirectToTask(data);
@@ -852,7 +851,6 @@ export default {
           this.handleProcessUpdated(data);
           break;
         case 'processCompletedRedirect':
-          debugger;
           this.processCompletedRedirect(
             data.params[0],
             this.userId,

--- a/src/main.js
+++ b/src/main.js
@@ -325,6 +325,14 @@ window.Echo = {
       }, 1000);
     });
   },
+
+  eventMockNext(event, response) {
+    this.listeners.forEach((listener) => {
+      setTimeout(() => {
+        listener.callback(response);
+      }, 1000);
+    });
+  },
   private() {
     return {
       notification(callback) {

--- a/tests/components/TaskWebEntry.vue
+++ b/tests/components/TaskWebEntry.vue
@@ -1,0 +1,107 @@
+<template>
+  <b-row>
+    <b-col cols="8">
+      <b-tabs>
+        <b-tab active title="Form">
+          <task
+            v-model="data"
+            :initial-request-id="task.process_request.id"
+            :initial-task-id="task.id"
+            @submit="submit"
+            :is-web-entry="true"
+            @completed="completed"
+          />
+        </b-tab>
+        <b-tab title="Data">
+          <monaco-editor
+            class="data-editor"
+            language="json"
+            :value="JSON.stringify(data, null, 4)"
+            :options="{ automaticLayout: true, minimap: { enabled: false } }"
+          />
+          <div class="text-right">
+            <b-button variant="secondary">{{ __("Save") }}</b-button>
+          </div>
+        </b-tab>
+      </b-tabs>
+    </b-col>
+  </b-row>
+</template>
+
+<script>
+import moment from "moment";
+import MonacoEditor from "vue-monaco";
+import Screens from "../e2e/fixtures/webentry.json";
+
+export default {
+  components: { MonacoEditor },
+  data() {
+    return {
+      data: {},
+      task: {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        created_at: moment().toISOString(),
+        completed_at: moment().toISOString(),
+        due_at: moment().add(1, "day").toISOString(),
+        user: {
+          avatar: "",
+          fullname: "Assigned User"
+        },
+        screen: Screens.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE",
+          user: {
+            avatar: "",
+            fullname: "Requester User"
+          }
+        },
+        process: {
+          id: 1,
+          name: "Process Name"
+        },
+        request_data: {}
+      }
+    };
+  },
+  methods: {
+    completed(e){
+      console.log('task was completed', e);
+    },
+    moment(...args) {
+      return moment(...args);
+    },
+    __(text) {
+      return text;
+    },
+    formatDate(date) {
+      return moment(date).format("YYYY-MM-DD HH:mm");
+    },
+    submit(task) {
+      if (this.disabled) {
+        return;
+      }
+      this.disabled = true;
+      const taskId = task.id;
+      const formData = task.request_data;
+      window.ProcessMaker.apiClient
+        .put(`/tasks/${taskId}`, { status: "COMPLETED", data: formData })
+        .then(() => {
+          alert("Task Completed Successfully");
+        })
+        .finally(() => {
+          this.disabled = false;
+        });
+    }
+  }
+};
+</script>
+
+<style scoped>
+.data-editor {
+  border: 1px solid gray;
+  min-height: 400px;
+}
+</style>

--- a/tests/e2e/specs/EndEventRedirection.spec.js
+++ b/tests/e2e/specs/EndEventRedirection.spec.js
@@ -1,0 +1,344 @@
+import SingleScreen from "../fixtures/single_line_input.json";
+
+ function initializeTaskAndScreenIntercepts(method, url, response) {
+   cy.intercept(
+     method,
+     url.replace(",screen,", ",").replace(",nested,", ","),
+     response
+   );
+   cy.intercept(
+     method,
+     url.replace(/\?.*$/, "/screen?include=screen,nested"),
+     response.screen
+   );
+ }
+ describe("End Event Redirect (Process completed) ", () => {
+   it("Element destination type is summaryScreen", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'taskList',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type:"summaryScreen",
+           value: null
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/requests/1");
+   });
+   it("Element destination type is taskList", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'taskList',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type:"taskList",
+           value:"http://localhost:5173/tasks"
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/tasks");
+   });
+   it("Element destination type is processLaunchpad", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'taskList',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type:"processLaunchpad",
+           value: "http://localhost:5173/process-browser/7?categorySelected=-1"
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/process-browser/7?categorySelected=-1");
+   });
+   it("Element destination type is homepageDashboard", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'homepageDashboard',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type: "homepageDashboard",
+           value: "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP"
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP");
+   });
+   it("Element destination type is customDashboard", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'homepageDashboard',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type: "customDashboard",
+           value: "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP"
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP");
+   });
+   it("Element destination type is externalURL", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'homepageDashboard',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type: "externalURL",
+           value: "http://localhost:5173/about"
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.url().should("eq", "http://localhost:5173/about");
+   });
+   it("Element destination type is anotherProcess", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         id: 1,
+         advanceStatus: "open",
+         component: "task-screen",
+         allow_interstitial: false,
+         elementDestination: {
+           type: 'homepageDashboard',
+           value: 'http://localhost:5173/tasks',
+         },
+         user: {
+           id: 1
+         },
+         screen: SingleScreen.screens[0],
+         process_request: {
+           id: 1,
+           status: "ACTIVE"
+         }
+       }
+     );
+     cy.intercept(
+       "POST",
+       "http://localhost:5173/api/1.0/process_events/4?event=node_1",
+       {}
+     );
+     cy.intercept(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks?user_id=1&process_request_id=undefined&page=1&per_page=1&status=ACTIVE",
+       {
+         "data": [
+             {
+                 "id": 585,
+                 "uuid": "9ce21eaf-0991-495c-9f11-2e47b409acd5",
+                 "user_id": 1,
+                 "process_id": 7,
+                 "process_request_id": 194,
+                 "subprocess_request_id": null,
+                 "element_id": "node_117",
+                 "element_type": "task",
+                 "element_name": "Form Task 222",
+                 "status": "ACTIVE",
+                 "element_index": 0,
+                 "subprocess_start_event_id": null,
+                 "completed_at": null,
+                 "due_at": "2024-09-01T16:45:13+00:00",
+                 "due_notified": 0,
+                 "initiated_at": null,
+                 "riskchanges_at": "2024-08-31T18:45:13+00:00",
+                 "created_at": "2024-08-29T16:45:13+00:00",
+                 "updated_at": "2024-08-29T16:45:13+00:00",
+                 "version_id": 63,
+                 "version_type": "ProcessMaker\\Models\\ScreenVersion",
+                 "is_self_service": 0,
+                 "self_service_groups": [],
+                 "token_properties": [],
+                 "is_priority": false,
+                 "is_actionbyemail": false,
+                 "user_viewed_at": null,
+                 "advanceStatus": "open",
+                 "draft": null,
+                 "assignable_users": [
+                     3
+                 ],
+                 "can_view_parent_request": false,
+             }
+         ]
+       }
+     );
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         endEventDestination: {
+           type: "anotherProcess",
+           value: '{"calledElement":"ProcessId-4","processId":4,"startEvent":"node_1","name":"subprocess"}'
+         }
+       }],
+       method: "processCompletedRedirect"
+     });
+     cy.wait(1000);
+     cy.url().should("eq", "http://localhost:5173/tasks/585/edit");
+   });
+ });

--- a/tests/e2e/specs/InterstitialRedirect.spec.js
+++ b/tests/e2e/specs/InterstitialRedirect.spec.js
@@ -1,0 +1,374 @@
+import SingleScreen from "../fixtures/single_line_input.json";
+
+ function initializeTaskAndScreenIntercepts(method, url, response) {
+   cy.intercept(
+     method,
+     url.replace(",screen,", ",").replace(",nested,", ","),
+     response
+   );
+   cy.intercept(
+     method,
+     url.replace(/\?.*$/, "/screen?include=screen,nested"),
+     response.screen
+   );
+ }
+ describe("Interstitial", () => {
+   it("Load interstitial screen", () => {
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+       {
+         "advanceStatus": "open",
+         "id": 667,
+         "element_name": "Form Task 11",
+         "element_id": "node_92",
+         "element_type": "task",
+         "status": "ACTIVE",
+         "due_at": "2024-09-02T16:12:01.000000Z",
+         "process_request_id": 219,
+         "is_self_service": 0,
+
+         "user": {
+             "id": 1,
+             "firstname": "Admin",
+             "lastname": "User",
+             "email": "admin@processmaker.com",
+             "username": "admin",
+             "avatar": "",
+             "fullname": "Admin User"
+         },
+         "requestor": {
+             "id": 1,
+             "uuid": "9cd28c78-f74c-4731-b0e5-aa5e49df3f7e",
+             "email": "admin@processmaker.com",
+             "firstname": "Admin",
+             "lastname": "User",
+             "username": "admin",
+             "status": "ACTIVE",
+             "address": null,
+             "city": null,
+             "state": null,
+             "postal": null,
+             "country": null,
+             "phone": null,
+             "fax": null,
+             "cell": null,
+             "title": null,
+             "birthdate": null,
+             "timezone": "America\/Los_Angeles",
+             "datetime_format": "m\/d\/Y H:i",
+             "language": "en",
+             "meta": {
+             },
+             "connected_accounts": null,
+             "is_administrator": true,
+             "is_system": 0,
+             "expires_at": null,
+             "loggedin_at": "2024-08-30T14:01:18+00:00",
+             "active_at": "2024-08-30T16:12:13+00:00",
+             "remember_token": null,
+             "created_at": "2024-08-21T22:58:58+00:00",
+             "updated_at": "2024-08-23T15:06:58+00:00",
+             "deleted_at": null,
+             "delegation_user_id": null,
+             "manager_id": null,
+             "schedule": null,
+             "force_change_password": 0,
+             "avatar": "",
+             "password_changed_at": null,
+             "preferences_2fa": null,
+             "fullname": "Admin User"
+         },
+         "process_request": {
+             "id": 219,
+             "uuid": "9ce415cb-08cd-49c9-aff5-b97fb8362346",
+             "process_id": 7,
+             "user_id": 1,
+             "parent_request_id": null,
+             "status": "ACTIVE",
+             "do_not_sanitize": [
+                 "interstitial_message",
+                 " _user.fullname "
+             ],
+             "errors": null,
+             "completed_at": null,
+             "initiated_at": "2024-08-30T16:12:01+00:00",
+             "created_at": "2024-08-30T16:12:01+00:00",
+             "updated_at": "2024-08-30T16:12:01+00:00",
+             "case_title": "Case #207",
+             "case_number": 207,
+             "callable_id": "ProcessId",
+             "process_version_id": 143
+         },
+         "draft": null,
+         "component": "task-screen",
+      
+         "loop_context": "",
+         "definition": {
+             "outgoing": {},
+             "incoming": {},
+             "id": "node_92",
+             "name": "Form Task 11",
+             "screenRef": "33",
+             "allowInterstitial": "true",
+             "interstitialScreenRef": "22",
+             "assignment": "requester",
+             "assignmentLock": "false",
+             "allowReassignment": "false",
+             "config": "{\"web_entry\":null}",
+             "elementDestination": "{\"type\":\"taskSource\",\"value\":null}"
+         },
+         "bpmn_tag_name": "task",
+         "allow_interstitial": true,
+         "interstitial_screen": {
+             "id": 22,
+             "uuid": "9ca9bc5c-468e-4a11-8bb9-30a29494833d",
+             "screen_category_id": "1",
+             "title": "IDA - Dynamic Message - Interstitial Screen 7",
+             "description": "IDA - Dynamic Message - Interstitial Screen",
+             "type": "DISPLAY",
+             "config": [
+                 {
+                     "name": "Retrieving Invoices - Interstitial Screen",
+                     "items": [
+                         {
+                             "items": [
+                                 [],
+                                 [
+                                     {
+                                         "label": "Image",
+                                         "config": {
+                                             "icon": "fas fa-image",
+                                             "name": "Interstitial",
+                                             "event": "submit",
+                                             "label": "Image",
+                                             "value": null,
+                                             "width": "297.21",
+                                             "height": "220.61",
+                                             "variant": "primary",
+                                             "renderImage": false,
+                                             "customCssSelector": "imgInterstitial"
+                                         },
+                                         "component": "FormImage",
+                                         "editor-control": "FormImage",
+                                         "editor-component": "FormImage"
+                                     },
+                                     {
+                                         "label": "Rich Text",
+                                         "config": {
+                                             "icon": "fas fa-pencil-ruler",
+                                             "label": null,
+                                             "content": "<h3 style=\"text-align: center;\">{{interstitial_title}}<\/h3>",
+                                             "interactive": true,
+                                             "renderVarHtml": false,
+                                             "conditionalHide": null
+                                         },
+                                         "component": "FormHtmlViewer",
+                                         "editor-control": "FormHtmlEditor",
+                                         "editor-component": "FormHtmlEditor"
+                                     },
+                                     {
+                                         "label": "Rich Text",
+                                         "config": {
+                                             "icon": "fas fa-pencil-ruler",
+                                             "label": null,
+                                             "content": "<h5 style=\"text-align: center; padding: 20px 270px 20px 270px;\">{{interstitial_message}}<\/h5>",
+                                             "interactive": true,
+                                             "renderVarHtml": true,
+                                             "customCssSelector": null
+                                         },
+                                         "component": "FormHtmlViewer",
+                                         "editor-control": "FormHtmlEditor",
+                                         "editor-component": "FormHtmlEditor"
+                                     }
+                                 ],
+                                 []
+                             ],
+                             "label": "Multicolumn \/ Table",
+                             "config": {
+                                 "icon": "fas fa-table",
+                                 "label": null,
+                                 "options": [
+                                     {
+                                         "value": "1",
+                                         "content": "2"
+                                     },
+                                     {
+                                         "value": "2",
+                                         "content": "8"
+                                     },
+                                     {
+                                         "value": "3",
+                                         "content": "2"
+                                     }
+                                 ],
+                                 "customCssSelector": "fullbox"
+                             },
+                             "component": "FormMultiColumn",
+                             "container": true,
+                             "editor-control": "FormMultiColumn",
+                             "editor-component": "MultiColumn"
+                         }
+                     ],
+                     "order": 1
+                 }
+             ],
+             "computed": [
+                 {
+                     "id": 5,
+                     "name": "interstitial_title",
+                     "type": "javascript",
+                     "formula": "if(this.interstitial_title == null){\r\n    return \"We're getting the next task for you...\";\r\n}",
+                     "property": "interstitial_title"
+                 }
+             ],
+             "custom_css": "[selector='imgInterstitial']{\r\n     text-align: center;\r\n     padding-top: 10px;\r\n     padding-bottom: 30px;\r\n}\r\n[selector='fullbox']{\r\n     padding: 50px 10px 50px 10px;\r\n}\r\n[selector='text']{\r\n     max-width: 430px; \r\n     text-align: center;\r\n}",
+             "created_at": "2024-07-08T15:23:18+00:00",
+             "updated_at": "2024-08-21T22:59:40+00:00",
+             "status": "ACTIVE",
+             "key": null,
+             "watchers": [],
+             "translations": null,
+             "is_template": 0,
+             "asset_type": null,
+             "projects": "[]"
+         },
+         "user_request_permission": [
+             {
+                 "process_request_id": 219,
+                 "allowed": true
+             }
+         ],
+         "elementDestination": {
+             "type": "taskSource",
+             "value": "taskSource"
+         }
+       }
+     );
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/1/screen?include=screen,nested",
+       {
+         "id": 63,
+         "screen_id": 33,
+         "screen_category_id": 1,
+         "draft": 0,
+         "title": "first-form",
+         "description": "test",
+         "type": "FORM",
+         "config": [
+             {
+                 "name": "first-form",
+                 "items": [
+                     {
+                         "label": "Line Input",
+                         "config": {
+                             "icon": "far fa-square",
+                             "name": "form_input_1",
+                             "type": "text",
+                             "label": "New Input",
+                             "helper": null,
+                             "dataFormat": "string",
+                             "validation": null,
+                             "placeholder": null
+                         },
+                         "component": "FormInput",
+                         "editor-control": "FormInput",
+                         "editor-component": "FormInput"
+                     },
+                     {
+                         "label": "Submit Button",
+                         "config": {
+                             "icon": "fas fa-share-square",
+                             "name": null,
+                             "event": "submit",
+                             "label": "New Submit",
+                             "loading": false,
+                             "tooltip": [],
+                             "variant": "primary",
+                             "fieldValue": null,
+                             "loadingLabel": "Loading...",
+                             "defaultSubmit": true
+                         },
+                         "component": "FormButton",
+                         "editor-control": "FormSubmit",
+                         "editor-component": "FormButton"
+                     }
+                 ],
+                 "order": 1
+             }
+         ],
+         "computed": [],
+         "custom_css": null,
+         "created_at": "2024-08-22 15:00:04",
+         "updated_at": "2024-08-22 15:00:04",
+         "status": "ACTIVE",
+         "key": null,
+         "watchers": [],
+         "translations": null,
+         "is_template": 0,
+         "asset_type": null,
+         "nested": []
+       }
+     );
+     cy.visit("/?scenario=TaskRedirect", {});
+
+     cy.get(".form-group").find("button").click();
+     initializeTaskAndScreenIntercepts(
+       "GET",
+       "http://localhost:5173/api/1.1/tasks/2?include=data,user,draft,requestor,processRequest,component,requestData,loopContext,bpmnTagName,interstitial,definition,userRequestPermission,elementDestination",
+       {
+         "data": [
+             {
+                 "id": 585,
+                 "uuid": "9ce21eaf-0991-495c-9f11-2e47b409acd5",
+                 "user_id": 1,
+                 "process_id": 7,
+                 "process_request_id": 194,
+                 "subprocess_request_id": null,
+                 "element_id": "node_117",
+                 "element_type": "task",
+                 "element_name": "Form Task 222",
+                 "status": "ACTIVE",
+                 "element_index": 0,
+                 "subprocess_start_event_id": null,
+                 "completed_at": null,
+                 "due_at": "2024-09-01T16:45:13+00:00",
+                 "due_notified": 0,
+                 "initiated_at": null,
+                 "riskchanges_at": "2024-08-31T18:45:13+00:00",
+                 "created_at": "2024-08-29T16:45:13+00:00",
+                 "updated_at": "2024-08-29T16:45:13+00:00",
+                 "version_id": 63,
+                 "version_type": "ProcessMaker\\Models\\ScreenVersion",
+                 "is_self_service": 0,
+                 "self_service_groups": [],
+                 "token_properties": [],
+                 "is_priority": false,
+                 "is_actionbyemail": false,
+                 "user_viewed_at": null,
+                 "advanceStatus": "open",
+                 "draft": null,
+                 "assignable_users": [
+                     3
+                 ],
+                 "can_view_parent_request": false,
+             }
+         ]
+       }
+     );
+
+
+
+
+     cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+       params: [{
+         nodeId: 'node_2',
+         tokenId: 2,
+         userId: 1,
+       }],
+       method: "redirectToTask"
+     });
+     cy.get("[data-cy=screen-field-Interstitial").should('exist')
+   });
+ });

--- a/tests/e2e/specs/TaskRedirect.spec.js
+++ b/tests/e2e/specs/TaskRedirect.spec.js
@@ -1,0 +1,832 @@
+
+import SingleScreen from "../fixtures/single_line_input.json";
+
+function initializeTaskAndScreenIntercepts(method, url, response) {
+  cy.intercept(
+    method,
+    url.replace(",screen,", ",").replace(",nested,", ","),
+    response
+  );
+  cy.intercept(
+    method,
+    url.replace(/\?.*$/, "/screen?include=screen,nested"),
+    response.screen
+  );
+}
+describe("On Task Completed (Submitting Task) ", () => {
+  it("Element destination type is taskList", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: 'taskList',
+          value: 'http://localhost:5173/tasks',
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+
+    cy.visit("/?scenario=TaskRedirect", {});
+
+    cy.get(".form-group").find("button").click();
+
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/tasks");
+  });
+  it("Element destination type is processLaunchpad", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: 'processLaunchpad',
+          value: "http://localhost:5173/process-browser/7?categorySelected=-1",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+
+    cy.visit("/?scenario=TaskRedirect", {});
+
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/process-browser/7?categorySelected=-1");
+  });
+  it("Element destination type is homepageDashboard", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: 'homepageDashboard',
+          value: "http://localhost:5173",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+
+    cy.visit("/?scenario=TaskRedirect", {});
+
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/");
+  });
+  it("Element destination type is customDashboard", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: 'customDashboard',
+          value: "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+
+    cy.visit("/?scenario=TaskRedirect", {});
+
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/home/customize-ui/dashboards/eHEXsFrIwmClHoTRnMvOdMKSPbR3HalSFxaIHYxNh67UrtloUiuDBh5N8NrMoQVP");
+  });
+  it("Element destination type is externalURL", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: 'externalURL',
+          value: "http://localhost:5173/about",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+
+    cy.visit("/?scenario=TaskRedirect", {});
+
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/about");
+  });
+  it("Element destination type is taskSource case 1(redirect to task list if the next user is not assigned to the same user)" , () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: "taskSource",
+          value: "taskSource",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks?user_id=1&process_request_id=1&page=1&per_page=1&status=ACTIVE",
+      {
+    "data": [
+        {
+            "id": 585,
+            "uuid": "9ce21eaf-0991-495c-9f11-2e47b409acd5",
+            "user_id": 3,
+            "process_id": 7,
+            "process_request_id": 194,
+            "subprocess_request_id": null,
+            "element_id": "node_117",
+            "element_type": "task",
+            "element_name": "Form Task 222",
+            "status": "ACTIVE",
+            "element_index": 0,
+            "subprocess_start_event_id": null,
+            "completed_at": null,
+            "due_at": "2024-09-01T16:45:13+00:00",
+            "due_notified": 0,
+            "initiated_at": null,
+            "riskchanges_at": "2024-08-31T18:45:13+00:00",
+            "created_at": "2024-08-29T16:45:13+00:00",
+            "updated_at": "2024-08-29T16:45:13+00:00",
+            "version_id": 63,
+            "version_type": "ProcessMaker\\Models\\ScreenVersion",
+            "is_self_service": 0,
+            "self_service_groups": [],
+            "token_properties": [],
+            "is_priority": false,
+            "is_actionbyemail": false,
+            "user_viewed_at": null,
+            "advanceStatus": "open",
+            "process_request": {
+                "id": 194,
+                "uuid": "9ce21e35-087d-45dd-b1ed-f2874307e293",
+                "process_id": 7,
+                "process_collaboration_id": null,
+                "collaboration_uuid": null,
+                "user_id": 1,
+                "parent_request_id": null,
+                "participant_id": null,
+                "callable_id": "ProcessId",
+                "status": "ACTIVE",
+                "name": "processTL",
+                "do_not_sanitize": [],
+                "errors": null,
+                "completed_at": null,
+                "initiated_at": "2024-08-29T16:43:53+00:00",
+                "created_at": "2024-08-29T16:43:53+00:00",
+                "updated_at": "2024-08-29T16:45:13+00:00",
+                "process_version_id": 129,
+                "signal_events": [],
+                "case_title": "Case #182",
+                "case_number": 182,
+                "case_title_formatted": "Case #<b>182<\/b>",
+                "process": {
+                    "id": 7,
+                    "uuid": "9cdc0e74-0e60-4a33-a6e6-71c96b6b7330",
+                    "process_category_id": "2",
+                    "user_id": 1,
+                    "description": "test",
+                    "name": "processTL",
+                    "cancel_screen_id": null,
+                    "request_detail_screen_id": null,
+                    "status": "ACTIVE",
+                    "is_valid": 1,
+                    "package_key": null,
+                    "pause_timer_start": 0,
+                    "deleted_at": null,
+                    "created_at": "2024-08-26T16:24:52+00:00",
+                    "updated_at": "2024-08-29T16:43:37+00:00",
+                    "updated_by": 1,
+                    "start_events": [
+                        {
+                            "id": "node_91",
+                            "name": "Start Event",
+                            "config": "{\"web_entry\":null}",
+                            "ownerProcessId": "ProcessId",
+                            "eventDefinitions": [],
+                            "ownerProcessName": "ProcessName",
+                            "allowInterstitial": "false",
+                            "interstitialScreenRef": "1"
+                        }
+                    ],
+                    "self_service_tasks": [],
+                    "signal_events": [],
+                    "conditional_events": [],
+                    "properties": {
+                        "manager_id": "undefined"
+                    },
+                    "is_template": 0,
+                    "case_title": null,
+                    "launchpad_properties": null,
+                    "asset_type": null,
+                    "alternative": "A",
+                    "has_timer_start_events": false,
+                    "projects": "[]"
+                }
+            },
+            "process": {
+                "id": 7,
+                "uuid": "9cdc0e74-0e60-4a33-a6e6-71c96b6b7330",
+                "process_category_id": "2",
+                "user_id": 1,
+                "description": "test",
+                "name": "processTL",
+                "cancel_screen_id": null,
+                "request_detail_screen_id": null,
+                "status": "ACTIVE",
+                "is_valid": 1,
+                "package_key": null,
+                "pause_timer_start": 0,
+                "deleted_at": null,
+                "created_at": "2024-08-26T16:24:52+00:00",
+                "updated_at": "2024-08-29T16:43:37+00:00",
+                "updated_by": 1,
+                "start_events": [
+                    {
+                        "id": "node_91",
+                        "name": "Start Event",
+                        "config": "{\"web_entry\":null}",
+                        "ownerProcessId": "ProcessId",
+                        "eventDefinitions": [],
+                        "ownerProcessName": "ProcessName",
+                        "allowInterstitial": "false",
+                        "interstitialScreenRef": "1"
+                    }
+                ],
+                "self_service_tasks": [],
+                "signal_events": [],
+                "conditional_events": [],
+                "properties": {
+                    "manager_id": "undefined"
+                },
+                "is_template": 0,
+                "case_title": null,
+                "launchpad_properties": null,
+                "asset_type": null,
+                "alternative": "A",
+                "has_timer_start_events": false,
+                "projects": "[]"
+            },
+            "user": {
+                "id": 3,
+                "uuid": "9cdee13e-7aff-4d09-9322-0257e4a4996f",
+                "email": "homero@simpsom.com",
+                "firstname": "homero",
+                "lastname": "simpsom",
+                "username": "homero",
+                "status": "ACTIVE",
+                "address": null,
+                "city": null,
+                "state": null,
+                "postal": null,
+                "country": null,
+                "phone": null,
+                "fax": null,
+                "cell": null,
+                "title": "none",
+                "birthdate": null,
+                "timezone": "UTC",
+                "datetime_format": "m\/d\/Y H:i",
+                "language": "en",
+                "meta": null,
+                "connected_accounts": null,
+                "is_administrator": true,
+                "is_system": 0,
+                "expires_at": null,
+                "loggedin_at": "2024-08-28T02:09:33+00:00",
+                "active_at": "2024-08-28T02:25:55+00:00",
+                "remember_token": null,
+                "created_at": "2024-08-28T02:05:56+00:00",
+                "updated_at": "2024-08-28T02:06:05+00:00",
+                "deleted_at": null,
+                "delegation_user_id": null,
+                "manager_id": null,
+                "schedule": null,
+                "force_change_password": 0,
+                "avatar": null,
+                "password_changed_at": "2024-08-28 02:05:56",
+                "preferences_2fa": null,
+                "fullname": "homero simpsom"
+            },
+            "draft": null,
+            "assignable_users": [
+                3
+            ],
+            "can_view_parent_request": false
+        }
+    ],
+    "meta": {
+        "filter": "",
+        "sort_by": "due_at",
+        "sort_order": "asc",
+        "count": 1,
+        "total_pages": 1,
+        "in_overdue": 0,
+        "current_page": 1,
+        "from": 1,
+        "last_page": 1,
+        "links": [
+            {
+                "url": null,
+                "label": "&laquo; Previous",
+                "active": false
+            },
+            {
+                "url": "http:\/\/processmaker.test\/api\/1.0\/tasks?page=1",
+                "label": "1",
+                "active": true
+            },
+            {
+                "url": null,
+                "label": "Next &raquo;",
+                "active": false
+            }
+        ],
+        "path": "http:\/\/processmaker.test\/api\/1.0\/tasks",
+        "per_page": 15,
+        "to": 1,
+        "total": 1
+    }
+}
+    );
+
+
+    cy.visit("/?scenario=TaskRedirect", {
+      onBeforeLoad: function (window) {
+        sessionStorage.removeItem('sessionUrlSelfService');
+      } 
+    });
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 2,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/tasks");
+  });
+  it("Element destination type is taskSource case 2(redirect to previous page if the next task is not assigned to the same user)" , () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: "taskSource",
+          value: "taskSource",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks?user_id=1&process_request_id=1&page=1&per_page=1&status=ACTIVE",
+      {
+        "data": [
+            {
+                "id": 585,
+                "uuid": "9ce21eaf-0991-495c-9f11-2e47b409acd5",
+                "user_id": 3,
+                "process_id": 7,
+                "process_request_id": 194,
+                "subprocess_request_id": null,
+                "element_id": "node_117",
+                "element_type": "task",
+                "element_name": "Form Task 222",
+                "status": "ACTIVE",
+                "element_index": 0,
+                "subprocess_start_event_id": null,
+                "completed_at": null,
+                "due_at": "2024-09-01T16:45:13+00:00",
+                "due_notified": 0,
+                "initiated_at": null,
+                "riskchanges_at": "2024-08-31T18:45:13+00:00",
+                "created_at": "2024-08-29T16:45:13+00:00",
+                "updated_at": "2024-08-29T16:45:13+00:00",
+                "version_id": 63,
+                "version_type": "ProcessMaker\\Models\\ScreenVersion",
+                "is_self_service": 0,
+                "self_service_groups": [],
+                "token_properties": [],
+                "is_priority": false,
+                "is_actionbyemail": false,
+                "user_viewed_at": null,
+                "advanceStatus": "open",
+                "process_request": {
+                    "id": 194,
+                    "uuid": "9ce21e35-087d-45dd-b1ed-f2874307e293",
+                    "process_id": 7,
+                    "process_collaboration_id": null,
+                    "collaboration_uuid": null,
+                    "user_id": 1,
+                    "parent_request_id": null,
+                    "participant_id": null,
+                    "callable_id": "ProcessId",
+                    "status": "ACTIVE",
+                    "name": "processTL",
+                    "do_not_sanitize": [],
+                    "errors": null,
+                    "completed_at": null,
+                    "initiated_at": "2024-08-29T16:43:53+00:00",
+                    "created_at": "2024-08-29T16:43:53+00:00",
+                    "updated_at": "2024-08-29T16:45:13+00:00",
+                    "process_version_id": 129,
+                    "signal_events": [],
+                    "case_title": "Case #182",
+                    "case_number": 182,
+                    "case_title_formatted": "Case #<b>182<\/b>",
+                    "process": {
+                        "id": 7,
+                        "uuid": "9cdc0e74-0e60-4a33-a6e6-71c96b6b7330",
+                        "process_category_id": "2",
+                        "user_id": 1,
+                        "description": "test",
+                        "name": "processTL",
+                        "cancel_screen_id": null,
+                        "request_detail_screen_id": null,
+                        "status": "ACTIVE",
+                        "is_valid": 1,
+                        "package_key": null,
+                        "pause_timer_start": 0,
+                        "deleted_at": null,
+                        "created_at": "2024-08-26T16:24:52+00:00",
+                        "updated_at": "2024-08-29T16:43:37+00:00",
+                        "updated_by": 1,
+                        "start_events": [
+                            {
+                                "id": "node_91",
+                                "name": "Start Event",
+                                "config": "{\"web_entry\":null}",
+                                "ownerProcessId": "ProcessId",
+                                "eventDefinitions": [],
+                                "ownerProcessName": "ProcessName",
+                                "allowInterstitial": "false",
+                                "interstitialScreenRef": "1"
+                            }
+                        ],
+                        "self_service_tasks": [],
+                        "signal_events": [],
+                        "conditional_events": [],
+                        "properties": {
+                            "manager_id": "undefined"
+                        },
+                        "is_template": 0,
+                        "case_title": null,
+                        "launchpad_properties": null,
+                        "asset_type": null,
+                        "alternative": "A",
+                        "has_timer_start_events": false,
+                        "projects": "[]"
+                    }
+                },
+                "process": {
+                    "id": 7,
+                    "uuid": "9cdc0e74-0e60-4a33-a6e6-71c96b6b7330",
+                    "process_category_id": "2",
+                    "user_id": 1,
+                    "description": "test",
+                    "name": "processTL",
+                    "cancel_screen_id": null,
+                    "request_detail_screen_id": null,
+                    "status": "ACTIVE",
+                    "is_valid": 1,
+                    "package_key": null,
+                    "pause_timer_start": 0,
+                    "deleted_at": null,
+                    "created_at": "2024-08-26T16:24:52+00:00",
+                    "updated_at": "2024-08-29T16:43:37+00:00",
+                    "updated_by": 1,
+                    "start_events": [
+                        {
+                            "id": "node_91",
+                            "name": "Start Event",
+                            "config": "{\"web_entry\":null}",
+                            "ownerProcessId": "ProcessId",
+                            "eventDefinitions": [],
+                            "ownerProcessName": "ProcessName",
+                            "allowInterstitial": "false",
+                            "interstitialScreenRef": "1"
+                        }
+                    ],
+                    "self_service_tasks": [],
+                    "signal_events": [],
+                    "conditional_events": [],
+                    "properties": {
+                        "manager_id": "undefined"
+                    },
+                    "is_template": 0,
+                    "case_title": null,
+                    "launchpad_properties": null,
+                    "asset_type": null,
+                    "alternative": "A",
+                    "has_timer_start_events": false,
+                    "projects": "[]"
+                },
+                "user": {
+                    "id": 3,
+                    "uuid": "9cdee13e-7aff-4d09-9322-0257e4a4996f",
+                    "email": "homero@simpsom.com",
+                    "firstname": "homero",
+                    "lastname": "simpsom",
+                    "username": "homero",
+                    "status": "ACTIVE",
+                    "address": null,
+                    "city": null,
+                    "state": null,
+                    "postal": null,
+                    "country": null,
+                    "phone": null,
+                    "fax": null,
+                    "cell": null,
+                    "title": "none",
+                    "birthdate": null,
+                    "timezone": "UTC",
+                    "datetime_format": "m\/d\/Y H:i",
+                    "language": "en",
+                    "meta": null,
+                    "connected_accounts": null,
+                    "is_administrator": true,
+                    "is_system": 0,
+                    "expires_at": null,
+                    "loggedin_at": "2024-08-28T02:09:33+00:00",
+                    "active_at": "2024-08-28T02:25:55+00:00",
+                    "remember_token": null,
+                    "created_at": "2024-08-28T02:05:56+00:00",
+                    "updated_at": "2024-08-28T02:06:05+00:00",
+                    "deleted_at": null,
+                    "delegation_user_id": null,
+                    "manager_id": null,
+                    "schedule": null,
+                    "force_change_password": 0,
+                    "avatar": null,
+                    "password_changed_at": "2024-08-28 02:05:56",
+                    "preferences_2fa": null,
+                    "fullname": "homero simpsom"
+                },
+                "draft": null,
+                "assignable_users": [
+                    3
+                ],
+                "can_view_parent_request": false
+            }
+        ],
+        "meta": {
+            "filter": "",
+            "sort_by": "due_at",
+            "sort_order": "asc",
+            "count": 1,
+            "total_pages": 1,
+            "in_overdue": 0,
+            "current_page": 1,
+            "from": 1,
+            "last_page": 1,
+            "links": [
+                {
+                    "url": null,
+                    "label": "&laquo; Previous",
+                    "active": false
+                },
+                {
+                    "url": "http:\/\/processmaker.test\/api\/1.0\/tasks?page=1",
+                    "label": "1",
+                    "active": true
+                },
+                {
+                    "url": null,
+                    "label": "Next &raquo;",
+                    "active": false
+                }
+            ],
+            "path": "http:\/\/processmaker.test\/api\/1.0\/tasks",
+            "per_page": 15,
+            "to": 1,
+            "total": 1
+        }
+      }
+    );
+
+
+    cy.visit("/?scenario=TaskRedirect", {
+      onBeforeLoad: function (window) {
+        sessionStorage.removeItem('sessionUrlSelfService');
+        sessionStorage.setItem('sessionUrlSelfService', "http://localhost:5173/about");
+      }
+    });
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 2,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/about");
+    sessionStorage.removeItem("sessionUrlSelfService");
+  });
+  it("Element destination type is taskSource case 3(redirect to next task if the next task is assigned to the same user)" , () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        allow_interstitial: false,
+        elementDestination: {
+          type: "taskSource",
+          value: "taskSource",
+        },
+        user: {
+          id: 1
+        },
+        screen: SingleScreen.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE"
+        }
+      }
+    );
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/2?include=data,user,draft,requestor,processRequest,component,requestData,loopContext,bpmnTagName,interstitial,definition,userRequestPermission,elementDestination",
+      {
+        "data": [
+            {
+                "id": 585,
+                "uuid": "9ce21eaf-0991-495c-9f11-2e47b409acd5",
+                "user_id": 1,
+                "process_id": 7,
+                "process_request_id": 194,
+                "subprocess_request_id": null,
+                "element_id": "node_117",
+                "element_type": "task",
+                "element_name": "Form Task 222",
+                "status": "ACTIVE",
+                "element_index": 0,
+                "subprocess_start_event_id": null,
+                "completed_at": null,
+                "due_at": "2024-09-01T16:45:13+00:00",
+                "due_notified": 0,
+                "initiated_at": null,
+                "riskchanges_at": "2024-08-31T18:45:13+00:00",
+                "created_at": "2024-08-29T16:45:13+00:00",
+                "updated_at": "2024-08-29T16:45:13+00:00",
+                "version_id": 63,
+                "version_type": "ProcessMaker\\Models\\ScreenVersion",
+                "is_self_service": 0,
+                "self_service_groups": [],
+                "token_properties": [],
+                "is_priority": false,
+                "is_actionbyemail": false,
+                "user_viewed_at": null,
+                "advanceStatus": "open",
+                "draft": null,
+                "assignable_users": [
+                    3
+                ],
+                "can_view_parent_request": false,
+            }
+        ]
+      }
+
+    );
+
+
+    cy.visit("/?scenario=TaskRedirect", {
+      onBeforeLoad: function (window) {
+        sessionStorage.removeItem('sessionUrlSelfService');
+      }
+    });
+    cy.get(".form-group").find("button").click();
+
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [{
+        nodeId: 'node_2',
+        tokenId: 2,
+        userId: 1,
+      }],
+      method: "redirectToTask"
+    });
+    cy.url().should("eq", "http://localhost:5173/?scenario=TaskRedirect");
+  });
+});

--- a/tests/e2e/specs/WebEntryEndEventRedirect.spec.js
+++ b/tests/e2e/specs/WebEntryEndEventRedirect.spec.js
@@ -1,0 +1,56 @@
+import SingleScreen from "../fixtures/single_line_input.json";
+
+function initializeTaskAndScreenIntercepts(method, url, response) {
+  cy.intercept(method, url.replace(",screen,", ",").replace(",nested,", ","), response).as('getTask');
+  cy.intercept(method, url.replace(/\?.*$/, "/screen?include=screen,nested"), response.screen).as('getScreen');
+}
+
+describe("End Event Redirect (Process completed)", () => {
+  beforeEach(() => {
+    // Reset the intercepts and the state before each test
+    cy.visit("/?scenario=TaskWebEntry", {});
+  });
+
+  it("Element destination type is summaryScreen and process was opened from webEntry", () => {
+    const taskUrl = "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination";
+
+    initializeTaskAndScreenIntercepts("GET", taskUrl, {
+      id: 1,
+      advanceStatus: "open",
+      component: "task-screen",
+      allow_interstitial: false,
+      elementDestination: {
+        type: "taskList",
+        value: "http://localhost:5173/tasks",
+      },
+      user: {
+        id: 1,
+      },
+      screen: SingleScreen.screens[0],
+      process_request: {
+        id: 1,
+        status: "ACTIVE",
+      },
+    });
+
+    // Interact with the UI
+    cy.get('.form-group > .btn').click();
+
+    // Emit socket event and verify the URL change
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: [
+        {
+          endEventDestination: {
+            type: "summaryScreen",
+            value: null,
+          },
+        },
+      ],
+      method: "processCompletedRedirect",
+    })
+    cy.wait(1000);
+    // This code will execute after the socket event is finished
+    cy.url().should("eq", "http://localhost:5173/?scenario=TaskWebEntry");
+   
+  });
+});

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -65,6 +65,11 @@ Cypress.Commands.add("socketEvent", (event, body) => {
   });
 });
 
+Cypress.Commands.add("socketEventNext", (event, body) => {
+  cy.window().then((win) => {
+    win.Echo.eventMockNext(event, body);
+  });
+});
 /**
  * Converts Cypress fixtures, including JSON, to a Blob. All file types are
  * converted to base64 then converted to a Blob using Cypress
@@ -74,7 +79,7 @@ Cypress.Commands.add("socketEvent", (event, body) => {
  * @param {String} type - content type of the uploaded file
  * @return {Promise} Resolves with blob containing fixture contents
  */
-function getFixtureBlob(fileUrl, type) {
+function getFixtureBlob(fileUrl, type, c) {
   return type === "application/json"
     ? cy
         .fixture(fileUrl)

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -79,7 +79,7 @@ Cypress.Commands.add("socketEventNext", (event, body) => {
  * @param {String} type - content type of the uploaded file
  * @return {Promise} Resolves with blob containing fixture contents
  */
-function getFixtureBlob(fileUrl, type, c) {
+function getFixtureBlob(fileUrl, type) {
   return type === "application/json"
     ? cy
         .fixture(fileUrl)


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
The message "This request is complete" should appear when completing the request
Actual behavior: 
The user is redirected to summary
## Solution
- add a isWebEntry property to identify if the task is running in web entry mode

https://github.com/user-attachments/assets/0ecc9e44-39ac-4d04-9bc9-be6d91511db8


## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19011

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
