### PR TITLE
FOUR-22483: "Open Edit Screen" shows an Oops! screen

### DIFF
--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -130,10 +130,12 @@ export default {
 
         this.collections = [
           { value: null, text: this.$t("Select a collection") },
-          ...response.data.data.map((collection) => ({
-            text: collection.name,
-            value: collection.id
-          }))
+          ...response.data.data
+              .filter((collection) => collection.type !== 'RAG')
+              .map((collection) => ({
+                text: collection.name,
+                value: collection.id
+              }))
         ];
       });
     },


### PR DESCRIPTION
## Solution
- RAG collection are not displayed in the Collection Record Control as they have a different flow and it is not its intended use.
 
## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-22483
https://processmaker.atlassian.net/browse/FOUR-22484

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
