### PR TITLE
FOUR-24596 It is not possible delete page in screen form even when it…

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1381,15 +1381,27 @@ export default {
       }
       return index > this.pageDelete ? index - 1 : index;
     },
+    // This function is used to calculate the new index of the references FormRecordList
+    calcNewIndexForFormRecordList(index, referencedBy, config) {
+      if (config[this.pageDelete].items.length > 0) {
+        throw new Error(
+          `${this.$t(
+            "Can not delete this page, it is referenced by"
+          )}: ${referencedBy}`
+        );
+      }
+      return index > this.pageDelete ? index - 1 : index;
+    },
     // Update Record list references
     updateRecordListReferences() {
       this.config.forEach((page) => {
         page.items.forEach((item) => {
           if (item.component === "FormRecordList") {
             // eslint-disable-next-line no-param-reassign
-            item.config.form = this.calcNewIndexFor(
+            item.config.form = this.calcNewIndexForFormRecordList(
               item.config.form * 1,
-              item.config.label
+              item.config.label,
+              this.config,
             );
           }
         });


### PR DESCRIPTION
… has no relation to any page.

 ## Description
-Create screen
-Add two pages
-in the second page add record list
-Save the form
-Click on view all pages
-Delete the page that does not have relation ship with record list

Current Behavior
-It is not possible delete page in screen form even when it has no relation to any page Preview unavailable

Expected Behavior
-It should be possible to delete the page that does not relation with any control in forms

 ## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24596
