### PR TITLE
FOUR-28359: It is possible to left undefined in selective Variable Submition in Screens

### DIFF
--- a/src/components/inspector/variables-to-submit.vue
+++ b/src/components/inspector/variables-to-submit.vue
@@ -231,6 +231,20 @@ export default {
     someSelected() {
       const selectedCount = this.filteredVariables.filter(v => this.selectedVariables.includes(v)).length;
       return selectedCount > 0 && selectedCount < this.filteredVariables.length;
+    },
+    
+    /**
+     * Source for computed properties to watch for changes
+     */
+    computedPropertiesSource() {
+      return this.getComputedProperties() || [];
+    },
+    
+    /**
+     * Source for watchers to watch for changes
+     */
+    watchersSource() {
+      return this.getWatchers() || [];
     }
   },
   watch: {
@@ -276,15 +290,23 @@ export default {
       deep: true,
       immediate: true
     },
-    // Watch for computed properties changes in App.vue
-    '$root.computed'() {
-      // Force recomputation when computed properties change
-      this.$forceUpdate();
+    // Watch for computed properties changes
+    computedPropertiesSource: {
+      handler() {
+        this.$nextTick(() => {
+          this.cleanupInvalidSelections();
+        });
+      },
+      deep: true
     },
-    // Watch for watchers changes in App.vue
-    '$root.watchers'() {
-      // Force recomputation when watchers change
-      this.$forceUpdate();
+    // Watch for watchers changes
+    watchersSource: {
+      handler() {
+        this.$nextTick(() => {
+          this.cleanupInvalidSelections();
+        });
+      },
+      deep: true
     }
   },
   methods: {
@@ -396,6 +418,11 @@ export default {
       // Try App.vue (root component)
       if (this.$root?.$data?.computed) {
         return this.$root.$data.computed;
+      }
+      
+      // Try $root.$children[0] (App.vue pattern)
+      if (this.$root?.$children?.[0]?.computed && Array.isArray(this.$root.$children[0].computed)) {
+        return this.$root.$children[0].computed;
       }
       
       // Try builder sources

--- a/src/components/inspector/variables-to-submit.vue
+++ b/src/components/inspector/variables-to-submit.vue
@@ -267,9 +267,14 @@ export default {
     'selectedControl.config.event'(newVal) {
       this.event = newVal;
     },
-    'builder.variablesTree'() {
-      // Force recomputation when variables tree changes
-      this.$forceUpdate();
+    formConfig: {
+      handler() {
+        this.$nextTick(() => {
+          this.cleanupInvalidSelections();
+        });
+      },
+      deep: true,
+      immediate: true
     },
     // Watch for computed properties changes in App.vue
     '$root.computed'() {
@@ -283,6 +288,20 @@ export default {
     }
   },
   methods: {
+    /**
+     * Remove selected variables that no longer exist in availableVariables
+     */
+    cleanupInvalidSelections() {
+      const available = this.availableVariables;
+      const validSelected = this.selectedVariables.filter(v => available.includes(v));
+      if (validSelected.length !== this.selectedVariables.length) {
+        this.selectedVariables = validSelected;
+        // Turn off toggle if no variables remain selected
+        if (validSelected.length === 0) {
+          this.isEnabled = false;
+        }
+      }
+    },
     /**
      * Load variables from the variables tree
      * Only includes root-level variables (no prefix, no dots in name)


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
It is possible to left undefined in selective Variable Submission in the Screens, so the data arrives empty
Actual behavior: 
If left undefined, all variables are submitted (default behavior).As show defined on the PRD 
## Solution
- In order to manage remove contron, we added formConfig watcher and cleanupInvalidSelections

https://github.com/user-attachments/assets/cadc635c-7914-42f4-90ce-26417b24768b


## How to Test
please find the steps in the related ticket
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-28359

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
