### PR TITLE
observation/FOUR-22498 The select list control displays Rag Collections

### DIFF
--- a/src/components/inspector/collection-select-list.vue
+++ b/src/components/inspector/collection-select-list.vue
@@ -95,7 +95,7 @@ export default {
   props: {
     value: Object,
     renderAs: String,
-    collectionTypeFilter: {
+    excludeCollectionType: {
       type: String,
       default: null
     }
@@ -163,9 +163,9 @@ export default {
         let collections = response.data.data;
 
         // Apply filter if collectionType is set
-        if (this.collectionTypeFilter) {
+        if (this.excludeCollectionType) {
           collections = collections.filter(
-            (collection) => collection.type !== this.collectionTypeFilter
+            (collection) => collection.type !== this.excludeCollectionType
           );
         }
 

--- a/src/components/inspector/collection-select-list.vue
+++ b/src/components/inspector/collection-select-list.vue
@@ -92,7 +92,14 @@ export default {
     MustacheHelper,
     ScreenVariableSelector
   },
-  props: ["value", "renderAs"],
+  props: {
+    value: Object,
+    renderAs: String,
+    collectionTypeFilter: {
+      type: String,
+      default: null
+    }
+  },
   data() {
     return {
       collections: [],
@@ -153,9 +160,18 @@ export default {
     },
     getCollections() {
       this.$dataProvider.getCollections().then((response) => {
+        let collections = response.data.data;
+
+        // Apply filter if collectionType is set
+        if (this.collectionTypeFilter) {
+          collections = collections.filter(
+            (collection) => collection.type !== this.collectionTypeFilter
+          );
+        }
+
         this.collections = [
           { value: null, text: this.$t("Select a collection") },
-          ...response.data.data.map((collection) => {
+          ...collections.map((collection) => {
             return {
               text: collection.name,
               value: collection.id

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -137,7 +137,7 @@
     </div>
     
     <div v-if="dataSource === dataSourceValues.collection">
-      <collection-select-list v-model="collectionOptions" :renderAs="renderAs" collection-type-filter="RAG"></collection-select-list>
+      <collection-select-list v-model="collectionOptions" :renderAs="renderAs" exclude-collection-type="RAG"></collection-select-list>
     </div>
 
     <div v-if="showRenderAs">

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -137,7 +137,7 @@
     </div>
     
     <div v-if="dataSource === dataSourceValues.collection">
-      <collection-select-list v-model="collectionOptions" :renderAs="renderAs"></collection-select-list>
+      <collection-select-list v-model="collectionOptions" :renderAs="renderAs" collection-type-filter="RAG"></collection-select-list>
     </div>
 
     <div v-if="showRenderAs">


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Create a rag collection
2.Create some records.
3.Create a screen
4.Add a select list
5 data source add the rag collection
6.Complete the settings

Expected behavior: 
RAG collections should not be displayed for the select list control.

Actual behavior: 
It only displays the record ID option and the record ID and New input values.

## Solution
Added a filter to the select collection component in the screen builder

## How to Test
Test the steps above

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-22498

