### PR TITLE
FOUR-22771:Aria Label is duplicated between select lists of Radio check type

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -222,6 +222,7 @@ export default [
           allowMultiSelect: false,
           selectedOptions: [],
           optionsList: [],
+          optionsListExtra: [],
           key:'value',
           value:'content',
           ariaLabel: 'ariaLabel',


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen form 
2. Add select list of Radio check box type
3. Set the provide values + Set Aria label also
4. Add another select list of Radio check box type
5. Set provide values and left black the Aria label field
6. Check the record is provide values of the second select list

**Current Behavior**
Aria Label is duplicated between select list of Radio check type, According the position : The firs aria label It is reflected in the second select list of the same position

**Expected Behavior**
Configurations in select lists and configuration of each theirs records should be independent 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22771

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy