### PR TITLE
FOUR-22021: Default variables are not displayed on a screen when using a language other than English

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -329,7 +329,7 @@
                       : null
                   "
                   @focusout.native="updateState"
-                  
+
                 />
               </div>
             </div>
@@ -1476,8 +1476,12 @@ export default {
       }
 
       // Generate Variable Name
+      const keyNamePropertyToFind = _.cloneDeep(keyNameProperty);
+      delete keyNamePropertyToFind.config.helper;
+      delete keyNamePropertyToFind.config.label;
+
       if (
-        _.findIndex(control.inspector, keyNameProperty) !== -1 ||
+        _.findIndex(control.inspector, keyNamePropertyToFind) !== -1 ||
         control.component === "FormLoop"
       ) {
         [this.variables, copy.config.name] = this.generator.generate(

--- a/src/main.js
+++ b/src/main.js
@@ -163,6 +163,9 @@ window.ProcessMaker = {
   app: {
     url: `${protocol}//${hostname}:${port}` // Create a URL with the current port
   },
+  setValidatorLanguage(language) {
+    window.ProcessMaker.user.lang = 'en';
+  },
   apiClient: {
     create() {
       return this;


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a screen
- On the screen click on the flag and change the language e.g. Spanish
- Add a line input/Select list/ etc

**Actual Behavior:**
The default variables of the components are not displayed.

**Current behavior:** 
As in previous versions, this change of language should not affect the assignment of the default variable of the components of a screen.

## Solution
- When adding a new control to a screen, now the inspector configuration uses an object without translated attributes

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22021

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:release-2025-winter