### PR TITLE
task/FOUR-25270-fix: Fixing mustache syntax variables in values with spaces

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -469,9 +469,9 @@ export default {
         this.currentPage = this.currentPage == 0 ? 1 : this.currentPage;
       }
     },
-    // Watch for changes in the option input field
-    "validationData.option": {
-      handler(newValue) {
+    // Watch for changes in validationData to handle any Mustache variable changes
+    validationData: {
+      handler(newValue, oldValue) {
         if (this.source?.sourceOptions === "Collection" && this.source?.collectionFields?.pmql) {
           this.onCollectionChange(
             this.source?.collectionFields?.collectionId, 
@@ -479,6 +479,7 @@ export default {
           );
         }
       },
+      deep: true,
       immediate: false
     }
   },
@@ -614,12 +615,9 @@ export default {
         // Get data from validationData
         const data = this.validationData || {};
         
-        // Clean up the PMQL by removing unnecessary quotes around Mustache variables
-        let processedPmql = pmql.replace(/"{{([^}]+)}}"/g, "{{$1}}");
-        
-        // Process Mustache variables
-        processedPmql = Mustache.render(processedPmql, data);
-        
+        // First, process all Mustache variables (both quoted and unquoted)
+        let processedPmql = Mustache.render(pmql, data);
+
         // Check if the processed PMQL has empty values
         if (this.hasEmptyValues(processedPmql)) {
           this.collectionData = [];
@@ -628,7 +626,10 @@ export default {
         
         // Add quotes around string values in PMQL if they don't have them
         // This regex now properly handles values with spaces by looking for the end of the comparison
-        processedPmql = processedPmql.replace(/= ([^"'\s][^"']*[^"'\s]|[^"'\s]+)(?=\s|$)/g, '= "$1"');
+        processedPmql = processedPmql.replace(
+          /= ([^"'\s][^"']*[^"'\s]|[^"'\s]+)(?=\s|$)/g,
+          '= "$1"'
+        );
         
         return processedPmql;
       } catch (error) {

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -627,7 +627,8 @@ export default {
         }
         
         // Add quotes around string values in PMQL if they don't have them
-        processedPmql = processedPmql.replace(/= ([^"'\s]+)/g, '= "$1"');
+        // This regex now properly handles values with spaces by looking for the end of the comparison
+        processedPmql = processedPmql.replace(/= ([^"'\s][^"']*[^"'\s]|[^"'\s]+)(?=\s|$)/g, '= "$1"');
         
         return processedPmql;
       } catch (error) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: Mustache syntax must work with variables values with spaces

Actual behavior: Mustache syntax only takes first string before spaces from string value in mustache syntax

## Solution
- Filters were added to resolve mustache syntax notation in Record List control with Collections data source

## How to Test
1. Go to server https://develop-qa.processmaker.net/ or any PM4 environment
2. Create a form screen 
3. Add a line input 
    * Change the variable name to other (e.g. option)
4. Add a record list
    * Select collection option in the Source of Record List field
    * Select any collection in the Collection Name field (e.g. Country Airports B1
[country_airports_b1.json](https://github.com/user-attachments/files/21233644/country_airports_b1.json)
)
    * Add a value like data.airportName = "Sharm El Sheikh" in the pmql field
    *  Select Single field of record option in the Data Selection field
    * Select id option in the Column field
    * Display all columns in the columns accordion.
5. Press Preview button
    * The record list is displayed according to condition data.airportName= "Sharm El Sheikh"
6. Change the value data.airportName= "Sharm El Sheikh" to data.airportName = "{{option}}" in the pmql field
7. Press Preview button
8. Write "Sharm El Sheikh" in the line input


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25270
- https://processmaker.atlassian.net/browse/FOUR-25194

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

