### PR TITLE
Bugfix/four 24577

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -450,8 +450,6 @@ export default {
      * Emits a closed event.
      */
     async emitClosedEvent() {
-      console.log('emitClosedEvent', this.task);
-      debugger;
       this.$emit("closed", this.task?.id, await this.getDestinationUrl());
     },
     /**
@@ -460,8 +458,6 @@ export default {
      */
     // eslint-disable-next-line consistent-return
     async getDestinationUrl() {
-      console.log('getDestinationUrl', this.task);
-      debugger;
       const { elementDestination, allow_interstitial: allowInterstitial } = this.task || {};
 
       if (!elementDestination) {
@@ -521,7 +517,6 @@ export default {
       return document.referrer || '/tasks';
     },
     loadNextAssignedTask(requestId = null) {
-      console.log('loadNextAssignedTask', requestId);
       if (!requestId) {
         requestId = this.requestId;
       }
@@ -814,7 +809,6 @@ export default {
      * Listens for specific events related to the process and triggers appropriate actions.
      */
     addProcessUpdateListener() {
-      console.log('addProcessUpdateListener', this.requestId);
       this.addSocketListener(
         `updated-${this.requestId}`,
         `ProcessMaker.Models.ProcessRequest.${this.requestId}`,
@@ -830,7 +824,6 @@ export default {
      * @param {Object} data - The event data received from the socket listener.
      */
     handleProcessUpdate(data) {
-      console.log('handleProcessUpdate', data);
       if (data.event === 'ACTIVITY_EXCEPTION') {
         this.$emit('error', this.requestId);
         window.location.href = `/requests/${this.requestId}`;
@@ -857,8 +850,6 @@ export default {
      * @param {Object} data - The event data received from the socket listener.
      */
     handleRedirect(data) {
-      console.log('handleRedirect', data);
-      debugger;
       // Validate if the task is still active before redirects
       if (data.params?.activeTokens?.includes(this.taskId)) {
         return;


### PR DESCRIPTION
## Issue & Reproduction Steps
The task is set to "Task Source (Default)" in the Task Destination. Submitting one thread reloads the other and redirects to the request page (see the attached video on the parallel problem)

## Solution
- improve getActiveTokens
- add activeTokens to processUpdated model
- add test for getActiveTokens method


https://github.com/user-attachments/assets/752fb093-c99b-4adf-9206-e0be6191e33a


## How to Test
Described in the related ticket 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-24577

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
