### PR TITLE
observation/FOUR-20173 The open screen of the Collection Record control opens a different screen

### DIFF
--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -54,7 +54,8 @@ export default {
       dataRecordList: [],
       idCollectionScreenView: null,
       idCollectionScreenEdit: null,
-      screenMode: null
+      screenMode: null,
+      collectionsMap: {}
     };
   },
   computed: {
@@ -76,6 +77,7 @@ export default {
     },
     collectionId: {
       handler() {
+        this.updateScreenIds();
         this.getFields();
       }
     },
@@ -114,17 +116,20 @@ export default {
     },
     getCollections() {
       this.$dataProvider.getCollections().then((response) => {
-        const [firstItem = {}] = response.data.data || [];
-        this.idCollectionScreenView = firstItem.read_screen_id;
-        this.idCollectionScreenEdit = firstItem.create_screen_id;
+        this.collectionsMap = response.data.data.reduce((acc, collection) => {
+          acc[collection.id] = {
+            read_screen_id: collection.read_screen_id,
+            create_screen_id: collection.create_screen_id
+          };
+          return acc;
+        }, {});
+
         this.collections = [
           { value: null, text: this.$t("Select a collection") },
-          ...response.data.data.map((collection) => {
-            return {
-              text: collection.name,
-              value: collection.id
-            };
-          })
+          ...response.data.data.map((collection) => ({
+            text: collection.name,
+            value: collection.id
+          }))
         ];
       });
     },
@@ -155,6 +160,16 @@ export default {
     },
     onPmqlChange(pmql) {
       this.pmql = pmql;
+    },
+    updateScreenIds() {
+      if (this.collectionId && this.collectionsMap[this.collectionId]) {
+        const selectedCollection = this.collectionsMap[this.collectionId];
+        this.idCollectionScreenView = selectedCollection.read_screen_id;
+        this.idCollectionScreenEdit = selectedCollection.create_screen_id;
+      } else {
+        this.idCollectionScreenView = null;
+        this.idCollectionScreenEdit = null;
+      }
     }
   }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
The open screen of the Collection Record control opens a different screen

Expected behavior: 
When you click on open screen of the collection record control, it should open the screen that is in the collection

Actual behavior: 
As we can see, when clicking on open screen of the collection record screen control, it opens a different screen than the one configured in the collection.

## Solution
Added a method to obtain the screen id for editing collections

## How to Test
Log in 
Go to Designer
Click on Screens
Create a new form screen
Create a Collection Record Control 
Configure. with collection 
Click on Opone screen 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-20173
