### PR TITLE
FOUR:25043:It is possible to delete screen that are dependent of a record list

### DIFF
--- a/src/components/vue-form-builder.vue
+++ b/src/components/vue-form-builder.vue
@@ -1390,6 +1390,9 @@ export default {
           )}: ${referencedBy}`
         );
       }
+      if (index === this.pageDelete) {
+        throw new Error(`${this.$t("Can not delete this page")}`);
+      }
       return index > this.pageDelete ? index - 1 : index;
     },
     // Update Record list references
@@ -1399,7 +1402,7 @@ export default {
           if (item.component === "FormRecordList") {
             // eslint-disable-next-line no-param-reassign
             item.config.form = this.calcNewIndexForFormRecordList(
-              item.config.form * 1,
+              parseInt(item.config.form, 10) * 1,
               item.config.label,
               this.config,
             );


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a screen form 
2. Add record list
3. Add a second page
4. Return to first page with record list 
5. Configure the record list to will be dependent with second page
6. Saved the chages
7. Refresh the page
8. Click on all page
9. Delete the second page

**Current Behavior**
It is possible to delete a page that is dependent of a record list 

**Expected Behavior**
If a page It is dependent on a record list, even if it has no data, it should not be possible to delete it.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25043

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
