### PR TITLE
FOUR-21952 : "This content does not exist. We could not locate indicated data" alert error appears in Collection record control even though the id exists

### DIFF
--- a/src/components/inspector/collection-display-mode.vue
+++ b/src/components/inspector/collection-display-mode.vue
@@ -1,86 +1,68 @@
 <template>
   <div>
     <div>
-      <label for="collectionmode">{{ $t("Mode") }}</label>
+      <label for="collection-mode">{{ $t(label) }}</label>
       <b-form-select
-        id="collectionmode"
-        v-model="modeId"
-        :options="displayOptions"
+        id="collection-mode"
+        v-model="mode"
+        :options="options"
         data-cy="inspector-collection"
+        @change="saveFields"
       />
     </div>
-    <div class="mt-2" v-if="modeId !== 'View'">
-      <b-form-checkbox v-model="submitCollectionCheck">
-      {{  $t("Update collection on submit") }}
+    <div v-show="showCollectionCheck" class="mt-2">
+      <b-form-checkbox v-model="submitCollectionCheck" @change="saveFields">
+        {{ $t("Update collection on submit") }}
       </b-form-checkbox>
     </div>
   </div>
 </template>
 
 <script>
-import ScreenVariableSelector from "../screen-variable-selector.vue";
-
-const CONFIG_FIELDS = ["modeId", "submitCollectionCheck"];
 export default {
-  components: {
-    ScreenVariableSelector
-  },
-  props: ["value", "screenType"],
-  data() {
-    return {
-      fields: [],
-      modeId: null,
-      submitCollectionCheck: true,
-      displayOptions: []
-    };
-  },
-  mounted() {
-    this.getFields();
-  },
-  computed: {
-    options() {
-      return Object.fromEntries(
-        CONFIG_FIELDS.map((field) => [field, this[field]])
-      );
-    }
-  },
-  watch: {
+  props: {
     value: {
-      handler(value) {
-        if (!value) {
-          return;
-        }
-        CONFIG_FIELDS.forEach((field) => (this[field] = value[field]));
-      },
-      immediate: true
-    },
-    modeId: {
-      handler() {
-        this.getFields();
-      }
-    },
-    submitCollectionCheck(newValue) {
-      this.submitCollectionCheck = newValue;
+      type: Object,
+      default: () => ({})
     },
     screenType: {
-      handler() {
-        this.getFields();
-      },
-      immediate: true
+      type: String,
+      default: ""
     },
     options: {
-      handler() {
-        this.$emit("input", this.options);
-      },
-      deep: true
+      type: Array,
+      default: () => []
+    },
+    label: {
+      type: String,
+      default: ""
     }
   },
+  data() {
+    return {
+      mode: "",
+      submitCollectionCheck: null
+    };
+  },
+  computed: {
+    showCollectionCheck() {
+      return this.mode === "Edit";
+    }
+  },
+  mounted() {
+    // Set the defaulta data
+    this.mode = this.value.modeId || "Edit";
+    this.submitCollectionCheck =
+      this.value.submitCollectionCheck !== undefined
+        ? this.value.submitCollectionCheck
+        : true;
+  },
   methods: {
-    getFields() {
-      this.displayOptions = [
-        { value: "Edit", text: "Edit" },
-        { value: "View", text: "View" }
-      ];
+    saveFields() {
+      this.$emit("input", {
+        modeId: this.mode,
+        submitCollectionCheck: this.submitCollectionCheck
+      });
     }
   }
 };

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -1157,6 +1157,10 @@ export default [
           field: "collectionmode",
           config: {
             label: "Mode",
+            options: [
+              { value: "Edit", text: "Edit" },
+              { value: "View", text: "View" },
+            ]
           }
         },
       ],


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Import collections with records
2. Create screen form 
3. Add Collection Record control
4. Set one collection with record 
5. Type one id record that exits

**Current Behavior**
"This content does not exist. We could not locate indicated data" alert error appears in Collection record control even though the id exists and this is valid

**Expected Behavior**
"This content does not exist. We could not locate indicated data" alert error should appears in Collection record control when the id record does not exits

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21952

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy