### PR TITLE
FOUR-28401 Issue Identified with Parallel Task Redirect Behavior

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -890,7 +890,7 @@ export default {
       if (
         (data?.params[0]?.tokenId &&
         this.task.user?.id === data.params[0]?.userId) ||
-        this.task.elementDestination.type === 'taskSource'
+        this.task.elementDestination?.type === 'taskSource'
       ) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -888,8 +888,9 @@ export default {
      */
     async handleRedirectToTask(data) {
       if (
-        data?.params[0]?.tokenId &&
-        this.task.user?.id === data.params[0]?.userId
+        (data?.params[0]?.tokenId &&
+        this.task.user?.id === data.params[0]?.userId) ||
+        this.task.elementDestination.type === 'taskSource'
       ) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -887,7 +887,10 @@ export default {
      * @param {Object} data - The event data containing the tokenId of the task.
      */
     async handleRedirectToTask(data) {
-      if (data?.params[0]?.tokenId) {
+      if (
+        data?.params[0]?.tokenId &&
+        this.task.user?.id === data.params[0]?.userId
+      ) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.
         if (this.task && !(this.task.allow_interstitial || this.isSameUser(this.task, data))) {

--- a/tests/e2e/specs/ComplexScreen.spec.js
+++ b/tests/e2e/specs/ComplexScreen.spec.js
@@ -761,9 +761,15 @@ describe("Complex screen", () => {
     cy.get("[data-cy=preview-content] [name=form_checkbox_6]").should(
       "be.checked"
     );
-    cy.get("[data-cy=preview-content] [name=form_select_list_3]").eq(1).click();
-    cy.get("[data-cy=preview-content] [name=form_select_list_4]").eq(1).click(); // Select b
-    cy.get("[data-cy=preview-content] [name=form_select_list_4]").eq(2).click(); // Select c
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_3-b-"]'
+    ).click();
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_4-b-"]'
+    ).click(); // Select b
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_4-c-"]'
+    ).click(); // Select c
     // record list - complete new fields
     cy.get(
       "[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=edit-row]"

--- a/tests/e2e/specs/SelectListWatcher.spec.js
+++ b/tests/e2e/specs/SelectListWatcher.spec.js
@@ -51,7 +51,7 @@ describe("SelectList - Watcher", () => {
 
     // Select "John" option in radio buttons "form_select_list_2"
     cy.get(
-      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+      '[data-cy=preview-content] [id^="form_select_list_2-John-"]'
     ).click();
 
     // Select "Mary" option in select list "form_select_list_3"
@@ -78,7 +78,7 @@ describe("SelectList - Watcher", () => {
 
     // Select "John" option in radio buttons "form_select_list_2"
     cy.get(
-      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+      '[data-cy=preview-content] [id^="form_select_list_2-John-"]'
     ).click();
 
     // Select "Mary" option in select list "form_select_list_3"

--- a/tests/e2e/specs/SingleSelectWithInvalidValue.spec.js
+++ b/tests/e2e/specs/SingleSelectWithInvalidValue.spec.js
@@ -23,9 +23,9 @@ describe("single select with invalid initial value", () => {
     cy.setPreviewDataInput({ person: [] });
     cy.get("[data-cy=mode-preview]").click();
 
-    cy.get("[data-cy=preview-content] [name=person]").eq(0).click();
-    cy.get("[data-cy=preview-content] [name=person]").eq(1).click();
-    cy.get("[data-cy=preview-content] [name=person]").eq(0).click();
+    cy.get('[data-cy=preview-content] [id^="person-one-"]').click();
+    cy.get('[data-cy=preview-content] [id^="person-two-"]').click();
+    cy.get('[data-cy=preview-content] [id^="person-one-"]').click();
 
     // Check the data of the screen
     cy.assertPreviewData({

--- a/tests/e2e/specs/Task.spec.js
+++ b/tests/e2e/specs/Task.spec.js
@@ -916,6 +916,7 @@ describe("Task component", () => {
         completed_at: moment().toISOString(),
         due_at: moment().add(1, "day").toISOString(),
         user: {
+          id: 1,
           avatar: "",
           fullname: "Assigned User"
         },


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior:
Redirect to the next task that the user is assigned to

Actual behavior: 
Keeps showing the interstitial page and attempts to redirect to another
task the user does not has access to

## Solution
Add a condition in order to execute the redirect task only if the current user is the same that returned in the channel

## How to Test
- Import the attached process and configure users
- Start a case as a user who has at least one assigned task after the first one
- Submit the form
- Wait for the redirection to the next task

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-28401

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens redirect handling and stabilizes tests.
> 
> - **Task redirect logic**: In `src/components/task.vue`, `handleRedirectToTask` now proceeds only when the event’s `userId` matches the current task’s `user.id`, or when `task.elementDestination.type` is `taskSource`. Preserves interstitial behavior and forces hard redirect for `ConversationalForm` when needed.
> - **E2E updates**: Refactors Cypress selectors to use stable id-prefix patterns for radio/checkbox/select options, reducing index-based flakiness (updates in `ComplexScreen.spec.js`, `SelectListWatcher.spec.js`, `SingleSelectWithInvalidValue.spec.js`). Adds `user.id` to mocked task responses and adjusts assertions in `Task.spec.js` to validate the new redirect constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b9c9f94b92452bb313d16ca3fd27b565fabe520. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->