### PR TITLE
bugfix/FOUR-23723 added an new param for redirectListener

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -850,6 +850,10 @@ export default {
      * @param {Object} data - The event data received from the socket listener.
      */
     handleRedirect(data) {
+      // Validate if the task is still active before redirects
+      if (data.params?.activeTokens?.includes(this.taskId)) {
+        return;
+      }
       switch (data.method) {
         case 'redirectToTask':
           this.handleRedirectToTask(data);

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -787,6 +787,128 @@ describe("Task component", () => {
 
     cy.url().should("eq", "http://localhost:5173/requests/3");
   });
+
+  it("Should display form fields and prevent redirect to next task when taskId is in activeTokens", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        created_at: moment().toISOString(),
+        completed_at: moment().toISOString(),
+        due_at: moment().add(1, "day").toISOString(),
+        user: {
+          avatar: "",
+          fullname: "Assigned User"
+        },
+        screen: Screens.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE",
+          user: {
+            avatar: "",
+            fullname: "Requester User"
+          }
+        },
+        process: {
+          id: 1,
+          name: "Process Name"
+        },
+        user_request_permission: [{ process_request_id: 1, allowed: true }]
+      }
+    );
+
+    cy.visit("/?scenario=TaskAssigned", {
+      onBeforeLoad(win) {
+        const requestIdMeta = win.document.createElement("meta");
+        requestIdMeta.setAttribute("name", "request-id");
+        requestIdMeta.setAttribute("content", "1");
+        win.document.head.appendChild(requestIdMeta);
+      }
+    });
+
+    cy.wait(2000);
+    cy.get("[data-cy=screen-field-firstname]").should("be.visible");
+    cy.get("[data-cy=screen-field-lastname]").should("be.visible");
+    
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: {
+        "0": {
+          nodeId: 'node_2',
+          tokenId: 2,
+          userId: 1,
+        },
+      
+        activeTokens: [1,2,3],
+      },
+      method: "redirectToTask"
+    });
+    cy.get("[data-cy=screen-field-firstname]").should("be.visible");
+    cy.get("[data-cy=screen-field-lastname]").should("be.visible");
+  });
+  
+  it("Should display form fields and redirect to next task when taskId is not in activeTokens", () => {
+    initializeTaskAndScreenIntercepts(
+      "GET",
+      "http://localhost:5173/api/1.1/tasks/1?include=data,user,draft,requestor,processRequest,component,screen,requestData,loopContext,bpmnTagName,interstitial,definition,nested,userRequestPermission,elementDestination",
+      {
+        id: 1,
+        advanceStatus: "open",
+        component: "task-screen",
+        created_at: moment().toISOString(),
+        completed_at: moment().toISOString(),
+        due_at: moment().add(1, "day").toISOString(),
+        user: {
+          avatar: "",
+          fullname: "Assigned User"
+        },
+        screen: Screens.screens[0],
+        process_request: {
+          id: 1,
+          status: "ACTIVE",
+          user: {
+            avatar: "",
+            fullname: "Requester User"
+          }
+        },
+        process: {
+          id: 1,
+          name: "Process Name"
+        },
+        user_request_permission: [{ process_request_id: 1, allowed: true }]
+      }
+    );
+
+    cy.visit("/?scenario=TaskAssigned", {
+      onBeforeLoad(win) {
+        const requestIdMeta = win.document.createElement("meta");
+        requestIdMeta.setAttribute("name", "request-id");
+        requestIdMeta.setAttribute("content", "1");
+        win.document.head.appendChild(requestIdMeta);
+      }
+    });
+
+    cy.wait(2000);
+    cy.get("[data-cy=screen-field-firstname]").should("be.visible");
+    cy.get("[data-cy=screen-field-lastname]").should("be.visible");
+    
+    cy.socketEventNext("ProcessMaker\\Events\\RedirectTo", {
+      params: {
+        "0": {
+          nodeId: 'node_2',
+          tokenId: 2,
+          userId: 1,
+        },
+      
+        activeTokens: [2,3],
+      },
+      method: "redirectToTask"
+    });
+    cy.get("[data-cy=screen-field-firstname]").should("not.exist");
+    cy.get("[data-cy=screen-field-lastname]").should("not.exist");
+  });
 });
 
 function getTask(url, responseData) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Describe the issue this ticket solves and describe how to reproduce the issue (please attach any fixtures used to reproduce the issue).

## Solution
added an new param for redirectListener with active tokes to validate the redirection

## How to Test
Steps to Reproduce: 

# [step1] 
import the attached process
# [step2]  
Assign the users per each task
# [step3] 
create a new case for the new process
# [step4] 
run the case in parallel thread in the same time (with different users and browsers)
# [step5] 
submit the first task
h5. Current Behavior: 

We have two scenarios: 

The task is set to "Task Source (Default)" in the Task Destination. Submitting one thread reloads the other and redirects to the request page (see the attached video on the parallel problem).

The task is set to "Show Next Assigned Task" in the Task Destination. Submitting one thread reloads the other and redirects to the next task in the submitted thread, thus bypassing permissions to view tasks (see the attached video on the parallel problem with interstitials).

Expected Behavior: 
The submission of tasks should be independent. Other threads should not reload automatically.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-23723