### PR TITLE
Bugfix/FOUR-20076: Properties are not cleaned when `Source of Record List` field is changed from Collection to variable

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -431,20 +431,22 @@ export default {
       }
 
       // Adds radio buttons or checkbox to the table depending selected option
-      if (['single-field', 'single-record'].includes(this.source?.dataSelectionOptions)) {
-        fields.unshift({
-          key: 'radio',
-          label: '',
-          sortable: false,
-        });
-      }
-
-      if (this.source?.dataSelectionOptions === 'multiple-records') {
-        fields.unshift({
-          key: 'checkbox',
-          label: '',
-          sortable: false
-        });
+      if(this.source?.sourceOptions === "Collection") { 
+        if (['single-field', 'single-record'].includes(this.source?.dataSelectionOptions)) {
+          fields.unshift({
+            key: 'radio',
+            label: '',
+            sortable: false,
+          });
+        }
+  
+        if (this.source?.dataSelectionOptions === 'multiple-records') {
+          fields.unshift({
+            key: 'checkbox',
+            label: '',
+            sortable: false
+          });
+        }
       }
       
       return fields;


### PR DESCRIPTION

## Solution
- All settings for Collections in Recod List Control will cleaned when option "Variable" is selected.

## How to Test
- Login PM
- Create a screen
- Create a Record list
   select collection option in the Configuration > Source of Record List
   Select a collection
   Select any option in the Data Selection and select a column
- Press preview button (it works correctly)
- Press Design button
- Edit the Record list
   select Variable option in the Configuration > Source of Record List
- Add custom header in the columns accordion
- Press Preview button

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20076

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
