### PR TITLE
FOUR-24945 Error screen is not displayed

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -247,7 +247,11 @@ export default {
       return json;
     },
     showSimpleErrorMessage() {
-      this.renderComponent = 'simpleErrorMessage';
+      // This triggers a re-render if it has already been displayed.
+      this.renderComponent = null;
+      setTimeout(() => {
+        this.renderComponent = 'simpleErrorMessage';
+      }, 0);
     },
     loadScreen(id) {
       this.disabled = true;


### PR DESCRIPTION
 ## Description
Create a simple process (start event - script task/data connector - task - end event) Run a Case
 ## Current Behavior:
When a script task or data connector has an error, the error screen is not displayed. An error screen is displayed in PM 4.12.0
 ## Expected Behavior:
The error screen should be displayed when a error occurs in a data connector or script and the error should be displayed in the Request
 ## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-24945
