### PR TITLE
Task/FOUR-19875: aria-label property is the same in all options in the select list component generating unexpected behaviors for screen readers

### DIFF
--- a/src/components/inspector/collection-select-list.vue
+++ b/src/components/inspector/collection-select-list.vue
@@ -32,6 +32,16 @@
     </div>
 
     <div v-if="fields.length > 1" class="mt-3">
+      <label for="aria-label">{{ $t("Aria Label") }}</label>
+      <b-form-select
+        id="aria-label"
+        v-model="ariaLabelField"
+        :options="fields"
+        data-cy="inspector-collection-aria-label"
+      />
+    </div>
+
+    <div v-if="fields.length > 1" class="mt-3">
       <pmql-input
         v-model="pmql"
         :search-type="'collections_w_mustaches'"
@@ -72,6 +82,7 @@ const CONFIG_FIELDS = [
   "collectionId",
   "labelField",
   "valueField",
+  "ariaLabelField",
   "pmql",
   "unique"
 ];
@@ -89,6 +100,7 @@ export default {
       collectionId: null,
       labelField: null,
       valueField: null,
+      ariaLabelField: null,
       pmql: "",
       unique: false
     };
@@ -137,6 +149,7 @@ export default {
     resetFields() {
       this.labelField = null;
       this.valueField = null;
+      this.ariaLabelField = null;
     },
     getCollections() {
       this.$dataProvider.getCollections().then((response) => {

--- a/src/components/inspector/collection-select-list.vue
+++ b/src/components/inspector/collection-select-list.vue
@@ -31,7 +31,7 @@
       />
     </div>
 
-    <div v-if="fields.length > 1" class="mt-3">
+    <div v-if="fields.length > 1 && renderAs === 'checkbox'" class="mt-3">
       <label for="aria-label">{{ $t("Aria Label") }}</label>
       <b-form-select
         id="aria-label"
@@ -92,7 +92,7 @@ export default {
     MustacheHelper,
     ScreenVariableSelector
   },
-  props: ["value"],
+  props: ["value", "renderAs"],
   data() {
     return {
       collections: [],

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -29,8 +29,8 @@
           <label class="mt-3" for="option-content">{{ $t('Content') }}</label>
           <b-form-input id="option-content" v-model="optionContent" data-cy="inspector-option-content" />
           
-          <label class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
-          <b-form-input id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
+          <label v-if="renderAs === 'checkbox'" class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
+          <b-form-input v-if="renderAs === 'checkbox'" id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
         </div>
 
         <div class="card-footer text-right p-2">
@@ -78,8 +78,8 @@
                     <label class="mt-3" for="option-content">{{ $t('Content') }}</label>
                     <b-form-input id="option-content" v-model="optionContent" data-cy="inspector-option-content" />
                     
-                    <label class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
-                    <b-form-input id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
+                    <label v-if="renderAs === 'checkbox'" class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
+                    <b-form-input v-if="renderAs === 'checkbox'" id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
                   </div>
 
                   <div class="card-footer text-right p-2">
@@ -137,7 +137,7 @@
     </div>
     
     <div v-if="dataSource === dataSourceValues.collection">
-      <collection-select-list v-model="collectionOptions"></collection-select-list>
+      <collection-select-list v-model="collectionOptions" :renderAs="renderAs"></collection-select-list>
     </div>
 
     <div v-if="showRenderAs">
@@ -210,10 +210,10 @@
       <b-form-input id="value" v-model="value" @change="valueChanged" data-cy="inspector-datasource-content"/>
       <small class="form-text text-muted mb-3">{{ $t('Content to display to the user in the select list.') }}</small>
 
-      <label for="aria-label">{{ $t('Aria Label') }}</label>
-      <mustache-helper/>
-      <b-form-input id="aria-label" v-model="optionAriaLabel" data-cy="inspector-datasource-aria-label"/>
-      <small class="form-text text-muted mb-3">{{ $t('Aria label for accessibility support.') }}</small>
+      <label v-if="renderAs === 'checkbox'" for="aria-label">{{ $t('Aria Label') }}</label>
+      <mustache-helper v-if="renderAs === 'checkbox'" />
+      <b-form-input v-if="renderAs === 'checkbox'" id="aria-label" v-model="optionAriaLabel" data-cy="inspector-datasource-aria-label"/>
+      <small v-if="renderAs === 'checkbox'" class="form-text text-muted mb-3">{{ $t('Aria label for accessibility support.') }}</small>
     </div>
 
     <div v-if="valueTypeReturned === 'single' && dataSource === dataSourceValues.dataObject">
@@ -221,9 +221,9 @@
       <b-form-input id="key" v-model="key" @change="keyChanged" placeholder="Request Variable Property" data-cy="inspector-options-value" />
       <small class="form-text text-muted mb-3">{{ $t('Enter the property name from the Request data variable that will be passed as the value when selected.') }}</small>
 
-      <label for="aria-label">{{ $t('Aria Label') }}</label>
-      <b-form-input id="aria-label" v-model="optionAriaLabel" placeholder="Aria Label Property" data-cy="inspector-options-aria-label" />
-      <small class="form-text text-muted mb-3">{{ $t('Enter the property name for the aria label from the Request data variable.') }}</small>
+      <label v-if="renderAs === 'checkbox'" for="aria-label">{{ $t('Aria Label') }}</label>
+      <b-form-input v-if="renderAs === 'checkbox'" id="aria-label" v-model="optionAriaLabel" placeholder="Aria Label Property" data-cy="inspector-options-aria-label" />
+      <small v-if="renderAs === 'checkbox'" class="form-text text-muted mb-3">{{ $t('Enter the property name for the aria label from the Request data variable.') }}</small>
     </div>
 
     <div v-if="dataSource === dataSourceValues.dataConnector">

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -28,6 +28,9 @@
           </div>
           <label class="mt-3" for="option-content">{{ $t('Content') }}</label>
           <b-form-input id="option-content" v-model="optionContent" data-cy="inspector-option-content" />
+          
+          <label class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
+          <b-form-input id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
         </div>
 
         <div class="card-footer text-right p-2">
@@ -74,6 +77,9 @@
                     </div>
                     <label class="mt-3" for="option-content">{{ $t('Content') }}</label>
                     <b-form-input id="option-content" v-model="optionContent" data-cy="inspector-option-content" />
+                    
+                    <label class="mt-3" for="option-aria-label">{{ $t('Aria Label') }}</label>
+                    <b-form-input id="option-aria-label" v-model="optionAriaLabel" data-cy="inspector-option-aria-label" />
                   </div>
 
                   <div class="card-footer text-right p-2">
@@ -203,12 +209,21 @@
       <mustache-helper/>
       <b-form-input id="value" v-model="value" @change="valueChanged" data-cy="inspector-datasource-content"/>
       <small class="form-text text-muted mb-3">{{ $t('Content to display to the user in the select list.') }}</small>
+
+      <label for="aria-label">{{ $t('Aria Label') }}</label>
+      <mustache-helper/>
+      <b-form-input id="aria-label" v-model="optionAriaLabel" data-cy="inspector-datasource-aria-label"/>
+      <small class="form-text text-muted mb-3">{{ $t('Aria label for accessibility support.') }}</small>
     </div>
 
     <div v-if="valueTypeReturned === 'single' && dataSource === dataSourceValues.dataObject">
       <label for="key">{{ $t('Variable Data Property') }}</label>
       <b-form-input id="key" v-model="key" @change="keyChanged" placeholder="Request Variable Property" data-cy="inspector-options-value" />
       <small class="form-text text-muted mb-3">{{ $t('Enter the property name from the Request data variable that will be passed as the value when selected.') }}</small>
+
+      <label for="aria-label">{{ $t('Aria Label') }}</label>
+      <b-form-input id="aria-label" v-model="optionAriaLabel" placeholder="Aria Label Property" data-cy="inspector-options-aria-label" />
+      <small class="form-text text-muted mb-3">{{ $t('Enter the property name for the aria label from the Request data variable.') }}</small>
     </div>
 
     <div v-if="dataSource === dataSourceValues.dataConnector">
@@ -287,6 +302,7 @@ export default {
       removeIndex: null,
       optionValue: '',
       optionContent: '',
+      optionAriaLabel: '',
       showRenderAs: false,
       renderAs: 'dropdown',
       allowMultiSelect: false,
@@ -413,6 +429,9 @@ export default {
     valueField() {
       return this.value || 'content';
     },
+    ariaLabelField() {
+      return this.optionAriaLabel || 'ariaLabel';
+    },
     currentItemToDelete() {
       if (this.removeIndex !== null
           && this.optionsList.length > 0
@@ -450,6 +469,7 @@ export default {
         editIndex: this.editIndex,
         removeIndex: this.removeIndex,
         valueTypeReturned: this.valueTypeReturned,
+        optionAriaLabel: this.optionAriaLabel,
       };
     },
   },
@@ -467,6 +487,7 @@ export default {
     this.selectedEndPoint = this.options.selectedEndPoint,
     this.key = this.options.key;
     this.value = this.options.value;
+    this.optionAriaLabel = this.options.optionAriaLabel;
     this.pmqlQuery = this.options.pmqlQuery;
     this.defaultOptionKey= this.options.defaultOptionKey;
     this.selectedOptions = this.options.selectedOptions;
@@ -530,8 +551,9 @@ export default {
       const that = this;
       jsonList.forEach (item => {
         that.optionsList.push({
-          [that.keyField] : item[that.keyField],
-          [that.valueField] : item[that.valueField],
+          [that.keyField]: item[that.keyField],
+          [that.valueField]: item[that.valueField],
+          [that.ariaLabelField]: item[that.ariaLabelField]
         });
       });
       this.jsonError = '';
@@ -560,12 +582,14 @@ export default {
       this.editIndex = index;
       this.optionContent = this.optionsList[index][this.valueField];
       this.optionValue = this.optionsList[index][this.keyField];
+      this.optionAriaLabel = this.optionsList[index][this.ariaLabelField];
       this.optionError = '';
     },
     showAddOption() {
       this.optionCardType = 'insert';
       this.optionContent = '';
       this.optionValue = '';
+      this.optionAriaLabel = '';
       this.showOptionCard = true;
       this.optionError = '';
       this.editIndex = null;
@@ -582,6 +606,7 @@ export default {
           {
             [this.valueField]: this.optionContent,
             [this.keyField]: this.optionValue,
+            [this.ariaLabelField]: this.optionAriaLabel,
           }
         );
       }
@@ -592,6 +617,7 @@ export default {
         }
         this.optionsList[this.editIndex][this.keyField] = this.optionValue;
         this.optionsList[this.editIndex][this.valueField] = this.optionContent;
+        this.optionsList[this.editIndex][this.ariaLabelField] = this.optionAriaLabel;
       }
 
       this.jsonData = JSON.stringify(this.optionsList);

--- a/tests/e2e/specs/FormSelectList.spec.js
+++ b/tests/e2e/specs/FormSelectList.spec.js
@@ -348,14 +348,14 @@ describe("Form Select List", () => {
     cy.get("[data-cy=inspector-edit-json]").click();
 
     cy.assertComponentValueAsJson('[data-cy="inspector-monaco-json"]', [
-      { content: "one", value: "one" }
+      { content: "one", value: "one", ariaLabel: "" }
     ]);
 
     cy.setVueComponentValue(
       '[data-cy="inspector-monaco-json"]',
       JSON.stringify([
-        { content: "one", value: "one" },
-        { content: "two", value: "two" }
+        { content: "one", value: "one", ariaLabel: "" },
+        { content: "two", value: "two", ariaLabel: "" }
       ])
     );
     cy.get("[data-cy=inspector-monaco-json-expand]").click();
@@ -363,8 +363,8 @@ describe("Form Select List", () => {
       '[data-cy="inspector-monaco-json-expanded"]',
       JSON.stringify(
         [
-          { content: "one", value: "one" },
-          { content: "two", value: "two" }
+          { content: "one", value: "one", ariaLabel: "" },
+          { content: "two", value: "two", ariaLabel: "" }
         ],
         null,
         2


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce:**

- Create a new screen
- Use the Select List component in the screen
- Configure the aria-label in Advanced property

**Current Behavior:**
The same aria-label is repeated for each option in the Select List. This is causing that the screen readers for disabilities reads the label question every time. This behavior is unexpected for the customer.

**Expected Behavior:**

ProcessMaker should allow configure the aria-label for each option in the aria-label property. One for the label and one for each option in the Select List component for the screen readers.

## Solution
- Added area label option for checkbox renderAs mode, for provide data, request data, data connectors and collections.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-19875](https://processmaker.atlassian.net/browse/FOUR-19875)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1769)
- [Vue Form Elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/442)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:vue-form-elements:task/FOUR-19875

[FOUR-19875]: https://processmaker.atlassian.net/browse/FOUR-19875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ