### PR TITLE
FOUR-25776: Record List UI Unchecks Selections When Using PMQL with Multiple Records Mode

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -739,6 +739,82 @@ export default {
       });
       //sets Collection result(columns and rows) into this.collectionData
       this.collectionData = result;
+      this.reapplyCollectionSelections(result);
+    },
+    // Keep selected rows in sync after collection refreshes triggered by PMQL filters.
+    reapplyCollectionSelections(newCollection) {
+      if (!this.shouldPersistCollectionSelection()) {
+        return;
+      }
+
+      if (!Array.isArray(this.selectedRows) || this.selectedRows.length === 0) {
+        return;
+      }
+
+      const keyCounts = this.selectedRows.reduce((accumulator, item) => {
+        const key = this.getCollectionRowKey(item);
+        if (!key) {
+          return accumulator;
+        }
+        const occurrences = accumulator.get(key) || 0;
+        accumulator.set(key, occurrences + 1);
+        return accumulator;
+      }, new Map());
+
+      if (keyCounts.size === 0) {
+        this.selectedRows = [];
+        return;
+      }
+
+      const updatedSelection = [];
+
+      newCollection.forEach((row, index) => {
+        const rowKey = this.getCollectionRowKey(row);
+        const occurrences = keyCounts.get(rowKey);
+        if (!occurrences) {
+          return;
+        }
+
+        const newRow = { ...row, selectedRowsIndex: index };
+        updatedSelection.push(newRow);
+
+        if (occurrences === 1) {
+          keyCounts.delete(rowKey);
+        } else {
+          keyCounts.set(rowKey, occurrences - 1);
+        }
+      });
+
+      this.selectedRows = updatedSelection;
+    },
+    shouldPersistCollectionSelection() {
+      const pmql = this.source?.collectionFields?.pmql;
+      return (
+        this.source?.sourceOptions === "Collection" &&
+        this.source?.dataSelectionOptions === "multiple-records" &&
+        typeof pmql === "string" &&
+        pmql.trim().length > 0
+      );
+    },
+    getCollectionRowKey(item) {
+      if (!item || typeof item !== "object") {
+        return null;
+      }
+
+      const entries = Object.entries(item).filter(
+        ([key]) => key !== "selectedRowsIndex"
+      );
+
+      if (entries.length === 0) {
+        return null;
+      }
+
+      entries.sort(([keyA], [keyB]) => {
+        if (keyA > keyB) return 1;
+        if (keyA < keyB) return -1;
+        return 0;
+      });
+      return JSON.stringify(entries);
     },
     updateRowDataNamePrefix() {
       this.setUploadDataNamePrefix(this.currentRowIndex);

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -775,8 +775,9 @@ export default {
           return;
         }
 
-        const newRow = { ...row, selectedRowsIndex: index };
-        updatedSelection.push(newRow);
+        // eslint-disable-next-line no-param-reassign
+        row.selectedRowsIndex = index;
+        updatedSelection.push(row);
 
         if (occurrences === 1) {
           keyCounts.delete(rowKey);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Using a record list configured with Collection + PMQL filter + multiple-records selection.
- Checkboxes deselect immediately after data reloads triggered by PMQL evaluation, filtering, or pagination.
- Visual state and payload drift: UI showed no selections although the emitted IDs remained.

## Solution
- Rehydrated selectedRows after collection refreshes by matching refreshed rows against previously selected entries.
- Added guard helpers so the new behavior only applies to Collection sources using PMQL with multi-record selection.
- Preserved selectedRowsIndex metadata to keep pagination-aware indices in sync.

https://github.com/user-attachments/assets/aecf6037-92db-456b-a38c-d8fc504876bc

## How to Test
- Configure a screen as above (Collection source, PMQL filter, multiple-record selection).
- Select several rows, then change filter inputs to trigger a PMQL refresh; confirm the original checkboxes remain checked.
- Page forward and back after selecting rows and verify selections persist visually and in the emitted payload.

## Related Tickets & Packages
- [FOUR-25776](https://processmaker.atlassian.net/browse/FOUR-25776)

[FOUR-25776]: https://processmaker.atlassian.net/browse/FOUR-25776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy
.