### PR TITLE
Bugfix/FOUR-23508: [44179] Oakstart Bank - Spelling Error

### DIFF
--- a/src/components/inspector/validation-select.vue
+++ b/src/components/inspector/validation-select.vue
@@ -442,7 +442,7 @@ export default {
           field: "after_or_equal:",
           content: this.$t("After or Equal to Date"),
           helper: this.$t(
-            "The field unter validation must be after or equal to the given field."
+            "The field under validation must be after or equal to the given field."
           ),
           visible: true,
           configs: [
@@ -459,7 +459,7 @@ export default {
           field: "before:",
           content: this.$t("Before Date"),
           helper: this.$t(
-            "The field unter validation must be before the given date."
+            "The field under validation must be before the given date."
           ),
           visible: true,
           configs: [
@@ -476,7 +476,7 @@ export default {
           field: "before_or_equal:",
           content: this.$t("Before or Equal to Date"),
           helper: this.$t(
-            "The field unter validation must be before or equal to the given field."
+            "The field under validation must be before or equal to the given field."
           ),
           visible: true,
           configs: [

--- a/tests/e2e/fixtures/complex_screen.json
+++ b/tests/e2e/fixtures/complex_screen.json
@@ -16665,7 +16665,7 @@
                                                 {
                                                     "field": "before_or_equal:",
                                                     "value": "before_or_equal:2020-08-01",
-                                                    "helper": "The field unter validation must be before or equal to the given field.",
+                                                    "helper": "The field under validation must be before or equal to the given field.",
                                                     "configs": [
                                                         {
                                                             "type": "FormInput",

--- a/tests/e2e/fixtures/record_list.json
+++ b/tests/e2e/fixtures/record_list.json
@@ -17793,7 +17793,7 @@
                                                 {
                                                     "field": "before_or_equal:",
                                                     "value": "before_or_equal:2020-08-01",
-                                                    "helper": "The field unter validation must be before or equal to the given field.",
+                                                    "helper": "The field under validation must be before or equal to the given field.",
                                                     "configs": [
                                                         {
                                                             "type": "FormInput",

--- a/tests/e2e/fixtures/record_list_invalid.json
+++ b/tests/e2e/fixtures/record_list_invalid.json
@@ -17799,7 +17799,7 @@
                                                 {
                                                     "field": "before_or_equal:",
                                                     "value": "before_or_equal:2020-08-01",
-                                                    "helper": "The field unter validation must be before or equal to the given field.",
+                                                    "helper": "The field under validation must be before or equal to the given field.",
                                                     "configs": [
                                                         {
                                                             "type": "FormInput",

--- a/tests/e2e/fixtures/validation rules loop.json
+++ b/tests/e2e/fixtures/validation rules loop.json
@@ -9768,7 +9768,7 @@
                                   {
                                     "field": "before:",
                                     "value": "before:form_date_picker_3",
-                                    "helper": "The field unter validation must be before the given date.",
+                                    "helper": "The field under validation must be before the given date.",
                                     "configs": [
                                       {
                                         "type": "FormInput",
@@ -10547,7 +10547,7 @@
                                   {
                                     "field": "after_or_equal:",
                                     "value": "after_or_equal:form_date_picker_5",
-                                    "helper": "The field unter validation must be after or equal to the given field.",
+                                    "helper": "The field under validation must be after or equal to the given field.",
                                     "configs": [
                                       {
                                         "type": "FormInput",
@@ -11326,7 +11326,7 @@
                                   {
                                     "field": "before_or_equal:",
                                     "value": "before_or_equal:form_date_picker_7",
-                                    "helper": "The field unter validation must be before or equal to the given field.",
+                                    "helper": "The field under validation must be before or equal to the given field.",
                                     "configs": [
                                       {
                                         "type": "FormInput",

--- a/tests/e2e/fixtures/validation_rules.json
+++ b/tests/e2e/fixtures/validation_rules.json
@@ -3417,7 +3417,7 @@
                                         "value": "before_or_equal:today",
                                         "field": "before_or_equal:",
                                         "content": "Before or Equal to Date",
-                                        "helper": "The field unter validation must be before or equal to the given field.",
+                                        "helper": "The field under validation must be before or equal to the given field.",
                                         "visible": false,
                                         "configs": [
                                             {
@@ -19474,7 +19474,7 @@
                                                 {
                                                     "field": "before_or_equal:",
                                                     "value": "before_or_equal:2020-08-01",
-                                                    "helper": "The field unter validation must be before or equal to the given field.",
+                                                    "helper": "The field under validation must be before or equal to the given field.",
                                                     "configs": [
                                                         {
                                                             "type": "FormInput",


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

- Log into ProcessMaker, go to Designer, and click on the screen option.
- Create a Form Screen with one input type DATE
- choose the option Validation Rules: After or Equal to Date

**Current Behavior:**
The text is wrong “The field unter validation must be after or equal to the given field.”

**Expected Behavior:**
The text must be “The field under validation must be after or equal to the given field.”

## Solution
Fix typo for validation rules:
- After or Equal to Date
- Before Date
- Before or Equal to Date

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23508

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
