### PR TITLE
FOUR-29961: APPLICANT >> Improve Draft behavior

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -354,8 +354,7 @@ export default {
         this.loopContext = _.get(this.task, "loop_context", "");
 
         if (this.task.draft) {
-          this.requestData = _.merge(
-            {},
+          this.requestData = this.restoreDraftData(
             this.requestData,
             this.task.draft.data
           );
@@ -372,6 +371,13 @@ export default {
       } else {
         this.hasErrors = false;
       }
+    },
+    restoreDraftData(requestData, draftData) {
+      const shouldMerge =
+        globalThis?.ProcessMaker?.screen?.mergeDraftOnRestore ?? true;
+      return shouldMerge
+        ? _.merge({}, requestData, draftData)
+        : { ...requestData, ...draftData };
     },
     pageUpdate() {
       this.$emit("updated-page-core");


### PR DESCRIPTION
## Issue & Reproduction Steps

Currently the draft are restored using a merge aproach, this cause problems when the user remove elements from arrays like RecordLists.

As a developer I want to have an env property to replace the saved data instead of merging it. 
For backward compatibility keep the merge behavior.
SCREEN_MERGE_DRAFT_ON_RESTORE=true

In the screen builder/renderer side:
ProcessMaker.screen.mergeDraftOnRestore


## Solution
- Create mergeDraftOnRestore envirenment variable to manage the screen draft merge
<img width="1728" height="966" alt="image" src="https://github.com/user-attachments/assets/8c2eda1f-3b35-4a8c-bb18-f0d21595c5d7" />

## How to Test
set SCREEN_MERGE_DRAFT_ON_RESTORE=true or false
in developer tools see teh variable as the previous picture


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-29961

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
