### PR TITLE
Bugfix/FOUR-20075: Record list > Design > modern: colors are missing

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -255,9 +255,7 @@
                   v-model="element.items"
                   :validation-errors="validationErrors"
                   class="card-body"
-                  :class="styleMode === 'Modern' && element.component === 'FormRecordList' 
-                    ? elementCssClassModern(element) 
-                    : elementCssClass(element)"
+                  :class="elementCssClass(element)"
                   :selected="selected"
                   :config="element.config"
                   :ai-element="element"
@@ -321,9 +319,7 @@
                   :tabindex="element.config.interactive ? 0 : -1"
                   class="card-body m-0 pb-4 pt-4"
                   :class="[
-                    styleMode === 'Modern' && element.component === 'FormRecordList' 
-                    ? elementCssClassModern(element) 
-                    : elementCssClass(element),
+                    elementCssClass(element),
                     { 'prevent-interaction': !element.config.interactive }
                   ]"
                   :screen-type="screenType"

--- a/src/mixins/HasColorProperty.js
+++ b/src/mixins/HasColorProperty.js
@@ -5,6 +5,7 @@ export default {
       const css = [];
       element.config.bgcolor ? css.push(element.config.bgcolor) : null;
       element.config.color ? css.push(element.config.color) : null;
+      element.config.bgcolormodern ? css.push(element.config.bgcolormodern) : null;
       return css.join(' ');
     },
     elementCssClassModern(element) {


### PR DESCRIPTION
## How to Test
Go to screens page

Create a Screen

- Create a first record list
- Go to design > select the option Classic and select a color
- Create a second record list 
- Go to design > select the option Modern and select a color

   Scenario A
   Press Preview button
   Press Design button
- Record Lists color should be displayed when Design button is pressed

   Scenario B
   Reload the screen page
- Record Lists color should be displayed when Design button is pressed

   Scenario C
   Press in first and second record list (Each control must keep it own selected color)
   
## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20075

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
