### PR TITLE
Error Starting Cases via Web Entry (TCE)

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -831,6 +831,12 @@ export default {
      * @param {Object} data - The event data received from the socket listener.
      */
     handleProcessUpdate(data) {
+      if (!this.task) {
+        // reload the task if it is not found
+        this.reload();
+        return;
+      }
+      
       const { event, elementDestination, tokenId } = data;
 
       // If the activity is completed and there is an element destination, set the element destination to the task


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Progress must be made without the interstitial blocking the process.
Actual behavior: 
The task gets stuck in the Interstitial.


## Solution
- add task reload logic in handleProcessUpdate method when task in null.

## How to Test
<img width="446" height="323" alt="image" src="https://github.com/user-attachments/assets/c1c264ef-92c8-4117-ac5a-9bb5501c5af8" />

There is a web entry with a redirect, then a script task, and finally another task. The interstitial is enabled in the web entry.

The flow should proceed normally and not get stuck in the interstitial.

## Related Tickets & Packages
- [FOUR-29086](https://processmaker.atlassian.net/browse/FOUR-29086)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:deploy

[FOUR-29086]: https://processmaker.atlassian.net/browse/FOUR-29086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ