### PR TITLE
FOUR-21178: Navigation button shouldn't have the clipboard page as an option

### DIFF
--- a/src/components/editor/loop.vue
+++ b/src/components/editor/loop.vue
@@ -43,7 +43,7 @@
               </b-badge>
               <div class="ml-auto">
                 <clipboard-button
-                  v-if="screenType === 'form'"
+                  v-if="screenType === 'form' && !element.config.disableClipboard"
                   :index="index"
                   :config="element.config"
                   :isInClipboard="isInClipboard(items[index])"
@@ -118,7 +118,7 @@
               </b-badge>
               <div class="ml-auto">
                 <clipboard-button
-                  v-if="screenType === 'form'"
+                  v-if="screenType === 'form' && !element.config.disableClipboard"
                   :index="index"
                   :config="element.config"
                   :isInClipboard="isInClipboard(items[index])"

--- a/src/components/editor/multi-column.vue
+++ b/src/components/editor/multi-column.vue
@@ -53,7 +53,7 @@
                     </b-badge>
                     <div class="ml-auto">
                       <clipboard-button
-                        v-if="screenType === 'form'"
+                        v-if="screenType === 'form' && !element.config.disableClipboard"
                         :index="index"
                         :config="element.config"
                         :isInClipboard="isInClipboard(element)"
@@ -130,7 +130,7 @@
                     </b-badge>
                     <div class="ml-auto">
                       <clipboard-button
-                        v-if="screenType === 'form'"
+                        v-if="screenType === 'form' && !element.config.disableClipboard"
                         :index="index"
                         :config="element.config"
                         :isInClipboard="isInClipboard(element)"

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -213,7 +213,7 @@
                   </b-badge>
                   <div class="ml-auto">
                     <clipboard-button
-                      v-if="!isClipboardPage(tabPage) && screenType === 'form'"
+                      v-if="!isClipboardPage(tabPage) && screenType === 'form' && !element.config.disableClipboard"
                       :index="index"
                       :config="element.config"
                       :isInClipboard="isInClipboard(extendedPages[tabPage].items[index])"
@@ -288,7 +288,7 @@
                   </b-badge>
                   <div class="ml-auto">
                     <clipboard-button
-                      v-if="!isClipboardPage(tabPage) && screenType === 'form'"
+                      v-if="!isClipboardPage(tabPage) && screenType === 'form' && !element.config.disableClipboard"
                       :index="index"
                       :config="element.config"
                       :isInClipboard="isInClipboard(extendedPages[tabPage].items[index])"

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -361,7 +361,7 @@ export default [
         variant: 'primary',
         event: 'pageNavigate',
         eventData: null,
-
+        disableClipboard: true,
       },
       inspector: [
         {

--- a/tests/e2e/specs/ClipboardTestCases.spec.js
+++ b/tests/e2e/specs/ClipboardTestCases.spec.js
@@ -156,7 +156,7 @@ describe("Clipboard Button Actions", () => {
       .should('have.length', 6);
   });
 
-  it("TCP4-4443: Verify that the control from the NAVIGATION section have been added to the clipboard", () => {
+  it("TCP4-4443: Verify that the control from the NAVIGATION section have not been added to the clipboard", () => {
     cy.clearLocalStorage();
     cy.visit("/");
     cy.openAcordeonByLabel("Navigation");
@@ -166,16 +166,7 @@ describe("Clipboard Button Actions", () => {
     cy.get('[data-cy=controls-FormButton]:contains("Page")').drag("[data-cy=screen-drop-zone]", { position: "bottom" });
 
     cy.get(':nth-child(1) > [data-cy="screen-element-container"]').click();
-    cy.get('[data-cy="addToClipboard"]').should("be.visible");
-    cy.get('[data-cy="addToClipboard"]').click();
     cy.get('[data-cy="addToClipboard"]').should("not.exist");
-    cy.get('[data-cy="copied-badge"]').should("exist");
-
-    cy.get("[data-test=page-dropdown").click();
-    cy.get("[data-test=clipboard]").should("exist").click({ force: true });
-    cy.get('[data-cy="screen-element-container"]')
-      .children()
-      .should('have.length', 1);
   });
 
   it("TCP4-4443: Verify that the control from the FILES section have been added to the clipboard", () => {


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
Navigation button shouldn't have the clipboard page as an option
Actual behavior: 
Navigation button have the clipboard page as an option
## Solution
- add validation to not display a pageNavigate control by config

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/a1752124-0c11-4408-9ec0-89087c2be7b2" />

## How to Test

1. Test the steps above
2. Access the Screen Builder
3. Open a Form Screen
4. Select a Navigation Button
5. Configure where it should go
6. Finde the Clipboard Page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21178

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
