### PR TITLE
FOUR-25814: Preview screen is empty when dynamic Panel is created

### DIFF
--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -489,7 +489,7 @@ export default [
           varname: 'dynamic_panel',
           indexName: '',
           add: false,
-          emptyStateMessage:  'No data available for this dynamic panel',
+          emptyStateMessage:  'No data available. Please configure an Index Name for this dynamic panel.',
         },
       },
       inspector: [

--- a/src/mixins/extensions/FormDynamicPanel.js
+++ b/src/mixins/extensions/FormDynamicPanel.js
@@ -8,25 +8,13 @@ export default {
     };
   },
   methods: {
-    loadFormDynamicPanelProperties({ properties, element }) {
-      const variableName = element.config.settings.varname;
-      const index = element.config.settings.indexName;
-
-      // Add itemData to the properties of FormDynamicPanel
-      properties[':itemData'] = `${variableName} && ${variableName}[${index}]`;
-      
-      // Add emptyStateMessage property if configured
-      if (element.config.settings.emptyStateMessage) {
-        properties[':emptyStateMessage'] = this.byRef(element.config.settings.emptyStateMessage);
-      }
-      
-      // Add validationData for Mustache processing
-      properties[':validationData'] = 'getValidationData()';
-      
-      this.registerVariable(element.config.settings.varname, element);
-    },
-    loadFormDynamicPanelItems({ element, node, definition }) {
-      const nested = {
+    /**
+     * Builds the nested configuration for dynamic panel items
+     * @param {Object} element - The dynamic panel element
+     * @returns {Object} The nested configuration
+     */
+    buildNestedConfig(element) {
+      return {
         config: [
           {
             items: element.items,
@@ -35,21 +23,155 @@ export default {
         watchers: [], 
         isMobile: false
       };
+    },
 
+    /**
+     * Creates expressions for value and loop context based on index availability
+     * @param {string} variableName - The variable name
+     * @param {string} index - The index name
+     * @returns {Object} Object containing valueExpression and loopContextExpression
+     */
+    buildExpressions(variableName, index) {
+      if (index && index.trim()) {
+        return {
+          valueExpression: `${variableName} && ${variableName}[${index}]`,
+          loopContextExpression: `'${variableName} && ${variableName}[${index}]'`
+        };
+      }
+      
+      return {
+        valueExpression: variableName,
+        loopContextExpression: `'${variableName}'`
+      };
+    },
 
-      const variableName = element.config.settings.varname;
-      const index = element.config.settings.indexName;
-
-      // Add nested component inside dynamic panel
-      const child = this.createComponent("ScreenRenderer", {
+    /**
+     * Creates a ScreenRenderer component for the dynamic panel
+     * @param {Object} nested - The nested configuration
+     * @param {string} valueExpression - The value expression
+     * @param {string} loopContextExpression - The loop context expression
+     * @param {Object} definition - The definition object
+     * @returns {Object} The created component
+     */
+    createScreenRenderer(nested, valueExpression, loopContextExpression, definition) {
+      return this.createComponent("ScreenRenderer", {
         ":definition": this.byRef(nested),
-        ":value": `${variableName} && ${variableName}[${index}]`,
-        ":loop-context": `'${variableName} && ${variableName}[${index}]'`,
+        ":value": valueExpression,
+        ":loop-context": loopContextExpression,
         ":_parent": "getValidationData()",
         ":components": this.byRef(this.components),
         ":config-ref": this.byRef(this.configRef || definition.config),
         "@submit": "submitForm"
       });
+    },
+
+    /**
+     * Builds the itemData property based on variable name and index
+     * @param {string} variableName - The variable name
+     * @param {string} index - The index name
+     * @returns {string} The itemData expression
+     */
+    buildItemDataExpression(variableName, index) {
+      if (index && index.trim()) {
+        return `${variableName} && ${variableName}[${index}]`;
+      }
+      return variableName;
+    },
+
+    /**
+     * Gets a helpful empty state message based on whether index is configured
+     * @param {string} index - The index name
+     * @param {string} customMessage - Custom message from settings
+     * @returns {string} The appropriate empty state message
+     */
+    getEmptyStateMessage(index, customMessage) {
+      if (customMessage) {
+        return customMessage;
+      }
+      
+      if (!index || !index.trim()) {
+        console.warn('FormDynamicPanel: No Index Name configured. The dynamic panel will not function properly without an index.');
+        return 'No data available. Please configure an Index Name for this dynamic panel.';
+      }
+      
+      return 'No data available for this dynamic panel.';
+    },
+
+    /**
+     * Validates that required settings are present
+     * @param {Object} element - The dynamic panel element
+     * @returns {boolean} True if valid, false otherwise
+     */
+    validateElementSettings(element) {
+      if (!element.config || !element.config.settings) {
+        console.warn('FormDynamicPanel: Missing config or settings');
+        return false;
+      }
+      
+      if (!element.config.settings.varname) {
+        console.warn('FormDynamicPanel: Missing varname setting');
+        return false;
+      }
+      
+      return true;
+    },
+
+    /**
+     * Safely extracts settings from element with validation
+     * @param {Object} element - The dynamic panel element
+     * @returns {Object|null} Settings object or null if invalid
+     */
+    extractValidatedSettings(element) {
+      if (!this.validateElementSettings(element)) {
+        return null;
+      }
+      
+      return {
+        variableName: element.config.settings.varname,
+        index: element.config.settings.indexName || '',
+        emptyStateMessage: element.config.settings.emptyStateMessage
+      };
+    },
+
+    /**
+     * Loads the properties for the FormDynamicPanel
+     * @param {Object} params - The parameters object
+     */
+    loadFormDynamicPanelProperties({ properties, element }) {
+      const settings = this.extractValidatedSettings(element);
+      if (!settings) {
+        return;
+      }
+
+      // Add itemData to the properties of FormDynamicPanel
+      properties[':itemData'] = this.buildItemDataExpression(settings.variableName, settings.index);
+      
+      // Add emptyStateMessage property with helpful default
+      const emptyStateMessage = this.getEmptyStateMessage(settings.index, settings.emptyStateMessage);
+      properties[':emptyStateMessage'] = this.byRef(emptyStateMessage);
+      
+      // Add validationData for Mustache processing
+      properties[':validationData'] = 'getValidationData()';
+      
+      this.registerVariable(settings.variableName, element);
+    },
+    /**
+     * Loads the items for the FormDynamicPanel
+     * @param {Object} params - The parameters object
+     */
+    loadFormDynamicPanelItems({ element, node, definition }) {
+      const settings = this.extractValidatedSettings(element);
+      if (!settings) {
+        return;
+      }
+
+      const nested = this.buildNestedConfig(element);
+
+      // Build expressions based on index availability
+      const { valueExpression, loopContextExpression } = this.buildExpressions(settings.variableName, settings.index);
+
+      // Create and add the ScreenRenderer component
+      const child = this.createScreenRenderer(nested, valueExpression, loopContextExpression, definition);
       node.appendChild(child);
     }
   },

--- a/tests/e2e/fixtures/dynamic_panel_empty.json
+++ b/tests/e2e/fixtures/dynamic_panel_empty.json
@@ -1,0 +1,77 @@
+{
+  "screens": [
+    {
+      "id": "dynamic-panel-empty-test",
+      "config": [
+        {
+          "name": "Default",
+          "items": [
+            {
+              "uuid": "dynamic-panel-empty-uuid",
+              "config": {
+                "name": "dynamic_panel_1",
+                "icon": "fas fa-th-large",
+                "settings": {
+                  "type": "new",
+                  "varname": "dynamic_panel_1",
+                  "indexName": "",
+                  "add": false,
+                  "emptyStateMessage": ""
+                },
+                "label": "Dynamic Panel",
+                "container": true
+              },
+              "inspector": [
+                {
+                  "type": "DynamicPanelInspector",
+                  "field": "settings",
+                  "config": {}
+                }
+              ],
+              "component": "FormDynamicPanel",
+              "editor-component": "DynamicPanel",
+              "editor-control": "DynamicPanel",
+              "items": [
+                {
+                  "uuid": "nested-input-uuid",
+                  "config": {
+                    "icon": "far fa-square",
+                    "label": "Test Input",
+                    "name": "test_input",
+                    "placeholder": "",
+                    "validation": [],
+                    "helper": null,
+                    "type": "text",
+                    "dataFormat": "string",
+                    "readonly": false
+                  },
+                  "component": "FormInput",
+                  "inspector": [
+                    {
+                      "type": "FormInput",
+                      "field": "name",
+                      "config": {
+                        "label": "Variable Name",
+                        "name": "Variable Name",
+                        "validation": "dot_notation|required|not_in:null,break,case,catch,continue,debugger,default,delete,do,else,finally,for,function,if,in,instanceof,new,return,switch,this,throw,try,typeof,var,void,while,with,class,const,enum,export,extends,import,super,true,false",
+                        "helper": "A variable name is a symbolic name to reference information."
+                      }
+                    },
+                    {
+                      "type": "FormInput",
+                      "field": "label",
+                      "config": {
+                        "label": "Label",
+                        "helper": "The label describes the field's name"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+} 

--- a/tests/e2e/specs/DynamicPanelEmpty.spec.js
+++ b/tests/e2e/specs/DynamicPanelEmpty.spec.js
@@ -1,0 +1,143 @@
+describe("Dynamic Panel - Empty Configuration Tests", () => {
+  beforeEach(() => {
+    cy.visit("/");
+    // Load the screen configuration from fixture with only a dynamic panel
+    cy.loadFromJson("dynamic_panel_empty.json", 0, "form");
+  });
+
+  describe("Empty Dynamic Panel Rendering", () => {
+    it("should render empty dynamic panel with default error message", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // Wait a bit for the content to load
+      cy.wait(1000);
+
+      // Check if the preview content area exists and is visible
+      cy.get("[data-cy=preview-content]").should("be.visible");
+
+      // Since there's no index configured, the dynamic panel should show empty state
+      // Look for the empty state element
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+
+      // Check what's actually in the empty state element
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").then(($emptyState) => {
+        cy.log("Empty state HTML:", $emptyState.html());
+        cy.log("Empty state text:", $emptyState.text());
+      });
+
+      // Should show some message about missing index configuration (partial match)
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available");
+
+      // The nested input should not be visible since there's no data
+      cy.get("[data-cy=preview-content] [name=test_input]").should("not.exist");
+    });
+
+    it("should display proper styling for empty state", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // Wait for content to load
+      cy.wait(1000);
+
+      // Verify empty state styling - check if it has any styling classes
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+      
+      // Check what classes the empty state element actually has
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").then(($emptyState) => {
+        cy.log("Empty state classes:", $emptyState.attr("class"));
+      });
+    });
+  });
+
+  describe("Empty State Message Content", () => {
+    it("should show helpful message about missing index configuration", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+      // The message should guide the user to configure an Index Name (partial match)
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available");
+      
+      // Check if it mentions something about configuration or index
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").then(($emptyState) => {
+        const text = $emptyState.text();
+        cy.log("Full empty state message:", text);
+        
+        // Check if it contains any helpful information
+        expect(text.length).to.be.greaterThan(0);
+      });
+    });
+
+    it("should not show any dynamic panel content", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // The nested input should not be visible
+      cy.get("[data-cy=preview-content] [name=test_input]").should("not.exist");
+      
+      // No labels from the nested content should be visible
+      cy.get("[data-cy=preview-content] label").should("not.exist");
+    });
+  });
+
+  describe("Form Structure", () => {
+    it("should maintain proper form structure even when empty", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // The form should still be properly structured
+      cy.get("[data-cy=preview-content]").should("be.visible");
+      
+      // The dynamic panel container should be present (as an empty state)
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+    });
+
+    it("should not interfere with other form elements", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // The form should render without errors
+      cy.get("[data-cy=preview-content]").should("be.visible");
+      
+      // The empty state should be visible
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+    });
+  });
+
+  describe("Console Warnings", () => {
+    it("should log helpful warning about missing index configuration", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // Note: Console warnings might not be easily testable in Cypress
+      // This test documents the expected behavior
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+      
+      // The message should indicate some issue (partial match)
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available");
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should provide clear visual feedback about the empty state", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // Empty state should be clearly visible
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+      
+      // Message should be readable and helpful (partial match)
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("contain", "No data available");
+    });
+
+    it("should maintain proper contrast and readability", () => {
+      // Switch to preview mode
+      cy.get("[data-cy=mode-preview]").click();
+
+      // Empty state should have some styling
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+      
+      // The message should be clearly visible
+      cy.get("[data-cy=preview-content] .dynamic-panel-empty").should("be.visible");
+    });
+  });
+}); 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The screen should be displayed correctly, despite of some options are not configured in the dynamic panel
Actual behavior: 
The screen is empty, When the index name field has some value then the screen is displayed correctly
## Solution
- Fix [Vue warn]: Error compiling template with invalid expression 'dynamic_panel_1 && dynamic_panel_1[]'
- Improve user experience and error handling
- Refactor FormDynamicPanel.js to follow SOLID principles
- Enhance test coverage for dynamic panel edge cases

https://github.com/user-attachments/assets/291286a8-0bca-45fa-8a8e-ace01921683d


## How to Test
review the steps in the related ticket

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-25814

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
