### PR TITLE
FOUR-29085 REGRESSION>>The "verify data" task displays an error in the console: TypeError: Cannot read properties of null

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -900,11 +900,16 @@ export default {
      * @param {Object} data - The event data containing the tokenId of the task.
      */
     async handleRedirectToTask(data) {
-      if (
-        (data?.params[0]?.tokenId &&
-        this.task.user?.id === data.params[0]?.userId) ||
-        this.task.elementDestination?.type === 'taskSource'
-      ) {
+      const isWebEntry = !this.task;
+      let applyRedirect;
+      if (isWebEntry) {
+        applyRedirect = data?.params[0]?.tokenId;
+      } else {
+        applyRedirect = (data?.params[0]?.tokenId &&
+          this.task.user?.id === data.params[0]?.userId) ||
+          this.task.elementDestination?.type === 'taskSource';
+      }
+      if (applyRedirect) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.
         if (this.task && !(this.task.allow_interstitial || this.isSameUser(this.task, data))) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 

Actual behavior: 
task is null in webentry

## Solution
-
new condition when is not webentry task

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29085

ci:deploy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized conditional change in redirect handling; low risk aside from potentially altering when redirects trigger for web-entry sessions.
> 
> **Overview**
> Fixes a regression in `task.vue` where socket-driven `redirectToTask` events could throw when `this.task` is `null` (web entry). The redirect gating logic now explicitly treats web-entry cases as valid when a `tokenId` is present, and only applies the user/`elementDestination` checks when a task is already loaded.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e4c12fcd8729f0be2689ec35da620b852a418bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->