### PR TITLE
FOUR-19579: [41110] Bitia S.R.L.  - Input in collection edit screen not showing 0 variable

### DIFF
--- a/src/mixins/extensions/DataManager.js
+++ b/src/mixins/extensions/DataManager.js
@@ -12,8 +12,8 @@ export default {
           screen,
           safeDotName,
           `
-            this.getValue(${JSON.stringify(v.name)}, this.vdata) || 
-            this.getValue(${JSON.stringify(v.name)}, data) || 
+            this.getValue(${JSON.stringify(v.name)}, this.vdata) ?? 
+            this.getValue(${JSON.stringify(v.name)}, data) ?? 
             this.initialValue(
               '${component}',
               '${dataFormat}',

--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -30,7 +30,7 @@ export default {
       this.addData(screen, `${name}_was_filled__`, `!!this.getValue(${JSON.stringify(name)}, this.vdata) || !!this.getValue(${JSON.stringify(name)}, data)`);
       this.addMounted(
         screen,
-        `if (this.${safeDotName} === undefined || this.${safeDotName} === null) {
+        `if (this.${safeDotName} === undefined || this.${safeDotName} === null || this.${safeDotName} === false || this.${safeDotName} === "") {
             this.tryFormField(${JSON.stringify(name)}, () => {
             this.${safeDotName} = ${value};
             this.setValue(${JSON.stringify(name)}, ${value}, this.vdata, this);});

--- a/src/mixins/extensions/DefaultValues.js
+++ b/src/mixins/extensions/DefaultValues.js
@@ -29,8 +29,8 @@ export default {
       const defaultComputedName = `default_${safeDotName}__`;
       this.addData(screen, `${name}_was_filled__`, `!!this.getValue(${JSON.stringify(name)}, this.vdata) || !!this.getValue(${JSON.stringify(name)}, data)`);
       this.addMounted(
-        screen, 
-        `if (!this.${safeDotName}) {
+        screen,
+        `if (this.${safeDotName} === undefined || this.${safeDotName} === null) {
             this.tryFormField(${JSON.stringify(name)}, () => {
             this.${safeDotName} = ${value};
             this.setValue(${JSON.stringify(name)}, ${value}, this.vdata, this);});


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Log into ProcessMaker, go to the Admin tab, click on Collections, and create a new one.
2. in the screen of creation put an input type Integer and Select with value as well integer.
3. use the same screen to edit a collection 
4. add a new record and put values 0.
5. now edit a collection

## Current Behavior:
The input type integer with value 0 is not showing either the select, but then the input/select has a value different to 0 is showing the value

## Expected Behavior:
Inputs should show values in 0

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19579

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy