### PR TITLE
bugfix/FOUR-20057: `Select a collection` label is missing when `Record ID` field has a variable

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -167,7 +167,6 @@ export default {
       this.selCollectionId = collectionId;
       this.selRecordId = recordId;
       this.selDisplayMode = modeId;
-
       this.$dataProvider
         .getCollectionRecordsView(collectionId, recordId)
         .then((response) => {
@@ -176,9 +175,10 @@ export default {
           const viewScreen = response.collection.read_screen_id;
           const editScreen = response.collection.update_screen_id;
             //Choose screen id regarding of the display Mode
-            this.screenCollectionId =
-              this.selDisplayMode === "View" ? viewScreen : editScreen;
-          
+            this.screenCollectionId = 
+              typeof this.selDisplayMode === 'function' ? 
+                (this.collectionmode.modeId === "View" ? viewScreen : editScreen) :
+                (this.selDisplayMode === "View" ? viewScreen : editScreen);
           this.loadScreen(this.screenCollectionId);
          
           //This section validates if Collection has draft data

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -192,6 +192,7 @@ export default {
         .catch(() => {
           this.localData = {};
           globalObject.ProcessMaker.alert(this.$t('This content does not exist. We could not locate indicated data'), "danger");
+          this.placeholder = "Select a collection";
         });;
     },
     isMustache(record) {


### PR DESCRIPTION
## Solution
- Collection record Control was fixed when:
* Collection placeholder label restored
* Mode dropdown changes between View and Edit

## How to Test
- Login PM4
- Go to Designer->Screens
- Create Screen or select a previous one created
- Drag Collection Record Control
- Drag Input Field
- In collection control add Input Field variable name in mustache syntax into Record ID field
- Select Mode "View"
- Click on preview
- Insert a number in the Input Field Collection in View mode should be displayed

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20057

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
