### PR TITLE
Observation/FOUR-19978: Not all strings are added to the Json file for translation.

### DIFF
--- a/src/components/renderer/form-list-table.vue
+++ b/src/components/renderer/form-list-table.vue
@@ -160,12 +160,12 @@ export default {
   },
   watch: {
     listOption() {
-      this.title = this.checkTitle(this.listOption);
+      this.title = this.$t(this.checkTitle(this.listOption));
       this.dataControl = {};
     }
   },
   mounted() {
-    this.title = this.checkTitle(this.listOption);
+    this.title = this.$t(this.checkTitle(this.listOption));
   },
   methods: {
     /**

--- a/src/components/renderer/form-new-request.vue
+++ b/src/components/renderer/form-new-request.vue
@@ -17,7 +17,7 @@
       </div>
     </div>
     <div v-else>
-      <formEmpty link="" title="No Case to Start" url="" />
+      <formEmpty link="" :title="$t('No Case to Start')" url="" />
     </div>
   </div>
 </template>

--- a/src/components/renderer/form-requests.vue
+++ b/src/components/renderer/form-requests.vue
@@ -70,7 +70,7 @@
     </filter-table>
   </div>
   <div v-else>
-    <formEmpty link="Requests" title="No Cases to Show" :url="noDataUrl" />
+    <formEmpty link="Requests" :title="$t('No Cases to Show')" :url="noDataUrl" />
   </div>
 </template>
 


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:**

- Select a language
- Log in with an admin user
- Go to the Home tab
- Go to the Admin tab and click Translations
- Go to the Designer tab
- Go to the Tasks tab
- Go to the Cases tab
- Go to the Processes tab

**Current Behavior:**
There are several untranslated fields.
- In Home--No Cases to Show, START NEW CASE
- In translations--Add language, Source String (English), botton translate with AI, the options select all fields, select empty - files, Default Anon language
- In designer--Name, Modified
- In tasks--Drafts, status
- In Cases--My cases, In progress, All cases, my requests, case, Case title, Process, task, participants, status, started completed, No new cases at this moment.
- In processes--Search Categories and processes

## Solution
- Translate missing texts

## IMPORTANT
Some translations are missing in the **es.json** file, we need to manually run the script to translate missing transaltions.

## Related Tickets & Packages
- [FOUR- 19978](https://processmaker.atlassian.net/browse/FOUR-19978)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/7737)
- [Package Translations PR](https://github.com/ProcessMaker/package-translations/pull/162)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1774)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
