### PR TITLE
Bugfix/FOUR-21071: Collection Record Control changes saved settings when the control is clicked in Screen Builder

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -62,7 +62,8 @@ export default {
       hasMustache: false,
       flagDraft: {},
       taskDraft: {},
-      enableDraft: true
+      enableDraft: true,
+      defaultColumnsRecordId: 1
     };
   },
   computed: {
@@ -80,7 +81,6 @@ export default {
         Object.keys(data).forEach((variable) => {
           this.validationData && this.$set(this.validationData, variable, data[variable]);
         });
-
         if (this.collection) {
           this.$set(this.collection, 'data', Array.isArray(data) ? data : [data]);
           this.$set(this.collection, 'screen', this.screenCollectionId);
@@ -140,7 +140,6 @@ export default {
       this.customCSS = null;
       this.watchers = [];
       this.screenTitle = null;
-
       if (id) {
         this.$dataProvider.getScreen(id).then((response) => {
           this.config = response.data.config;
@@ -212,6 +211,9 @@ export default {
     collection(collection) {
       if(collection) {
         this.selCollectionId = collection.collectionId;
+        const currentData = this.localData;
+        this.$set(collection, 'data', Array.isArray(currentData) ? currentData : [currentData]);
+        this.$set(collection, 'screen', this.screenCollectionId);
       }
     },
     record(record) {
@@ -240,7 +242,11 @@ export default {
     });
 
     if (this.collection && this.record) {
-      this.loadRecordCollection(this.collection.collectionId, this.record, this.collectionmode.modeId);
+      const recordId = this.isMustache(this.record) ? this.defaultColumnsRecordId : this.record;
+      if(this.isMustache(this.record)) {
+        this.hasMustache = true;
+      }
+      this.loadRecordCollection(this.collection.collectionId, recordId, this.collectionmode.modeId);
     }
   },
 };


### PR DESCRIPTION
## Solution
- In Screen Builder, when some screen has Collection Record Control, and user clicks over the control, its settings does not change

## How to Test
- Login PM4
- Go to Designer->Screens
- Create a  FORM type Screen
- Drag Input Field and rename as "list", drag also a Submit button.
- Drag Collection Record Control, select a collection and set {{list}} into Record Id field. Select EDIT mode.
- Save and Publish this new Screen and Assign to some simple Process start-task-end
- Run the process and fill the Form. Submit the process.
- Open the previous Screen in Screen Builder and click on Collection Record Control.
- Save and Publish.
- Run again the process and fill the form.
- When submit button is clicked, no errors should be displayed anda process should be completed normally.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-21071

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
