### PR TITLE
Bugfix/FOUR-20097:`Record ID` field does not work to Collection Record Control

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -181,13 +181,17 @@ export default {
                 (this.selDisplayMode === "View" ? viewScreen : editScreen);
           this.loadScreen(this.screenCollectionId);
          
-          //This section validates if Collection has draft data
-          if(this.taskDraft?.draft?.data == null || this.taskDraft.draft.data === '') {
+          //This section validates if Collection has draft data and if the record is different to the draft record
+          if (
+            this.taskDraft?.draft?.data == null || 
+            this.taskDraft.draft.data === '' || 
+            String(this.selRecordId) !== this.taskDraft.draft.data.id
+          ) {
             this.localData = respData;
           }else{
             this.localData = _.merge({}, respData, this.taskDraft.draft.data);
           }
-          
+
         })
         .catch(() => {
           this.localData = {};

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -61,7 +61,8 @@ export default {
       screenType: "",
       hasMustache: false,
       flagDraft: {},
-      taskDraft: {}
+      taskDraft: {},
+      enableDraft: true
     };
   },
   computed: {
@@ -181,12 +182,9 @@ export default {
                 (this.selDisplayMode === "View" ? viewScreen : editScreen);
           this.loadScreen(this.screenCollectionId);
          
-          //This section validates if Collection has draft data and if the record is different to the draft record
-          if (
-            this.taskDraft?.draft?.data == null || 
-            this.taskDraft.draft.data === '' || 
-            String(this.selRecordId) !== this.taskDraft.draft.data.id
-          ) {
+          //This section validates if Collection has draft data
+          if (this.taskDraft?.draft?.data == null || this.taskDraft.draft.data === '' || !this.enableDraft) 
+          {
             this.localData = respData;
           }else{
             this.localData = _.merge({}, respData, this.taskDraft.draft.data);
@@ -218,6 +216,7 @@ export default {
     },
     record(record) {
       this.hasMustache = false;
+      this.enableDraft = false;
       if (record && !isNaN(record) && record > 0 && this.collection.collectionId) {
         this.selRecordId = record;
         this.loadRecordCollection(this.collection.collectionId, record, this.selDisplayMode);


### PR DESCRIPTION
## Solution
- Fix was implemented to use draft data only when record id of collection does not change

## How to Test
- Login PM
- Go to Designer->screens
- Create or select a screen
- Drag Collection Record Control and Input Field
- In Collection Record Control name Record ID with Input field variable name in mustache syntax (i.e {{record_id}})
- Choose Edit or View Mode
- Save Screen and assign it to a Process.
- Run a Case with last screen modified
- Enter different Record ID numbers in Input Field, each record Id must shown respective collection data
- Enter an specific Record ID, change some information in the screen and wait for autosave.
- Refresh page. Draft data must be recovered in the screen.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20097

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
.