### PR TITLE
FOUR-24945: “View Details” button on the error screen that takes the user to the Requests page to inspect error details, rather than an automatic redirection

### DIFF
--- a/src/components/SimpleErrorMessage.vue
+++ b/src/components/SimpleErrorMessage.vue
@@ -4,6 +4,9 @@
             <img src="../assets/icons/ErrorMessage.svg" class="simple-error-message-icon"/>
         </p>
         <p>
+            <b-button variant="primary" @click="redirectToError">{{ $t(label) }}</b-button>
+        </p>
+        <p>
             <span class="simple-error-message-title"> {{ $t(title) }} </span>
         </p>
         <p>
@@ -14,12 +17,22 @@
 
 <script>
 export default {
+    props: ['instanceId'],
     data() {
         return {
             title: "We're Sorry",
             message:
-                "An error has occurred. Please try again. If the problem persists, please contact your administrator."
+                "An error has occurred. Please try again. If the problem persists, please contact your administrator.",
+            label: "View error details"
         };
+    },
+    methods: {
+        redirectToError() {
+            if (!this.instanceId) {
+                return;
+            }
+            window.location.href = `/requests/${this.instanceId}`;
+        }
     }
 };
 </script>


### PR DESCRIPTION
**Description**
Add an error-details button: Introduce a “View Details” button on the error screen that takes the user to the Requests page to inspect error details, rather than an automatic redirection.

**Related Tickets & Packages**
https://processmaker.atlassian.net/browse/FOUR-24945

ci:deploy