### PR TITLE
FOUR-29531 The screen does not open when a user belongs to a self-service group

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -915,7 +915,8 @@ export default {
       if (
         (data?.params[0]?.tokenId &&
         this.task.user?.id === data.params[0]?.userId) ||
-        this.task.elementDestination?.type === 'taskSource'
+        this.task.elementDestination?.type === 'taskSource' ||
+        (data.params[0]?.userId === null && data.params[0]?.userCanClaim === true)
       ) {
         this.loadingTask = true;
         // Check if interstitial tasks are allowed for this task.


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
If the user can claim the case should be redirected to the next assigned task

Actual behavior: 
The user is not redirected to the next assigned task

## Solution
Use the new attribute "userCanClaim" to determine if the current user can claim the current request

## How to Test

1. Go to server https://develop-qa.processmaker.net/
2. Create a process (start event - task (assign user) - task (self-service group) - task (Previous task assigned) - end event)  
3. Create a normal user
4. Create a Group
5. Assign the user to Group
6. Login with the user
7. Start the request
8. Fill data in the first task
9. Press Submit button
10. The interstitial screen is displayed 

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-29531

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

