### PR TITLE
FOUR-25717: Make customizable the message "No data available for this dynamic panel

### DIFF
--- a/src/components/inspector/dynamic-panel.vue
+++ b/src/components/inspector/dynamic-panel.vue
@@ -22,22 +22,34 @@
         data-test="i1177-inspector-index-name"
       />
     </div>
+
+    <div class="form-group border-bottom">
+      <FormTextArea
+        v-model="settings.emptyStateMessage"
+        :label="$t('Empty State Message')"
+        :name="$t('Empty State Message')"
+        :helper="$t('Custom message to display when the panel has no data. Supports HTML and Mustache placeholders')"
+        :rows="3"
+        data-test="i1177-inspector-empty-state-message"
+      />
+    </div>
   </div>
 </template>
 
 <script>
-import { FormInput } from '@processmaker/vue-form-elements';
+import { FormInput, FormTextArea } from '@processmaker/vue-form-elements';
 
 export default {
   props: ['value', 'screenType'],
   inheritAttrs: false,
-  components: { FormInput },
+  components: { FormInput, FormTextArea },
   data() {
     return {
       settings: {
         type: 'new',
         varname: '',
         indexName: '',
+        emptyStateMessage: this.$t('No data available for this dynamic panel'),
       },
     };
   },

--- a/src/components/renderer/form-dynamic-panel.vue
+++ b/src/components/renderer/form-dynamic-panel.vue
@@ -4,12 +4,13 @@
       <slot></slot>
     </div>
     <div v-else class="dynamic-panel-empty">
-      <p class="text-muted">No data available for this dynamic panel</p>
+      <div v-html="renderedEmptyMessage" class="text-muted"></div>
     </div>
   </div>
 </template>
 
 <script>
+import Mustache from 'mustache';
 
 export default {
   name: "FormDynamicPanel",
@@ -19,10 +20,34 @@ export default {
       required: false,
       default: null
     },
+    emptyStateMessage: {
+      type: String,
+      required: false,
+      default: 'No data available for this dynamic panel'
+    },
+    validationData: {
+      type: Object,
+      required: false,
+      default: () => ({})
+    }
   },
   computed: {
     hasData() {
       return this.itemData !== null && this.itemData !== undefined;
+    },
+    renderedEmptyMessage() {
+      if (!this.emptyStateMessage) {
+        return this.$t('No data available for this dynamic panel');
+      }
+
+      try {
+        // Process Mustache placeholders
+        const processedMessage = Mustache.render(this.emptyStateMessage, this.validationData);
+        return processedMessage;
+      } catch (error) {
+        // If Mustache processing fails, return the original message
+        return this.emptyStateMessage;
+      }
     }
   }
 };

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -489,6 +489,7 @@ export default [
           varname: 'dynamic_panel',
           indexName: '',
           add: false,
+          emptyStateMessage:  'No data available for this dynamic panel',
         },
       },
       inspector: [

--- a/src/mixins/extensions/FormDynamicPanel.js
+++ b/src/mixins/extensions/FormDynamicPanel.js
@@ -14,6 +14,15 @@ export default {
 
       // Add itemData to the properties of FormDynamicPanel
       properties[':itemData'] = `${variableName} && ${variableName}[${index}]`;
+      
+      // Add emptyStateMessage property if configured
+      if (element.config.settings.emptyStateMessage) {
+        properties[':emptyStateMessage'] = this.byRef(element.config.settings.emptyStateMessage);
+      }
+      
+      // Add validationData for Mustache processing
+      properties[':validationData'] = 'getValidationData()';
+      
       this.registerVariable(element.config.settings.varname, element);
     },
     loadFormDynamicPanelItems({ element, node, definition }) {

--- a/tests/e2e/fixtures/dynamic_panels_screen.json
+++ b/tests/e2e/fixtures/dynamic_panels_screen.json
@@ -631,7 +631,8 @@
                         "varname": "loop_1",
                         "indexOf": "index",
                         "add": false,
-                        "indexName": "index"
+                        "indexName": "index",
+                        "emptyStateMessage": "<h3>No data available for this dynamic panel {{loop_1.length}}</h3>"
                       },
                       "label": ""
                     },

--- a/tests/e2e/specs/DynamicPanelsSimplified.spec.js
+++ b/tests/e2e/specs/DynamicPanelsSimplified.spec.js
@@ -125,4 +125,40 @@ describe("Dynamic Panels - Simplified", () => {
       ]
     });
   });
+
+  it("should test state message with Mustache and html syntax", () => {
+    // Switch to preview mode
+    cy.get("[data-cy=mode-preview]").click();
+    
+    // Set up preview data with loop_1 array so {{loop_1.length}} resolves to "3"
+    const testData = {
+      index: "0",
+      loop_1: [
+        { name: "John Doe" },
+        { name: "Jane Smith" },
+        { name: "Bob Johnson" }
+      ]
+    };
+    
+    cy.setPreviewDataInput(testData);
+    
+    // Test with no data - should show default empty state message with Mustache processed
+    cy.get("[data-cy=preview-content] [name=index]").clear().type("5"); // Invalid index
+    
+    // Verify the default empty state message is displayed with Mustache processed
+    cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available for this dynamic panel 3");
+    
+    // Verify HTML is rendered (not escaped)
+    cy.get("[data-cy=preview-content] .dynamic-panel-empty h3").should("be.visible");
+    cy.get("[data-cy=preview-content] .dynamic-panel-empty h3").should("contain", "No data available for this dynamic panel 3");
+    
+    // Test with valid data - should show the panel content
+    cy.get("[data-cy=preview-content] [name=index]").clear().type("0");
+    cy.get("[data-cy=preview-content] label").contains("Selected Name").should("be.visible");
+    
+    // Test with another invalid index to show empty state again
+    cy.get("[data-cy=preview-content] [name=index]").clear().type("10");
+    cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available for this dynamic panel 3");
+  });
+
 }); 


### PR DESCRIPTION

\

Expected behavior: 
As a Builder User, I want to set a custom empty-state message (with basic HTML and Mustache placeholders) so users see helpful, contextual guidance when a panel has no data.
Actual behavior: 
n/a
## Solution
- add emptyStateMessage property for dynamic panel

https://github.com/user-attachments/assets/247d4e5c-0005-46fd-8a2e-977dd7d224e9




## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25717

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
