### PR TITLE
FOUR-21132: Screen clipboard is not working

### DIFF
--- a/src/mixins/Clipboard.js
+++ b/src/mixins/Clipboard.js
@@ -170,9 +170,10 @@ export default {
         }
       );
       if (confirm) {
-        this.clipboardPage.items = [];
         this.$store.dispatch("clipboardModule/clearClipboard");
         this.$root.$emit('update-clipboard');
+        // Update the clipboard page with the new clipboard items
+        this.clipboardPage.items = this.$store.getters["clipboardModule/clipboardItems"];
       }
     },
 

--- a/tests/e2e/specs/ClipboardTabClearAll.spec.js
+++ b/tests/e2e/specs/ClipboardTabClearAll.spec.js
@@ -39,4 +39,59 @@ describe("Clipboard Page and Clear All Functionality", () => {
     // Validate that all controls have been removed
     cy.get('[data-cy="editor-content"]').children().should('have.length', 0);
   });
+
+  it("should allow adding elements after clearing clipboard", () => {
+    // Clear local storage and visit home page
+    cy.clearLocalStorage();
+    cy.visit("/");
+    cy.openAcordeonByLabel("Input Fields");
+
+    // Add initial controls to default page
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=editor-content]", { position: "bottom" });
+    cy.get("[data-cy=controls-FormButton]").drag("[data-cy=screen-element-container]", { position: "top" });
+
+    // Verify initial controls were added
+    cy.get('[data-cy="screen-element-container"]').children()
+      .should('have.length', 2)
+      .and('be.visible');
+
+    // Add both controls to clipboard
+    const addControlToClipboard = (index) => {
+      cy.get(`:nth-child(${index}) > [data-cy="screen-element-container"]`).click({ force: true });
+      cy.get('[data-cy="addToClipboard"]')
+        .should("be.visible")
+        .click();
+      cy.get('[data-cy="addToClipboard"]').should("not.exist");
+      cy.get('[data-cy="copied-badge"]').should("exist");
+    };
+
+    addControlToClipboard(1);
+    addControlToClipboard(2);
+
+    // Navigate to clipboard and verify controls were copied
+    cy.get("[data-test=page-dropdown]").click();
+    cy.get("[data-test=clipboard]").should("exist").click({ force: true });
+    cy.get('[data-cy="screen-element-container"]').children()
+      .should('have.length', 2)
+      .and('be.visible');
+
+    // Clear clipboard and verify it's empty
+    cy.contains('button', 'Clear All').click();
+    cy.contains('button', 'Confirm').click();
+    cy.get('[data-cy="editor-content"]').children().should('have.length', 0);
+
+    // Return to default page and add controls to clipboard again
+    cy.get("[data-test=page-dropdown]").click();
+    cy.get("[data-test=page-Default]").click({ force: true });
+
+    addControlToClipboard(1);
+    addControlToClipboard(2);
+
+    // Navigate back to clipboard and verify new controls were added
+    cy.get("[data-test=page-dropdown]").click();
+    cy.get("[data-test=clipboard]").should("exist").click({ force: true });
+    cy.get('[data-cy="screen-element-container"]').children()
+      .should('have.length', 2)
+      .and('be.visible');
+  });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The Clipboard should be cleared according to the PRD
Actual behavior: 
The Clipboard isn’t cleared after adding some controls to the Clipboard page
## Solution
- clipboard.items lost state reference after clear all, it was fixed

https://github.com/user-attachments/assets/53e26969-86f8-4084-8bbc-367bca39dcd8


## How to Test



the steps are detailed in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19767

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy