### PR TITLE
FOUR-22168 collection record control settings are copied when selection is inserted

### DIFF
--- a/src/components/inspector/collection-display-mode.vue
+++ b/src/components/inspector/collection-display-mode.vue
@@ -41,23 +41,37 @@ export default {
   data() {
     return {
       mode: "",
-      submitCollectionCheck: null
+      submitCollectionCheck: null,
+      defaultMode: 'Edit',
     };
   },
   computed: {
     showCollectionCheck() {
-      return this.mode === "Edit";
+      return this.mode === this.defaultMode;
+    }
+  },
+  watch: {
+    value: {
+      handler(newValue) {
+        this.updateModeAndCollectionCheck(newValue);
+      },
+      deep: true,
     }
   },
   mounted() {
-    // Set the defaulta data
-    this.mode = this.value.modeId || "Edit";
-    this.submitCollectionCheck =
-      this.value.submitCollectionCheck !== undefined
-        ? this.value.submitCollectionCheck
-        : true;
+    // Set the default data
+    this.updateModeAndCollectionCheck(this.value);
   },
   methods: {
+    /**
+     * Update the mode and collection check value
+     *
+     * @param {Object} value
+     */
+    updateModeAndCollectionCheck(value) {
+      this.mode = value.modeId || this.defaultMode;
+      this.submitCollectionCheck = value.submitCollectionCheck ?? true;
+    },
     saveFields() {
       this.$emit("input", {
         modeId: this.mode,

--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -10,15 +10,15 @@
           data-cy="inspector-collection"
         />
         <b-form-text class="mt-2">
-        {{ $t("Collection Record Control is not available for Anonymous Web Entry") }} 
+        {{ $t("Collection Record Control is not available for Anonymous Web Entry") }}
         </b-form-text>
     </b-form-group>
     </div>
     <div v-if="collectionId > 0" class="screen-link mt-2">
-      <a 
+      <a
         :href="`/designer/screen-builder/${
           screenMode === 'display' ? idCollectionScreenView : idCollectionScreenEdit
-          }/edit`" 
+          }/edit`"
           target="_blank">
         {{ $t(screenMode === 'display' ? "Open View Screen" : "Open Edit Screen") }}
         <i class="ml-1 fas fa-external-link-alt" />
@@ -67,11 +67,15 @@ export default {
   },
   watch: {
     value: {
-      handler(value) {
-        if (!value) {
+      handler(newValue) {
+        if (!newValue) {
+          // Clear collection id
+          this.collectionId = null;
+
           return;
         }
-        CONFIG_FIELDS.forEach((field) => (this[field] = value[field]));
+
+        CONFIG_FIELDS.forEach((field) => (this[field] = newValue[field]));
       },
       immediate: true
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Collection Record control settings are copied when a selection is inserted

Expected behavior: 
The options should not be copied in the collection record control, Each one should remain its own configuration like in 4.12.2

Actual behavior: 
The options like “Mode: Edit“ are copied in the second collection record when this is selected

## Solution
Update the collection mode and the collection submit for each collection

## How to Test
See the ticket

## Related Tickets & Packages
[FOUR-22168](https://processmaker.atlassian.net/browse/FOUR-22168)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22168]: https://processmaker.atlassian.net/browse/FOUR-22168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ