### PR TITLE
bugfix/FOUR-22187 Fields in a Select list type collection are corrupted after changing its Data source

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -375,6 +375,7 @@ export default {
           break;
         case 'collection':
           this.showRenderAs = false;
+          this.renderAs = 'dropdown';
           this.jsonData = '';
           this.dataName = '';
           this.selectedDataSource = '';


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce

Create Screen form 
Add select list
Configure the select list with data connector 
Enable Radio check box in select list
Change the select list to Collection 
Select one collection
Check the fields 

Expected behavior: 
Fields in a Select list type collection should not be corrupted after changing its Data source

Actual behavior: 
Aria label appears as new field in collection after change the select list of Data connector to Collections as select list as wrong values

## Solution
Reset the renderAs value when collection is selected

