### PR TITLE
FOUR-25821:Link URL has additional property in Design, which causes values to be lost with old screens

### DIFF
--- a/src/components/renderer/link-button.vue
+++ b/src/components/renderer/link-button.vue
@@ -22,10 +22,10 @@ export default {
   ],
   computed: {
     classColor() {
-      if (this.variantStyle === "link") {
-        return `text-${this.variant}`;
+      if (this.variantStyle === "button") {
+        return `btn btn-${this.variant}`;
       }
-      return `btn btn-${this.variant}`;
+      return `text-${this.variant}`;
     }
   }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a email screen in 4.15.5
2. Add Link URL
3. Check the configuration 
4. Click on Design 
5. Check the options
6. Save the screen 
7. Export the screen
8. Import the screen in PM with 4.15.6 version
9. Click on preview
10. The URL link is not visible and has another field in design 

**Current Behavior**
Link URL has additional property in Design, which causes values to be lost with old screens

**Expected Behavior**
Link URL should not have additional property in Design and should be possible to import old screen without problems

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25821

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
