### PR TITLE
FOUR-20206: Update the Copy Control icon as figma

### DIFF
--- a/src/components/editor/loop.vue
+++ b/src/components/editor/loop.vue
@@ -62,7 +62,7 @@
                 </button>
                 <button
                   v-if="!(isAiSection(element) && aiPreview(element))"
-                  class="btn btn-sm btn-secondary mr-2"
+                  class="btn btn-sm btn-primary mr-2"
                   :title="$t('Copy Control')"
                   @click="duplicateItem(index)"
                 >
@@ -128,7 +128,7 @@
                   @removeFromClipboard="removeFromClipboard(items[index])"
                 />
                 <button
-                  class="btn btn-sm btn-secondary mr-2"
+                  class="btn btn-sm btn-primary mr-2"
                   :title="$t('Copy Control')"
                   @click="duplicateItem(index)"
                 >

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -72,7 +72,7 @@
                       </button>
                       <button
                         v-if="!(isAiSection(element) && aiPreview(element))"
-                        class="btn btn-sm btn-secondary mr-2"
+                        class="btn btn-sm btn-primary mr-2"
                         :aria-label="$t('Duplicate')"
                         @click="duplicateItem(index, row)"
                       >
@@ -140,7 +140,7 @@
                         @removeFromClipboard="removeFromClipboard(element)"
                       />
                       <button
-                        class="btn btn-sm btn-secondary mr-2"
+                        class="btn btn-sm btn-primary mr-2"
                         :title="$t('Copy Control')"
                         @click="duplicateItem(index, row)"
                       >

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -234,7 +234,7 @@
                     <button
                       v-if="!(isAiSection(element) && aiPreview(element))"
                       data-test="copy-control-btn"
-                      class="btn btn-sm btn-secondary mr-2"
+                      class="btn btn-sm btn-primary mr-2"
                       :title="$t('Copy Control')"
                       @click="duplicateItem(index)"
                     >
@@ -300,7 +300,7 @@
                       @removeFromClipboard="removeFromClipboard(extendedPages[tabPage].items[index])"
                     />
                     <button
-                      class="btn btn-sm btn-secondary mr-2"
+                      class="btn btn-sm btn-primary mr-2"
                       :title="$t('Copy Control')"
                       @click="duplicateItem(index)"
                     >


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The Copy control Icon of controls actually is gray, it should be blue as figma design. 
Actual behavior: 
The Copy control Icon of controls actually is gray
## Solution
- Update the Copy button to use the primary button class instead of the secondary button class.
<img width="667" alt="image" src="https://github.com/user-attachments/assets/63a2f2da-7478-4c87-b880-aaec0868868f">

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-20206

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
