### PR TITLE
FOUR-21691:The values set by calcs in a select list(drop-down) lost after refresh the page

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -585,7 +585,6 @@ export default {
 
     },
     showEditOption(index) {
-      debugger;
       this.optionCardType = 'edit';
       this.editIndex = index;
       this.optionContent = this.optionsList[index][this.valueField];
@@ -606,7 +605,6 @@ export default {
     },
     addOption() {
       const that = this;
-      debugger;
 
       if (this.optionCardType === 'insert') {
         if (this.optionsList.find(item => { return item[that.keyField] === this.optionValue; })) {

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -302,7 +302,7 @@ export default {
       removeIndex: null,
       optionValue: '',
       optionContent: '',
-      optionAriaLabel: '',
+      optionAriaLabel: null,
       showRenderAs: false,
       renderAs: 'dropdown',
       allowMultiSelect: false,
@@ -589,7 +589,7 @@ export default {
       this.optionCardType = 'insert';
       this.optionContent = '';
       this.optionValue = '';
-      this.optionAriaLabel = '';
+      this.optionAriaLabel = null;
       this.showOptionCard = true;
       this.optionError = '';
       this.editIndex = null;

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -302,7 +302,7 @@ export default {
       removeIndex: null,
       optionValue: '',
       optionContent: '',
-      optionAriaLabel: null,
+      optionAriaLabel: '',
       showRenderAs: false,
       renderAs: 'dropdown',
       allowMultiSelect: false,
@@ -549,12 +549,19 @@ export default {
       }
       this.optionsList = [];
       const that = this;
-      jsonList.forEach (item => {
-        that.optionsList.push({
-          [that.keyField]: item[that.keyField],
-          [that.valueField]: item[that.valueField],
-          [that.ariaLabelField]: item[that.ariaLabelField]
-        });
+      jsonList.forEach((item) => {
+        if (that.renderAs === "checkbox") {
+          that.optionsList.push({
+            [that.keyField]: item[that.keyField],
+            [that.valueField]: item[that.valueField],
+            [that.ariaLabelField]: item[that.ariaLabelField]
+          });
+        } else {
+          that.optionsList.push({
+            [that.keyField]: item[that.keyField],
+            [that.valueField]: item[that.valueField]
+          });
+        }
       });
       this.jsonError = '';
     },
@@ -578,46 +585,56 @@ export default {
 
     },
     showEditOption(index) {
+      debugger;
       this.optionCardType = 'edit';
       this.editIndex = index;
       this.optionContent = this.optionsList[index][this.valueField];
       this.optionValue = this.optionsList[index][this.keyField];
-      this.optionAriaLabel = this.optionsList[index][this.ariaLabelField];
+      if (this.renderAs === "checkbox") {
+        this.optionAriaLabel = this.optionsList[index][this.ariaLabelField];
+      }
       this.optionError = '';
     },
     showAddOption() {
       this.optionCardType = 'insert';
       this.optionContent = '';
       this.optionValue = '';
-      this.optionAriaLabel = null;
+      this.optionAriaLabel = '';
       this.showOptionCard = true;
       this.optionError = '';
       this.editIndex = null;
     },
     addOption() {
       const that = this;
+      debugger;
 
       if (this.optionCardType === 'insert') {
         if (this.optionsList.find(item => { return item[that.keyField] === this.optionValue; })) {
           this.optionError = 'An item with the same key already exists';
           return;
         }
-        this.optionsList.push(
-          {
+        if (this.renderAs === "checkbox") {
+          this.optionsList.push({
             [this.valueField]: this.optionContent,
             [this.keyField]: this.optionValue,
-            [this.ariaLabelField]: this.optionAriaLabel,
-          }
-        );
-      }
-      else {
+            [this.ariaLabelField]: this.optionAriaLabel
+          });
+        } else {
+          this.optionsList.push({
+            [this.valueField]: this.optionContent,
+            [this.keyField]: this.optionValue
+          });
+        }
+      } else {
         if (this.optionsList.find((item, index) => { return item[that.keyField] === this.optionValue && index !== this.editIndex ; })) {
           this.optionError = 'An item with the same key already exists';
           return;
         }
         this.optionsList[this.editIndex][this.keyField] = this.optionValue;
         this.optionsList[this.editIndex][this.valueField] = this.optionContent;
-        this.optionsList[this.editIndex][this.ariaLabelField] = this.optionAriaLabel;
+        if (this.renderAs === "checkbox") {
+          this.optionsList[this.editIndex][this.ariaLabelField] = this.optionAriaLabel;
+        }
       }
 
       this.jsonData = JSON.stringify(this.optionsList);

--- a/tests/e2e/specs/FormSelectList.spec.js
+++ b/tests/e2e/specs/FormSelectList.spec.js
@@ -348,14 +348,14 @@ describe("Form Select List", () => {
     cy.get("[data-cy=inspector-edit-json]").click();
 
     cy.assertComponentValueAsJson('[data-cy="inspector-monaco-json"]', [
-      { content: "one", value: "one", ariaLabel: "" }
+      { content: "one", value: "one", ariaLabel: null }
     ]);
 
     cy.setVueComponentValue(
       '[data-cy="inspector-monaco-json"]',
       JSON.stringify([
-        { content: "one", value: "one", ariaLabel: "" },
-        { content: "two", value: "two", ariaLabel: "" }
+        { content: "one", value: "one", ariaLabel: null },
+        { content: "two", value: "two", ariaLabel: null }
       ])
     );
     cy.get("[data-cy=inspector-monaco-json-expand]").click();
@@ -363,8 +363,8 @@ describe("Form Select List", () => {
       '[data-cy="inspector-monaco-json-expanded"]',
       JSON.stringify(
         [
-          { content: "one", value: "one", ariaLabel: "" },
-          { content: "two", value: "two", ariaLabel: "" }
+          { content: "one", value: "one", ariaLabel: null },
+          { content: "two", value: "two", ariaLabel: null }
         ],
         null,
         2

--- a/tests/e2e/specs/FormSelectList.spec.js
+++ b/tests/e2e/specs/FormSelectList.spec.js
@@ -348,14 +348,14 @@ describe("Form Select List", () => {
     cy.get("[data-cy=inspector-edit-json]").click();
 
     cy.assertComponentValueAsJson('[data-cy="inspector-monaco-json"]', [
-      { content: "one", value: "one", ariaLabel: null }
+      { content: "one", value: "one", ariaLabel: "" }
     ]);
 
     cy.setVueComponentValue(
       '[data-cy="inspector-monaco-json"]',
       JSON.stringify([
-        { content: "one", value: "one", ariaLabel: null },
-        { content: "two", value: "two", ariaLabel: null }
+        { content: "one", value: "one", ariaLabel: "" },
+        { content: "two", value: "two", ariaLabel: "" }
       ])
     );
     cy.get("[data-cy=inspector-monaco-json-expand]").click();
@@ -363,8 +363,8 @@ describe("Form Select List", () => {
       '[data-cy="inspector-monaco-json-expanded"]',
       JSON.stringify(
         [
-          { content: "one", value: "one", ariaLabel: null },
-          { content: "two", value: "two", ariaLabel: null }
+          { content: "one", value: "one", ariaLabel: "" },
+          { content: "two", value: "two", ariaLabel: "" }
         ],
         null,
         2

--- a/tests/e2e/specs/FormSelectList.spec.js
+++ b/tests/e2e/specs/FormSelectList.spec.js
@@ -348,14 +348,14 @@ describe("Form Select List", () => {
     cy.get("[data-cy=inspector-edit-json]").click();
 
     cy.assertComponentValueAsJson('[data-cy="inspector-monaco-json"]', [
-      { content: "one", value: "one", ariaLabel: "" }
+      { content: "one", value: "one" }
     ]);
 
     cy.setVueComponentValue(
       '[data-cy="inspector-monaco-json"]',
       JSON.stringify([
-        { content: "one", value: "one", ariaLabel: "" },
-        { content: "two", value: "two", ariaLabel: "" }
+        { content: "one", value: "one" },
+        { content: "two", value: "two" }
       ])
     );
     cy.get("[data-cy=inspector-monaco-json-expand]").click();
@@ -363,8 +363,8 @@ describe("Form Select List", () => {
       '[data-cy="inspector-monaco-json-expanded"]',
       JSON.stringify(
         [
-          { content: "one", value: "one", ariaLabel: "" },
-          { content: "two", value: "two", ariaLabel: "" }
+          { content: "one", value: "one" },
+          { content: "two", value: "two" }
         ],
         null,
         2


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen 
2. Add select list 
3. Configure the select list with provide values
4. Set the select list with object type
5. Put some values in the provide values
6. Create a cal to set the select list
7. Click on preview
8. The select is working with calculate properties
9. Refresh the page
10. Click on preview button 

**Current Behavior**
The values set bu calculated properties lost after refresh the page 

**Expected Behavior**
The values set bu calculated properties lost after refresh the page

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21691

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
