### PR TITLE
FOUR-21685: The value set in the aria label field of the select list disappears after refreshing the page

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -430,7 +430,7 @@ export default {
       return this.value || 'content';
     },
     ariaLabelField() {
-      return this.optionAriaLabel || 'ariaLabel';
+      return this.ariaLabel || 'ariaLabel';
     },
     currentItemToDelete() {
       if (this.removeIndex !== null
@@ -487,7 +487,7 @@ export default {
     this.selectedEndPoint = this.options.selectedEndPoint,
     this.key = this.options.key;
     this.value = this.options.value;
-    this.optionAriaLabel = this.options.optionAriaLabel;
+    this.optionAriaLabel = this.options.ariaLabel;
     this.pmqlQuery = this.options.pmqlQuery;
     this.defaultOptionKey= this.options.defaultOptionKey;
     this.selectedOptions = this.options.selectedOptions;

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -224,6 +224,7 @@ export default [
           optionsList: [],
           key:'value',
           value:'content',
+          ariaLabel: 'ariaLabel',
           valueTypeReturned: 'single',
         },
         helper: null,


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a screen type form
2. Add select list 
3. Configure Show Control As Radio Check box
4. Add some provide values in the three fields (value, content and aria label)
5. Save the changes 
6. Refresh the page
7. Check the value set in aria label to options in select list

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21685

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
