### PR TITLE
Cannot create a pmblock with the language translation Português and Na Vosa Vakaviti (Fijian)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -340,6 +340,10 @@ import "./assets/css/tabs.css";
 // To include another language in the Validator with variable processmaker
 const globalObject = typeof window === "undefined" ? global : window;
 
+if (typeof globalObject.ProcessMaker?.setValidatorLanguage === 'function') {
+  globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
+}
+
 /* istanbul ignore next */
 Validator.register(
   "attr-value",
@@ -540,9 +544,11 @@ export default {
     if (
       globalObject.ProcessMaker &&
       globalObject.ProcessMaker.user &&
-      globalObject.ProcessMaker.user.lang
+      globalObject.ProcessMaker.user.lang &&
+      typeof globalObject.ProcessMaker.setValidatorLanguage === 'function'
     ) {
-      Validator.useLang(globalObject.ProcessMaker.user.lang);
+      //Validator.useLang(globalObject.ProcessMaker.user.lang);
+      globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
     }
     // Iterate through our initial config set, calling this.addControl
     controlConfig.forEach((config) => {
@@ -672,9 +678,11 @@ export default {
         if (
           globalObject.ProcessMaker &&
           globalObject.ProcessMaker.user &&
-          globalObject.ProcessMaker.user.lang
+          globalObject.ProcessMaker.user.lang &&
+          typeof globalObject.ProcessMaker.setValidatorLanguage === 'function'
         ) {
-          Validator.useLang(globalObject.ProcessMaker.user.lang);
+          globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
+          //Validator.useLang(globalObject.ProcessMaker.user.lang);
         }
 
         // Validation will not run until you call passes/fails on it

--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -568,9 +568,10 @@ const globalObject = typeof window === "undefined" ? global : window;
 if (
   globalObject.ProcessMaker &&
   globalObject.ProcessMaker.user &&
-  globalObject.ProcessMaker.user.lang
+  globalObject.ProcessMaker.user.lang &&
+  typeof globalObject.ProcessMaker.setValidatorLanguage === 'function'
 ) {
-  Validator.useLang(globalObject.ProcessMaker.user.lang);
+  globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
 }
 
 // Todo: Validation messages are not translated. These will need to be converted


### PR DESCRIPTION
## Issue & Reproduction Steps


1. Log-in
2. Go to translations and create a non major language like Afrikaans, Gallician, Catalan
3. Generate all the translations of the plataform for the language of step 2.
4. Select as the System language the language selected in step2.
5. Create a PMBlock

**Current Behavior**
The PMBlock configuation tabs are note displayed

**Expected Behavior**
A user should be able to create a PM Block with any language

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21898

## Solution:
The problem was caused by the limited set of translations that the library validator.js supports. We added code to use english as a fallback language.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:processmaker:bugfix/FOUR-21898
ci:package-pm-blocks:bugfix/FOUR-21898
ci:vue-form-elements:bugfix/FOUR-21898