### PR TITLE
[49581] First Financial Bank - Regression: Parent task hangs on “Getting the next task” when next step is a PM Block with Self-Service group assignment

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -912,42 +912,49 @@ export default {
      * @param {Object} data - The event data containing the tokenId of the task.
      */
     async handleRedirectToTask(data) {
-      if (
-        (data?.params[0]?.tokenId &&
-        this.task.user?.id === data.params[0]?.userId) ||
-        this.task.elementDestination?.type === 'taskSource'
-      ) {
-        this.loadingTask = true;
-        // Check if interstitial tasks are allowed for this task.
-        if (this.task && !(this.task.allow_interstitial || this.isSameUser(this.task, data))) {
-          // The getDestinationUrl() function is called asynchronously to retrieve the URL
-          window.location.href = await this.getDestinationUrl();
-          return;
+      const tokenId = data?.params[0]?.tokenId;
+        const newTaskUserId = data?.params[0]?.userId; // User assigned to the new task (from the backend)
+        const nodeId = data?.params[0]?.nodeId;
+        const currentUserId = this.userId; // Current user (who sees the page) = window.ProcessMaker.user.id
+        const elementDestType = this.task?.elementDestination?.type;
+        // Redirect if the new task is assigned to the current user, or if it is taskSource
+        const isNewTaskForCurrentUser = tokenId && (newTaskUserId === currentUserId || (newTaskUserId == null && (elementDestType === 'displayNextAssignedTask' || elementDestType === 'taskSource')));
+        const isTaskSource = elementDestType === 'taskSource';
+        const shouldHandle = isNewTaskForCurrentUser || isTaskSource;
+  
+        if (shouldHandle) {
+          this.loadingTask = true;
+          // Check if interstitial tasks are allowed for this task.
+          if (this.task && !(this.task.allow_interstitial || this.isSameUser(data))) {
+            window.location.href = await this.getDestinationUrl();
+            return;
+          }
+          this.nodeId = nodeId;
+          this.taskId = tokenId;
+  
+          // Force a redirect to ensure the correct task is loaded immediately for ConversationalForm.
+          if (this.renderComponent === "ConversationalForm") {
+            window.location.href = `/tasks/${this.taskId}/edit`;
+          }
+  
+          this.reload();
         }
-        this.nodeId = data.params[0].nodeId;
-        this.taskId = data.params[0].tokenId;
-
-        // Force a redirect to ensure the correct task is loaded immediately for ConversationalForm.
-        // This prevents async reloads that may cause inconsistencies specific to ConversationalForm.
-        if (this.renderComponent === "ConversationalForm") {
-          window.location.href = `/tasks/${this.taskId}/edit`;
-        }
-
-        this.reload();
-      }
     },
 
     /**
-     * Checks if the current task and the redirect data belong to the same user.
-     * and the destination is taskSource.
+     * Checks if the redirect applies to the current user.
+     * - userId of event = user assigned to the new task
+     * - It is considered a match if: new task assigned to the current user, or taskSource/displayNextAssignedTask with user null
      *
-     * @param {Object} currentTask - The current task object.
      * @param {Object} redirectData - The redirect data object.
      */
-    isSameUser(currentTask, redirectData) {
-      const userIdMatch = currentTask.user?.id === redirectData.params[0].userId;
-      const typeMatch = currentTask.elementDestination?.type === null
-                      || currentTask.elementDestination?.type === 'taskSource';
+      isSameUser(redirectData) {
+      const newTaskUserId = redirectData?.params?.[0]?.userId;
+      const currentUserId = this.userId;
+      const elementDestType = this.task?.elementDestination?.type;
+      const userIdMatch = newTaskUserId === currentUserId
+        || (newTaskUserId == null && (elementDestType === 'displayNextAssignedTask' || elementDestType === 'taskSource'));
+      const typeMatch = elementDestType === null || elementDestType === 'taskSource' || elementDestType === 'displayNextAssignedTask';
 
       return userIdMatch && typeMatch;
     },

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -913,9 +913,10 @@ export default {
      */
     async handleRedirectToTask(data) {
       const tokenId = data?.params[0]?.tokenId;
-        const newTaskUserId = data?.params[0]?.userId; // User assigned to the new task (from the backend)
-        const nodeId = data?.params[0]?.nodeId;
-        const currentUserId = this.userId; // Current user (who sees the page) = window.ProcessMaker.user.id
+      const newTaskUserId = data?.params[0]?.userId; // User assigned to the new task (from the backend)
+      const nodeId = data?.params[0]?.nodeId;
+      // Current user: prop > window.ProcessMaker.user > task assignee (when viewing assigned task)
+      const currentUserId = this.userId ?? window.ProcessMaker?.user?.id ?? this.task?.user?.id;
         const elementDestType = this.task?.elementDestination?.type;
         // Redirect if the new task is assigned to the current user, or if it is taskSource
         const isNewTaskForCurrentUser = tokenId && (newTaskUserId === currentUserId || (newTaskUserId == null && (elementDestType === 'displayNextAssignedTask' || elementDestType === 'taskSource')));
@@ -948,9 +949,9 @@ export default {
      *
      * @param {Object} redirectData - The redirect data object.
      */
-      isSameUser(redirectData) {
+    isSameUser(redirectData) {
       const newTaskUserId = redirectData?.params?.[0]?.userId;
-      const currentUserId = this.userId;
+      const currentUserId = this.userId ?? window.ProcessMaker?.user?.id ?? this.task?.user?.id;
       const elementDestType = this.task?.elementDestination?.type;
       const userIdMatch = newTaskUserId === currentUserId
         || (newTaskUserId == null && (elementDestType === 'displayNextAssignedTask' || elementDestType === 'taskSource'));


### PR DESCRIPTION


## Issue & Reproduction Steps
The steps are on the ticket.
Expected behavior: 
The shunt should pass correctly.
Actual behavior: 
The task derivation remains in the interstitial space
## Solution
- Refactor task redirection logic to improve clarity and ensure correct handling of user assignments and element destinations

## How to Test
Review the specific use case.
Review the different routings in the self-service case.

## Related Tickets & Packages
- [FOUR-29254](https://processmaker.atlassian.net/browse/FOUR-29254)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:processmaker:feature/FOUR-29250
ci:modeler:feature/FOUR-29250
ci:deploy


[FOUR-29254]: https://processmaker.atlassian.net/browse/FOUR-29254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ