### PR TITLE
FOUR-27977: [48377] DevLink does not import Data Connector dependencies inside PM Blocks

### DIFF
--- a/src/components/inspector/options-list.vue
+++ b/src/components/inspector/options-list.vue
@@ -341,6 +341,9 @@ export default {
         },
       ],
       valueTypeReturned: '',
+      assetType: null,
+      assetTypeResolved: false,
+      screenId: null,
     };
   },
   watch: {
@@ -504,9 +507,37 @@ export default {
     monacoMounted(editor) {
       editor.getAction('editor.action.formatDocument').run();
     },
-    getDataSourceList() {
+    resolveAssetType() {
+      if (this.assetTypeResolved) {
+        return Promise.resolve(this.assetType);
+      }
+      const match = window.location.pathname.match(/screen-builder\/(\d+)\/edit/);
+      if (!match) {
+        this.assetTypeResolved = true;
+        return Promise.resolve(this.assetType);
+      }
+      this.screenId = match[1];
+      return this.$dataProvider
+        .get(`/screens/${this.screenId}`)
+        .then(response => {
+          this.assetType = response.data.asset_type || null;
+          this.assetTypeResolved = true;
+          return this.assetType;
+        })
+        .catch(() => {
+          this.assetTypeResolved = true;
+          return this.assetType;
+        });
+    },
+    async getDataSourceList() {
+      await this.resolveAssetType();
+      const params = {};
+      if (this.assetType) {
+        // For PM Block screens, expose both regular and PM Block connectors.
+        params.asset_type = this.assetType === 'PM_BLOCK' ? 'all' : this.assetType;
+      }
       this.$dataProvider
-        .get('/data_sources')
+        .get('/data_sources', { params })
         .then(response => {
           let jsonData = response.data.data;
           // Map the data sources response to value/text items list


### PR DESCRIPTION
## Issue & Reproduction Steps

When using “Save as PM Block”, the Select List inside the cloned Screen loses its Data Connector selection: the dropdown shows no selected connector/endpoint.

**Repro:** create a process with a Screen containing a Select List bound to a Data Connector; click “Save as PM Block”; open the generated PM Block’s Screen in the Screen Builder—Data Connector and End Point are unselected.

## Solution
- Allow PM Block Data Connectors (asset_type = PM_BLOCK) to be included in the nonSystem scope so they are returned by /api/data_sources and visible in the builder.
- Ensure the Select List import remaps selectedDataSource as an integer ID so the builder pre-selects the cloned Data Connector.
- Added targeted tests to prevent regressions for both the scope change and the Select List remap.

## How to Test
1. Create a process with a Screen that has a Select List configured to a Data Connector and save it as a PM Block.
2. Open the PM Block’s Screen in the Screen Builder: the Data Connector should already be selected and the End Point set to GET.
3. API check: GET /api/1.0/data_sources should list both regular and PM Block Data Connectors.

Run package-data-sources tests.

ci:package-data-sources:bugfix/FOUR-27977
ci:deploy

## Related Tickets & Packages
- [FOUR-27977](https://processmaker.atlassian.net/browse/FOUR-27977)
- [Package Data Source PR](https://github.com/ProcessMaker/package-data-sources/pull/454)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-27977]: https://processmaker.atlassian.net/browse/FOUR-27977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters the Data Connector list based on the screen’s asset_type, resolving it from the current screen and passing it to /data_sources (PM_BLOCK maps to all).
> 
> - **Inspector Select List (`src/components/inspector/options-list.vue`)**:
>   - Add `resolveAssetType()` to determine `asset_type` from current screen (`/screens/:id`) using URL, with caching flags (`assetTypeResolved`, `screenId`).
>   - Update `getDataSourceList()` to be async and send `asset_type` param to `/data_sources` (`PM_BLOCK` => `all`), then map results and endpoints as before.
>   - Add new reactive fields: `assetType`, `assetTypeResolved`, `screenId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b68bef938e5550b8a1b7205f0eb9b2c24a70a06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


ci:k8s-branch:disable-verify-ci-ping