### PR TITLE
FOUR-22766: Aria label is duplicated in the rest of the records in the select list when one record is set >> Select list Radio check box

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -472,7 +472,6 @@ export default {
         editIndex: this.editIndex,
         removeIndex: this.removeIndex,
         valueTypeReturned: this.valueTypeReturned,
-        optionAriaLabel: this.optionAriaLabel,
       };
     },
   },
@@ -490,7 +489,6 @@ export default {
     this.selectedEndPoint = this.options.selectedEndPoint,
     this.key = this.options.key;
     this.value = this.options.value;
-    this.optionAriaLabel = this.options.ariaLabel;
     this.pmqlQuery = this.options.pmqlQuery;
     this.defaultOptionKey= this.options.defaultOptionKey;
     this.selectedOptions = this.options.selectedOptions;
@@ -593,8 +591,9 @@ export default {
       this.editIndex = index;
       this.optionContent = this.optionsList[index][this.valueField];
       this.optionValue = this.optionsList[index][this.keyField];
+      this.optionAriaLabel = "";
       if (this.renderAs === "checkbox") {
-        this.optionAriaLabel = this.optionsListExtra[index][this.ariaLabelField];
+        this.optionAriaLabel = this.optionsListExtra[index][this.ariaLabelField] ?? "";
       }
       this.optionError = '';
     },

--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -593,7 +593,9 @@ export default {
       this.optionValue = this.optionsList[index][this.keyField];
       this.optionAriaLabel = "";
       if (this.renderAs === "checkbox") {
-        this.optionAriaLabel = this.optionsListExtra[index][this.ariaLabelField] ?? "";
+        this.optionAriaLabel = this.optionsListExtra[index]
+          ? this.optionsListExtra[index][this.ariaLabelField]
+          : "";
       }
       this.optionError = '';
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen form 
2. Add select list
3. Set some values provide  values
4. Change the select list of Drop-down → Radio Check box 
5. Configure one record in the select list (Arial label), put some value
6. Check the other values aria label in the rest of the records of the select list 

**Current Behavior**
The Aria label filed is repeated in all the records in the select list, when one is set 

**Expected Behavior**
The Aria label should be individual in each of the records in the select list of Radio check box type

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22766

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
