### PR TITLE
FOUR-21699: Superadmin cannot open authenticated web entry task, only a blank page is shown

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -531,6 +531,7 @@ export default {
       const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${timestamp}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
+          this.$emit("load-data-task", response);
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
             if (task.process_request_id !== this.requestId) {


### PR DESCRIPTION
…a blank page is shown[43324]

 ## Description:
When a superadmin (who is not assigned to the task) tries to open an authenticated web entry task, the view is blank, nothing is loaded.

 ## Related Tickets & Packages:
https://processmaker.atlassian.net/browse/FOUR-21699