### PR TITLE
FOUR-25350: Fix record list screen links when collections load asynchronously

### DIFF
--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -137,6 +137,9 @@ export default {
                 value: collection.id
               }))
         ];
+        if (this.collectionId) {
+          this.updateScreenIds();
+        }
       });
     },
     getFields() {

--- a/tests/e2e/specs/ComplexScreen.spec.js
+++ b/tests/e2e/specs/ComplexScreen.spec.js
@@ -761,9 +761,15 @@ describe("Complex screen", () => {
     cy.get("[data-cy=preview-content] [name=form_checkbox_6]").should(
       "be.checked"
     );
-    cy.get("[data-cy=preview-content] [name=form_select_list_3]").eq(1).click();
-    cy.get("[data-cy=preview-content] [name=form_select_list_4]").eq(1).click(); // Select b
-    cy.get("[data-cy=preview-content] [name=form_select_list_4]").eq(2).click(); // Select c
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_3-b-"]'
+    ).click();
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_4-b-"]'
+    ).click(); // Select b
+    cy.get(
+      '[data-cy=preview-content] [id^="form_select_list_4-c-"]'
+    ).click(); // Select c
     // record list - complete new fields
     cy.get(
       "[data-cy=preview-content] [data-cy=screen-field-form_record_list_1] [data-cy=edit-row]"

--- a/tests/e2e/specs/SelectListWatcher.spec.js
+++ b/tests/e2e/specs/SelectListWatcher.spec.js
@@ -51,7 +51,7 @@ describe("SelectList - Watcher", () => {
 
     // Select "John" option in radio buttons "form_select_list_2"
     cy.get(
-      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+      '[data-cy=preview-content] [id^="form_select_list_2-John-"]'
     ).click();
 
     // Select "Mary" option in select list "form_select_list_3"
@@ -78,7 +78,7 @@ describe("SelectList - Watcher", () => {
 
     // Select "John" option in radio buttons "form_select_list_2"
     cy.get(
-      "[data-cy=preview-content] [name=form_select_list_2][value=John]"
+      '[data-cy=preview-content] [id^="form_select_list_2-John-"]'
     ).click();
 
     // Select "Mary" option in select list "form_select_list_3"

--- a/tests/e2e/specs/SingleSelectWithInvalidValue.spec.js
+++ b/tests/e2e/specs/SingleSelectWithInvalidValue.spec.js
@@ -23,9 +23,9 @@ describe("single select with invalid initial value", () => {
     cy.setPreviewDataInput({ person: [] });
     cy.get("[data-cy=mode-preview]").click();
 
-    cy.get("[data-cy=preview-content] [name=person]").eq(0).click();
-    cy.get("[data-cy=preview-content] [name=person]").eq(1).click();
-    cy.get("[data-cy=preview-content] [name=person]").eq(0).click();
+    cy.get('[data-cy=preview-content] [id^="person-one-"]').click();
+    cy.get('[data-cy=preview-content] [id^="person-two-"]').click();
+    cy.get('[data-cy=preview-content] [id^="person-one-"]').click();
 
     // Check the data of the screen
     cy.assertPreviewData({


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Open a Screen Builder screen with a Record List configured with a Collection.
2. Click “Open Edit Screen” on the Record List inspector.
3. It navigates to /designer/screen-builder/null/edit even though the collection has screens assigned.

## Solution
- Recalculate collection screen IDs after collections are loaded so the link is built with a real screen ID when the collection is already selected.

## How to Test
1. Open the Screen Builder for a screen containing a Record List linked to a Collection.
2. Verify “Open Edit Screen” opens the correct screen (not null).
3. Change the collection and verify the link updates correctly.

## Related Tickets & Packages
- [FOUR-25350](https://processmaker.atlassian.net/browse/FOUR-25350)

ci:deploy

[FOUR-25350]: https://processmaker.atlassian.net/browse/FOUR-25350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ