### PR TITLE
FOUR-21178 : Navigation button shouldn't have the clipboard page as an option

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   test:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -411,7 +411,7 @@
                   ''
                 )}`"
                 :builder="builder"
-                :form-config="extendedPages"
+                :form-config="config"
                 :screen-type="screenType"
                 :current-page="currentPage"
                 :selected-control="selected"


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Navigation button shouldn't have the clipboard page as an option
Actual behavior: 
Navigation button  have the clipboard page as an option
## Solution
- remove extended config and add  the config to the clipboard so the clipboard was removed
<img width="1160" alt="image" src="https://github.com/user-attachments/assets/b8fe25e9-ea77-45c9-a481-82f7627a97c5" />
 

## How to Test
datailed in the ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21178

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
.