### PR TITLE
FOUR-21660: The form screen is shown as conversational when we start a new case

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -890,6 +890,8 @@ export default {
         if (this.renderComponent === "ConversationalForm") {
           window.location.href = `/tasks/${this.taskId}/edit`;
         }
+
+        this.reload();
       }
     },
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -878,16 +878,18 @@ export default {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.
         if (this.task && !(this.task.allow_interstitial || this.isSameUser(this.task, data))) {
-           // The getDestinationUrl() function is called asynchronously to retrieve the URL
+          // The getDestinationUrl() function is called asynchronously to retrieve the URL
           window.location.href = await this.getDestinationUrl();
           return;
         }
         this.nodeId = data.params[0].nodeId;
         this.taskId = data.params[0].tokenId;
 
-        // Force a redirect to ensure the correct task is loaded immediately.
-        // This prevents async reloads that may cause inconsistencies.
-        window.location.href = `/tasks/${this.taskId}/edit`;
+        // Force a redirect to ensure the correct task is loaded immediately for ConversationalForm.
+        // This prevents async reloads that may cause inconsistencies specific to ConversationalForm.
+        if (this.renderComponent === "ConversationalForm") {
+          window.location.href = `/tasks/${this.taskId}/edit`;
+        }
       }
     },
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -884,7 +884,10 @@ export default {
         }
         this.nodeId = data.params[0].nodeId;
         this.taskId = data.params[0].tokenId;
-        this.reload();
+
+        // Force a redirect to ensure the correct task is loaded immediately.
+        // This prevents async reloads that may cause inconsistencies.
+        window.location.href = `/tasks/${this.taskId}/edit`;
       }
     },
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
- If we have two tasks and each one has a different type of screen, the screens should not change type in execution mode.


Actual behavior: 
- The conversational screen that is in the first task is completed and the controls of the next form screen are being displayed as if they were part of the conversational screen.

## Solution
- The issue was caused by the logic flow in handleRedirectToTask(), where loadTask() was being used instead of a hard redirect.
- The fix was to force a navigation to the correct task screen using window.location.href

## How to Test
- Follow the reproduction steps from the JIRA ticket.

## Related Tickets & Packages
- [FOUR-21660](https://processmaker.atlassian.net/browse/FOUR-21660)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-21660]: https://processmaker.atlassian.net/browse/FOUR-21660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ