### PR TITLE
FOUR-22166 Collection Record ID is not visible in preview screen

### DIFF
--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -63,7 +63,8 @@ export default {
       flagDraft: {},
       taskDraft: {},
       enableDraft: true,
-      defaultColumnsRecordId: 1
+      defaultColumnsRecordId: 1,
+      defaultCollectionMode: 'Edit',
     };
   },
   computed: {
@@ -148,13 +149,17 @@ export default {
       const recordId = this.isMustache(this.record)
         ? this.defaultColumnsRecordId
         : this.record;
+
       if (this.isMustache(this.record)) {
         this.hasMustache = true;
       }
+
+      const collectionMode = this.collectionmode?.modeId ?? this.defaultCollectionMode;
+
       this.loadRecordCollection(
         this.collection.collectionId,
         recordId,
-        this.collectionmode.modeId
+        collectionMode,
       );
     }
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
Collection Record ID is not visible in preview screen

Expected behavior: 
Collection Record ID should be visible in preview

Actual behavior: 
Collection Record ID is not visible in preview

## Solution
- Add a default collection mode

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-22166](https://processmaker.atlassian.net/browse/FOUR-22166)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22166]: https://processmaker.atlassian.net/browse/FOUR-22166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ