### PR TITLE
FOUR-21710:The options in the select list disappears to record list with collection configured

### DIFF
--- a/src/components/inspector/collection-data-source.vue
+++ b/src/components/inspector/collection-data-source.vue
@@ -33,7 +33,7 @@
       <small class="mt-3 form-text text-muted">
         {{ $t("Leave this field empty to show all the records of the collection") }}
       </small>
-      <label id="data-selection" class="mt-3">{{ $t("Data Selection") }}</label>
+      <label for="data-selection" class="mt-3">{{ $t("Data Selection") }}</label>
       <b-form-select
         id="data-selection"
         v-model="dataSelectionOptions"
@@ -44,7 +44,7 @@
         {{ $t("The user can select specific data to be stored into a variable") }}
       </small>
       <div v-if="dataSelectionOptions === 'single-field'" class="mt-3">
-        <label id="single-columns">{{ $t("Column") }}</label>
+        <label for="single-columns">{{ $t("Column") }}</label>
         <b-form-select
           id="single-columns"
           v-model="singleField"
@@ -190,7 +190,7 @@ export default {
       if (firstRecord?.data) {
         const dataObject = firstRecord.data;
 
-        for (const [key, value] of Object.entries(dataObject)) {
+        for (const [key] of Object.entries(dataObject)) {
           this.singleFieldOptions.push({ text: key, value: key });
         }
       }

--- a/src/components/inspector/collection-data-source.vue
+++ b/src/components/inspector/collection-data-source.vue
@@ -1,26 +1,25 @@
 <template>
+  <div>
     <div>
-      <div>
-        <label for="collectionsource">{{ $t("Source of Record List") }}</label>
-        <b-form-select
-          id="collectionsource"
-          v-model="sourceOptions"
-          :options="sourceDisplayOptions"
-          data-cy="inspector-collection-data-source"
-          @change="displayOptionChange"
-        />
-        <small class="mt-3 form-text text-muted">{{
-        $t("A record list can display the data of a defined variable or a collection")
-      }}</small>
-      </div>
-      <div class="mt-2" v-if="sourceOptions === 'Collection'">
-
-         <CollectionRecordsList 
-         v-model="collectionFields"
-         :record-pmql="pmql"
-         @change="collectionChanged"/>
-
-         <pmql-input
+      <label for="collectionsource">{{ $t("Source of Record List") }}</label>
+      <b-form-select
+        id="collectionsource"
+        v-model="sourceOptions"
+        :options="sourceDisplayOptions"
+        data-cy="inspector-collection-data-source"
+        @change="displayOptionChange"
+      />
+      <small class="mt-3 form-text text-muted">
+        {{ $t("A record list can display the data of a defined variable or a collection") }}
+      </small>
+    </div>
+    <div v-if="sourceOptions === 'Collection'" class="mt-2">
+      <CollectionRecordsList
+        v-model="collectionFields"
+        :record-pmql="pmql"
+        @change="collectionChanged"
+      />
+      <pmql-input
         v-model="pmql"
         :search-type="'collections_w_mustaches'"
         class="mt-3 mb-1"
@@ -31,172 +30,171 @@
         :placeholder="$t('PMQL')"
       >
       </pmql-input>
-      <small class="mt-3 form-text text-muted">{{
-        $t("Leave this field empty to show all the records of the collection")
-      }}</small>
-        <label class="mt-3" id="data-selection">{{ $t("Data Selection") }}</label>
-
+      <small class="mt-3 form-text text-muted">
+        {{ $t("Leave this field empty to show all the records of the collection") }}
+      </small>
+      <label id="data-selection" class="mt-3">{{ $t("Data Selection") }}</label>
+      <b-form-select
+        id="data-selection"
+        v-model="dataSelectionOptions"
+        :options="dataSelectionDisplayOptions"
+        data-cy="inspector-collection-data-selection"
+      />
+      <small class="mt-3 form-text text-muted">
+        {{ $t("The user can select specific data to be stored into a variable") }}
+      </small>
+      <div v-if="dataSelectionOptions === 'single-field'" class="mt-3">
+        <label id="single-columns">{{ $t("Column") }}</label>
         <b-form-select
-          id="data-selection"
-          v-model="dataSelectionOptions"
-          :options="dataSelectionDisplayOptions"
-          data-cy="inspector-collection-data-selection"
-        />
-        <small class="mt-3 form-text text-muted">{{
-        $t("The user can select specific data to be stored into a variable")
-      }}</small>
-
-        <div class="mt-3" v-if="dataSelectionOptions === 'single-field'">
-          <label id="single-columns">{{ $t('Column') }}</label>
-          <b-form-select
           id="single-columns"
           v-model="singleField"
           :options="singleFieldOptions"
           data-cy="inspector-collection-single-field"
         >
-        <option disabled value="">{{ $t("Select a column") }}</option>
-          </b-form-select>
-        </div>
+          <option disabled value="">{{ $t("Select a column") }}</option>
+        </b-form-select>
       </div>
     </div>
-  </template>
-  <script>
+  </div>
+</template>
+<script>
+import { cloneDeep } from "lodash";
+import CollectionRecordsList from "./collection-records-list.vue";
 
-  import CollectionRecordsList from "./collection-records-list.vue"
-  import { cloneDeep } from "lodash";
-
-  const CONFIG_FIELDS = [
-    "collectionFields",
-    "collectionFieldsColumns",
-    "pmql",
-    "sourceOptions",
-    "variableStore",
-    "dataSelectionOptions",
-    "singleField"
-  ];
-  export default {
-    components: {
-      CollectionRecordsList
-    },
-    props: ["value", "screenType"],
-    data() {
-      return {
-        fields: [],
-        sourceOptions: "Variable",
-        submitCollectionCheck: true,
-        sourceDisplayOptions: [],
-        collectionFields: [],
-        collectionFieldsColumns: [],
-        variableStore: null,
-        pmql: null,
-        sourceDisplayOptions: [
+const CONFIG_FIELDS = [
+  "collectionFields",
+  "collectionFieldsColumns",
+  "pmql",
+  "sourceOptions",
+  "variableStore",
+  "dataSelectionOptions",
+  "singleField"
+];
+export default {
+  components: {
+    CollectionRecordsList
+  },
+  props: ["value", "screenType"],
+  data() {
+    return {
+      fields: [],
+      sourceOptions: "Variable",
+      submitCollectionCheck: true,
+      collectionFields: [],
+      collectionFieldsColumns: [],
+      variableStore: null,
+      pmql: null,
+      sourceDisplayOptions: [
         {
-          text: this.$t('Variable'),
-          value: 'Variable',
+          text: this.$t("Variable"),
+          value: "Variable"
         },
         {
-          text: this.$t('Collection'),
-          value: 'Collection',
-        },
+          text: this.$t("Collection"),
+          value: "Collection"
+        }
       ],
       dataSelectionDisplayOptions: [
         {
-          text: this.$t('Do not allow selection'),
-          value: 'no-selection',
+          text: this.$t("Do not allow selection"),
+          value: "no-selection"
         },
         {
-          text: this.$t('Single field of record'),
-          value: 'single-field',
+          text: this.$t("Single field of record"),
+          value: "single-field"
         },
         {
-          text: this.$t('Single record'),
-          value: 'single-record',
+          text: this.$t("Single record"),
+          value: "single-record"
         },
         {
-          text: this.$t('Multiple records'),
-          value: 'multiple-records',
-        },
+          text: this.$t("Multiple records"),
+          value: "multiple-records"
+        }
       ],
-      dataSelectionOptions: "no-selection", 
+      dataSelectionOptions: "no-selection",
       collectionColumns: [],
       singleFieldOptions: [],
       singleField: null
-      };
-    },
-    methods: {
-      displayOptionChange() {
-        this.collectionFields = [];
-        this.collectionFieldsColumns = [];
-        this.pmql = null;
-        this.$root.$emit("collection-changed", true);
-      },
-      collectionChanged(data) {
-        if (Array.isArray(data)) {
-            const [firstItem] = data;
-            const collectionId = firstItem?.collection_id;
-            if(collectionId !== this.collectionFields.collectionId) {
-              this.$root.$emit("collection-changed", true);
-            }
+    };
+  },
+  computed: {
+    options() {
+      return Object.fromEntries(
+        CONFIG_FIELDS.map((field) => [field, this[field]])
+      );
+    }
+  },
+  watch: {
+    value: {
+      handler(value) {
+        if (!value) {
+          return;
         }
+        CONFIG_FIELDS.forEach((field) => (this[field] = value[field]));
       },
-      getCollectionColumns(records) {
-        const [firstRecord] = records?.dataRecordList || [];
-
-        if (firstRecord?.data) {
-          const dataObject = firstRecord.data;
-
-          for (const [key, value] of Object.entries(dataObject)) {
-            this.singleFieldOptions.push({ text: key, value: key });
-          }
-        }
-      },
+      immediate: true
     },
-    computed: {
-      options() {
-        return Object.fromEntries(
-          CONFIG_FIELDS.map((field) => [field, this[field]])
-        );
+    sourceOptions: {
+      handler(changeOption) {
+        this.$root.$emit("record-list-option", changeOption);
       }
     },
-    watch: {
-      value: {
-        handler(value) {
-          if (!value) {
-            return;
-          }
-          CONFIG_FIELDS.forEach((field) => (this[field] = value[field]));
-        },
-        immediate: true
+    collectionFields: {
+      handler(collectionFieldsData) {
+        this.getCollectionColumns(collectionFieldsData);
+        this.$root.$emit("record-list-collection", collectionFieldsData);
       },
-      sourceOptions: {
-        handler(changeOption) {
-           this.$root.$emit("record-list-option", changeOption);
-        }
-      },
-      collectionFields: {
-        handler(collectionFieldsData) {
-           this.getCollectionColumns(collectionFieldsData);
-           this.$root.$emit("record-list-collection", collectionFieldsData);
-        },
-        deep: true
-      },
-      pmql: {
-        handler(newPmql) {
-            this.$root.$emit("change-pmql", newPmql);
-        }
-      },
-      submitCollectionCheck(newValue) {
-        this.submitCollectionCheck = newValue;
-      },
-      options: {
-        handler() {
-          this.$emit("input", this.options);
-        },
-        deep: true
-      },
-      dataSelectionOptions() {
-        this.singleField = null;
+      deep: true
+    },
+    pmql: {
+      handler(newPmql) {
+        this.$root.$emit("change-pmql", newPmql);
       }
     },
-  };
-  </script>
+    submitCollectionCheck(newValue) {
+      this.submitCollectionCheck = newValue;
+    },
+    options: {
+      handler() {
+        this.$emit("input", this.options);
+      },
+      deep: true
+    },
+    dataSelectionOptions() {
+      this.singleField = null;
+    }
+  },
+  mounted() {
+    this.$root.$emit("record-list-option", this.sourceOptions);
+  },
+  methods: {
+    displayOptionChange() {
+      this.collectionFields = [];
+      this.collectionFieldsColumns = [];
+      this.pmql = null;
+      this.$root.$emit("collection-changed", true);
+    },
+    collectionChanged(data) {
+      if (Array.isArray(data)) {
+        const [firstItem] = data;
+        const collectionId = firstItem?.collection_id;
+        if (collectionId !== this.collectionFields.collectionId) {
+          this.$root.$emit("collection-changed", true);
+        }
+      }
+    },
+    getCollectionColumns(records) {
+      const [firstRecord] = records?.dataRecordList || [];
+
+      if (firstRecord?.data) {
+        const dataObject = firstRecord.data;
+
+        for (const [key, value] of Object.entries(dataObject)) {
+          this.singleFieldOptions.push({ text: key, value: key });
+        }
+      }
+    }
+  }
+};
+</script>

--- a/src/components/inspector/column-setup.vue
+++ b/src/components/inspector/column-setup.vue
@@ -360,10 +360,9 @@ export default {
   mounted() {
     this.initData();
     this.$root.$on("record-list-option", (val) => {
-      this.$nextTick(()=>{
-        this.isCollection = (val === "Collection") ? true : false;
+      this.$nextTick(() => {
+        this.isCollection = val === "Collection";
       });
-      
     });
     this.$root.$on("record-list-collection", (collectionData) => {
       this.getCollectionColumns(collectionData);


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen form 
2. Add record list 
3. Configure the select list with Collection 
4. Add Columns in the record list
5. Publish the changes 
6. Refresh the page 
7. Select the record list
8. Go to column
9. Add a new column 
10. Search for the options in the select list 

**Current Behavior**
The select list disappears after refresh the page Instead it only shows a line input 

**Expected Behavior**
The select list with options to record list should remain after the refresh the page 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21710

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
