### PR TITLE
FOUR-26908: Update the range to CSS to improve the development for tce screens implementations

### DIFF
--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -288,7 +288,7 @@ export default {
             }
           }
 
-          if (i > 2000) {
+          if (i > 20000) {
             throw Error("CSS is too long");
           }
 

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -287,6 +287,11 @@ export default {
               });
             }
           }
+
+          if (i > 2000) {
+            throw Error("CSS is too long");
+          }
+
           i += 1;
         });
 

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -287,10 +287,6 @@ export default {
               });
             }
           }
-          if (i > 5000) {
-            throw Error("CSS is too long");
-          }
-
           i += 1;
         });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Update the range to css to improve the development for tce screens implementations
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26908

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the hard cap that threw "CSS is too long" during CSS AST walking in `src/components/vue-form-renderer.vue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b46b5054a4f01229e821b73c8b5de9cbdec2a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->