### PR TITLE
FOUR-26457: Fix webentry nested screen 403 by always sending auth params on screen fetch

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -154,7 +154,18 @@ export default {
     }
 
     const screenPromise = new Promise((resolve, reject) => {
-      this.get(`${endpoint}/${id}${query}`)
+      let fullQuery = query || "";
+      const authQuery = this.authQueryString();
+      if (authQuery && !fullQuery.includes("request_id=")) {
+        const authParams = authQuery.startsWith("?") ? authQuery.slice(1) : authQuery;
+        if (fullQuery) {
+          fullQuery += `${fullQuery.includes("?") ? "&" : "?"}${authParams}`;
+        } else {
+          fullQuery = `?${authParams}`;
+        }
+      }
+
+      this.get(`${endpoint}/${id}${fullQuery}`)
         .then((response) => {
           if (response.data.nested) {
             this.addNestedScreenCache(response.data.nested);


### PR DESCRIPTION
## Issue & Reproduction Steps
Nested screens inside “completed” screens for anonymous web entry trigger a request like:
GET /api/1.0/webentry/{process}/{node}/screens/{id} without request_id, resulting in a 403 (authorization) even though the request and task are valid.

1. Import the provided process and start it via anonymous web entry.
2. Complete the task that shows a “completed screen” containing a nested screen.
3. Observe a 403 on the nested screen request.

## Solution
- Ensure screen-builder appends authParams (including request_id) when fetching screens so nested screens are loaded with proper webentry context.
- Updated DataProvider.getScreen() to append authQueryString() if it’s missing request_id.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-26457](https://processmaker.atlassian.net/browse/FOUR-26457)
- [Package Web Entry PR](https://github.com/ProcessMaker/package-webentry/pull/291)

ci:deploy
ci:package-webentry:bugfix/FOUR-26457

.

[FOUR-26457]: https://processmaker.atlassian.net/browse/FOUR-26457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ