### PR TITLE
Bugfix/FOUR-25270: Record List > Mustache syntax does not work in the `pmql` field

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -254,6 +254,8 @@ import _ from "lodash";
 import { dateUtils } from "@processmaker/vue-form-elements";
 import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
+import MustacheHelper from "../inspector/mustache-helper.vue";
+import Mustache from "mustache";
 
 const jsonOptionsActionsColumn = {
   key: "__actions",
@@ -264,7 +266,8 @@ const jsonOptionsActionsColumn = {
 
 export default {
   components: {
-    VueFormRenderer
+    VueFormRenderer,
+    MustacheHelper
   },
   mixins: [mustacheEvaluation],
   props: [
@@ -466,6 +469,18 @@ export default {
         this.currentPage = this.currentPage == 0 ? 1 : this.currentPage;
       }
     },
+    // Watch for changes in the option input field
+    "validationData.option": {
+      handler(newValue) {
+        if (this.source?.sourceOptions === "Collection" && this.source?.collectionFields?.pmql) {
+          this.onCollectionChange(
+            this.source?.collectionFields?.collectionId, 
+            this.source?.collectionFields?.pmql
+          );
+        }
+      },
+      immediate: false
+    }
   },
   mounted() {
     if (this._perPage) {
@@ -566,18 +581,64 @@ export default {
 
         return keys1.every(key => obj1[key] === obj2[key]);
     },
-    onCollectionChange(collectionId,pmql) {
-      let param = {params:{pmql:pmql}};
+    onCollectionChange(collectionId, pmql) {
+      // Si no hay PMQL, no hacer nada
+      if (!pmql || pmql.trim() === "") {
+        return;
+      }
+      
+      // Process Mustache variables in PMQL
+      let processedPmql = pmql;
+      if (pmql && pmql.includes("{{")) {
+        try {
+          // Get data from validationData
+          const data = this.validationData || {};
+          
+          // Clean up the PMQL by removing unnecessary quotes around Mustache variables
+          processedPmql = pmql.replace(/"{{([^}]+)}}"/g, "{{$1}}");
+          
+          // Process Mustache variables
+          processedPmql = Mustache.render(processedPmql, data);
+          
+          // Check if the processed PMQL has empty values and handle them
+          if (
+            processedPmql.includes('= ""') || 
+            processedPmql.includes('= " "') || 
+            processedPmql.includes('= null') ||
+            processedPmql.includes('= undefined')
+          ) {
+            this.collectionData = [];
+            return;
+          }
+          
+          // Add quotes around string values in PMQL if they don't have them
+          processedPmql = processedPmql.replace(/= ([^"'\s]+)/g, '= "$1"');
+        } catch (error) {
+          this.collectionData = [];
+          return;
+        }
+      }
+      
+      // Final validation before making API call
+      if (!processedPmql || processedPmql.trim() === "" || processedPmql.includes("{{")) {
+        this.collectionData = [];
+        return;
+      }
+      
+      const param = { params: { pmql: processedPmql } };
       let rowsCollection = [];
+      
       this.$dataProvider
         .getCollectionRecordsList(collectionId, param)
         .then((response) => {
           rowsCollection = response.data;
-
-          this.changeCollectionColumns(rowsCollection,this.fields);
+          this.changeCollectionColumns(rowsCollection, this.fields);
+        })
+        .catch((error) => {
+          this.collectionData = [];
         });
 
-      this.$emit('change', this.field);
+      this.$emit("change", this.field);
     },
     changeCollectionColumns(collectionFieldsColumns,columnsSelected) {
       

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -582,8 +582,18 @@ export default {
         return keys1.every(key => obj1[key] === obj2[key]);
     },
     onCollectionChange(collectionId, pmql) {
-      // Si no hay PMQL, no hacer nada
+      // If there is no PMQL, return
       if (!pmql || pmql.trim() === "") {
+        // When PMQL is empty, call API without PMQL parameter to get all records
+        this.$dataProvider
+          .getCollectionRecordsList(collectionId, {})
+          .then((response) => {
+            const rowsCollection = response.data;
+            this.changeCollectionColumns(rowsCollection, this.fields);
+          })
+          .catch((error) => {
+            this.collectionData = [];
+          });
         return;
       }
       

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -582,69 +582,118 @@ export default {
         return keys1.every(key => obj1[key] === obj2[key]);
     },
     onCollectionChange(collectionId, pmql) {
-      // If there is no PMQL, return
+      // If there is no PMQL, get all records
       if (!pmql || pmql.trim() === "") {
-        // When PMQL is empty, call API without PMQL parameter to get all records
-        this.$dataProvider
-          .getCollectionRecordsList(collectionId, {})
-          .then((response) => {
-            const rowsCollection = response.data;
-            this.changeCollectionColumns(rowsCollection, this.fields);
-          })
-          .catch((error) => {
-            this.collectionData = [];
-          });
+        this.fetchAllRecords(collectionId);
         return;
       }
       
       // Process Mustache variables in PMQL
-      let processedPmql = pmql;
-      if (pmql && pmql.includes("{{")) {
-        try {
-          // Get data from validationData
-          const data = this.validationData || {};
-          
-          // Clean up the PMQL by removing unnecessary quotes around Mustache variables
-          processedPmql = pmql.replace(/"{{([^}]+)}}"/g, "{{$1}}");
-          
-          // Process Mustache variables
-          processedPmql = Mustache.render(processedPmql, data);
-          
-          // Check if the processed PMQL has empty values and handle them
-          if (
-            processedPmql.includes('= ""') || 
-            processedPmql.includes('= " "') || 
-            processedPmql.includes('= null') ||
-            processedPmql.includes('= undefined')
-          ) {
-            this.collectionData = [];
-            return;
-          }
-          
-          // Add quotes around string values in PMQL if they don't have them
-          processedPmql = processedPmql.replace(/= ([^"'\s]+)/g, '= "$1"');
-        } catch (error) {
-          this.collectionData = [];
-          return;
-        }
+      const processedPmql = this.processMustacheInPmql(pmql);
+      
+      // If processing failed or resulted in invalid PMQL, return
+      if (!processedPmql) {
+        return;
       }
       
+      // Fetch records with processed PMQL
+      this.fetchRecordsWithPmql(collectionId, processedPmql);
+    },
+
+    /**
+     * Process Mustache variables in PMQL string
+     * @param {string} pmql - The PMQL string to process
+     * @returns {string|null} - Processed PMQL or null if invalid
+     */
+    processMustacheInPmql(pmql) {
+      if (!pmql || !pmql.includes("{{")) {
+        return pmql;
+      }
+
+      try {
+        // Get data from validationData
+        const data = this.validationData || {};
+        
+        // Clean up the PMQL by removing unnecessary quotes around Mustache variables
+        let processedPmql = pmql.replace(/"{{([^}]+)}}"/g, "{{$1}}");
+        
+        // Process Mustache variables
+        processedPmql = Mustache.render(processedPmql, data);
+        
+        // Check if the processed PMQL has empty values
+        if (this.hasEmptyValues(processedPmql)) {
+          this.collectionData = [];
+          return null;
+        }
+        
+        // Add quotes around string values in PMQL if they don't have them
+        processedPmql = processedPmql.replace(/= ([^"'\s]+)/g, '= "$1"');
+        
+        return processedPmql;
+      } catch (error) {
+        this.collectionData = [];
+        return null;
+      }
+    },
+
+    /**
+     * Check if processed PMQL contains empty values
+     * @param {string} processedPmql - The processed PMQL string
+     * @returns {boolean} - True if contains empty values
+     */
+    hasEmptyValues(processedPmql) {
+      const emptyValues = ['= ""', '= " "', "= null", "= undefined"];
+      return emptyValues.some(value => processedPmql.includes(value));
+    },
+
+    /**
+     * Validate if processed PMQL is valid for API call
+     * @param {string} processedPmql - The processed PMQL string
+     * @returns {boolean} - True if valid
+     */
+    isValidPmql(processedPmql) {
+      return processedPmql && 
+             processedPmql.trim() !== "" && 
+             !processedPmql.includes("{{");
+    },
+
+    /**
+     * Fetch all records from collection without PMQL filter
+     * @param {number} collectionId - The collection ID
+     */
+    fetchAllRecords(collectionId) {
+      this.$dataProvider
+        .getCollectionRecordsList(collectionId, {})
+        .then((response) => {
+          const rowsCollection = response.data;
+          this.changeCollectionColumns(rowsCollection, this.fields);
+        })
+        .catch(() => {
+          this.collectionData = [];
+        });
+    },
+
+    /**
+     * Fetch records from collection with PMQL filter
+     * @param {number} collectionId - The collection ID
+     * @param {string} processedPmql - The processed PMQL string
+     */
+    fetchRecordsWithPmql(collectionId, processedPmql) {
       // Final validation before making API call
-      if (!processedPmql || processedPmql.trim() === "" || processedPmql.includes("{{")) {
+      if (!this.isValidPmql(processedPmql)) {
         this.collectionData = [];
         return;
       }
       
       const param = { params: { pmql: processedPmql } };
-      let rowsCollection = [];
       
       this.$dataProvider
         .getCollectionRecordsList(collectionId, param)
         .then((response) => {
-          rowsCollection = response.data;
+          const rowsCollection = response.data;
           this.changeCollectionColumns(rowsCollection, this.fields);
         })
-        .catch((error) => {
+        .catch(() => {
           this.collectionData = [];
         });
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: Mustache syntax must work in the pmql field

Actual behavior: Mustache syntax does not work in the `pmql` field

## Solution
- Filters were added to resolve mustache syntax notation in Record List control with Collections data source

## How to Test
1. Go to server https://develop-qa.processmaker.net/ or any PM4 environment
2. Create a form screen 
3. Add a line input 
    * Change the variable name to other (e.g. option)
4. Add a record list
    * Select collection option in the Source of Record List field
    * Select any collection in the Collection Name field (or in other column name from the selected collection)
    * Add a value like data.form_input_1 = "test 2" in the pmql field
    *  Select Single field of record option in the Data Selection field
    * Select id option in the Column field
    * Display all columns in the columns accordion
5. Press Preview button
    * The record list is displayed according to condition data.form_input_1 = "test 2"
6. Change the value data.form_input_1 = "test 2" to data.form_input_1 = "{{option}}" in the pmql field
7. Press Preview button
8. Write test 2 in the line input


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25270
- https://processmaker.atlassian.net/browse/FOUR-25194

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

