### PR TITLE
FOUR-22882: Duplicate controls in the Clipboard page doesn't work

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -300,6 +300,7 @@
                     <button
                       class="btn btn-sm btn-primary mr-2"
                       :title="$t('Copy Control')"
+                      data-test="copy-control-btn"
                       @click="duplicateItem(index)"
                     >
                       <i class="fas fa-copy text-light" />
@@ -1326,7 +1327,7 @@ export default {
       this.updateState();
     },
     duplicateItem(index) {
-      const duplicate = _.cloneDeep(this.config[this.currentPage].items[index]);
+      const duplicate = _.cloneDeep(this.extendedPages[this.currentPage].items[index]);
       this.updateUuids(duplicate);
       this.extendedPages[this.currentPage].items.push(duplicate);
     },

--- a/tests/e2e/specs/ClipboardTabDuplicate.spec.js
+++ b/tests/e2e/specs/ClipboardTabDuplicate.spec.js
@@ -1,0 +1,133 @@
+describe("Clipboard Page and Control Duplication", () => {
+
+  beforeEach(() => {
+    cy.clearLocalStorage();
+    cy.visit("/");
+  });
+
+  it("should allow duplicating controls within the clipboard page", () => {
+    //STEP 1: Add initial control to clipboard
+    cy.openAcordeonByLabel("Input Fields");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", { position: "bottom" });
+    
+    //STEP 2: Add control to clipboard
+    cy.get('[data-cy="screen-element-container"]').click();
+    cy.get('[data-cy="addToClipboard"]').should("be.visible").click();
+    cy.get('[data-cy="copied-badge"]').should("exist");
+
+    //STEP 3: Navigate to clipboard page
+    cy.get("[data-test=page-dropdown]").click(); 
+    cy.get("[data-test=clipboard]").click({ force: true });
+
+    //STEP 4: Verify initial control exists
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 1);
+
+    //STEP 5: Test duplicating control multiple times
+    cy.get('[data-cy="screen-element-container"]').first().click();
+    cy.get('[data-test="copy-control-btn"]').click();
+    
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 2);
+
+    cy.get('[data-test="copy-control-btn"]').click();
+    
+    cy.get('[data-cy="editor-content"]')
+      .children() 
+      .should('have.length', 3);
+  });
+
+  it("should maintain control properties when duplicating", () => {
+    //STEP 1: Add and configure initial control
+    cy.openAcordeonByLabel("Input Fields");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", { position: "bottom" });
+    
+    //STEP 2: Configure the control
+    cy.get('[data-cy="screen-element-container"]').click();
+    cy.get('[data-cy="inspector-label"]').clear().type("Test Label");
+    cy.get('[data-cy="inspector-name"]').clear().type("test_field");
+    
+    //STEP 3: Add to clipboard and navigate
+    cy.get('[data-cy="addToClipboard"]').click();
+    cy.get("[data-test=page-dropdown]").click();
+    cy.get("[data-test=clipboard]").click({ force: true });
+    
+    //STEP 4: Duplicate control
+    cy.get('[data-cy="screen-element-container"]').first().click();
+    cy.get('[data-test="copy-control-btn"]').click();
+    
+    //STEP 5: Verify properties are maintained
+    cy.get('[data-cy="screen-element-container"]').eq(1).click();
+    cy.get('[data-cy="inspector-label"]').should('have.value', 'Test Label');
+    cy.get('[data-cy="inspector-name"]').should('have.value', 'test_field');
+  });
+
+
+  it("should handle edge cases in control duplication", () => {
+    //STEP 1: Add control with special characters
+    cy.openAcordeonByLabel("Input Fields");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", { position: "bottom" });
+    
+    //STEP 2: Configure with special characters
+    cy.get('[data-cy="screen-element-container"]').click();
+    cy.get('[data-cy="inspector-label"]').clear().type("Special $#@! Characters");
+    cy.get('[data-cy="inspector-name"]').clear().type("special_chars_123");
+    
+    //STEP 3: Add to clipboard and navigate
+    cy.get('[data-cy="addToClipboard"]').click();
+    cy.get("[data-test=page-dropdown]").click();
+    cy.get("[data-test=clipboard]").click({ force: true });
+    
+    //STEP 4: Rapid duplicate clicks
+    cy.get('[data-cy="screen-element-container"]').first().click();
+    cy.get('[data-test="copy-control-btn"]').click().click().click();
+    
+    //STEP 5: Verify duplicates and properties
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 4);
+    
+    cy.get('[data-cy="screen-element-container"]').last().click();
+    cy.get('[data-cy="inspector-label"]').should('have.value', 'Special $#@! Characters');
+    cy.get('[data-cy="inspector-name"]').should('have.value', 'special_chars_123');
+  });
+
+  it("should allow duplicating controls in the Default page", () => {
+     //STEP 3: Navigate to clipboard page
+     cy.get("[data-test=page-dropdown]").click(); 
+     cy.get("[data-test=page-Default]").click({ force: true });
+    //STEP 1: Add initial control to screen
+    cy.openAcordeonByLabel("Input Fields");
+    cy.get("[data-cy=controls-FormInput]").drag("[data-cy=screen-drop-zone]", { position: "bottom" });
+    
+
+    //STEP 2: Configure the control
+    cy.get('[data-cy="screen-element-container"]').click();
+    cy.get('[data-cy="inspector-label"]').clear().type("Original Control");
+    cy.get('[data-cy="inspector-name"]').clear().type("original_field");
+    
+    //STEP 3: Duplicate control in Default page
+    cy.get('[data-test="copy-control-btn"]').click();
+    
+    //STEP 4: Verify duplicate exists and maintains properties
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 2);
+    
+    cy.get('[data-cy="screen-element-container"]').last().click();
+    cy.get('[data-cy="inspector-label"]').should('have.value', 'Original Control');
+    cy.get('[data-cy="inspector-name"]').should('have.value', 'original_field');
+    
+    //STEP 5: Test multiple duplications
+    cy.get('[data-test="copy-control-btn"]').click();
+    cy.get('[data-test="copy-control-btn"]').click();
+    
+    cy.get('[data-cy="editor-content"]')
+      .children()
+      .should('have.length', 4);
+  });
+
+});
+


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The element clicked should be duplicated within the Clipboard page
Actual behavior: 
The element is NOT duplicated and there is an error displayed in the console
## Solution
- update duplicateItem method to allow duplicate in the clipboard page

https://github.com/user-attachments/assets/f34ebc2a-c773-4b89-94c4-65a46336fc19


## How to Test
Steps are detailed in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22882

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
