### PR TITLE
FOUR-27077: Conditions are not working when `Display Next Assgined Task` option is selected as condition

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -838,6 +838,8 @@ export default {
         elementDestination
       ) {
         this.task.elementDestination = elementDestination;
+        // update allow_interstitial based on the element destination change after the submit
+        this.task.allow_interstitial = elementDestination.type === "displayNextAssignedTask";
       }
 
       if (event === 'ACTIVITY_EXCEPTION') {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Task destination should be displayed according to each condition
Actual behavior: 
All conditions are not displayed according to each matching only the Screen Interstitial is displayed
## Solution
- add displayNextAssignedTask validation

## How to Test
please review the steps in the related ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27077

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:modeler:feature/FOUR-26707
ci:screen-builder:feature/FOUR-26707
ci:processmaker:feature/FOUR-26707
