### PR TITLE
FOUR-28994: Fix self-service lock after interstitial redirect

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -293,6 +293,7 @@ export default {
           .getTasks(url)
           .then((response) => {
             this.task = response.data;
+            this.setSelfService(this.task);
             this.linkTask(mounting);
             this.checkTaskStatus();
             if (
@@ -391,6 +392,7 @@ export default {
       }
     },
     checkTaskStatus() {
+      this.setSelfService(this.task);
       if (
         this.task.status == 'COMPLETED' ||
         this.task.status == 'CLOSED' ||
@@ -402,13 +404,19 @@ export default {
       }
       this.prepareTask();
     },
-    setSelfService() {
+    resolveSelfService(task = this.task) {
+      if (task) {
+        return (
+          _.get(task, 'process_request.status') === 'ACTIVE'
+          && Boolean(_.get(task, 'is_self_service', false))
+        );
+      }
+
+      return Boolean(_.get(window, 'ProcessMaker.isSelfService', false));
+    },
+    setSelfService(task = this.task) {
       this.$nextTick(() => {
-        if (window.ProcessMaker.isSelfService) {
-          this.isSelfService = true;
-        } else {
-          this.isSelfService = false;
-        }
+        this.isSelfService = this.resolveSelfService(task);
       });
     },
     /**

--- a/tests/unit/TaskSelfServiceLock.spec.js
+++ b/tests/unit/TaskSelfServiceLock.spec.js
@@ -1,0 +1,153 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const componentPath = path.join(
+  process.cwd(),
+  'src/components/task.vue',
+);
+
+const source = fs.readFileSync(componentPath, 'utf8');
+
+function getComponentOptions() {
+  const scriptMatch = source.match(/<script>([\s\S]*?)<\/script>/);
+
+  if (!scriptMatch) {
+    throw new Error('Unable to find task.vue script block');
+  }
+
+  const executableScript = scriptMatch[1]
+    .replace(/^import .*$/gm, '')
+    .replace('export default', 'module.exports =');
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    window: {
+      ProcessMaker: {},
+    },
+    VueFormRenderer: {},
+    simpleErrorMessage: {},
+    Promise,
+    setTimeout,
+    clearTimeout,
+    console,
+    _: {
+      get: (target, accessor, defaultValue = null) => {
+        if (!target || !accessor) {
+          return defaultValue;
+        }
+
+        return accessor.split('.').reduce((value, key) => {
+          if (value === undefined || value === null) {
+            return undefined;
+          }
+
+          return value[key];
+        }, target) ?? defaultValue;
+      },
+      merge: (...args) => Object.assign({}, ...args),
+    },
+  };
+
+  vm.runInNewContext(executableScript, sandbox, { filename: componentPath });
+
+  return {
+    component: sandbox.module.exports,
+    sandbox,
+  };
+}
+
+describe('Task self-service lock', () => {
+  const { component: Task, sandbox } = getComponentOptions();
+
+  test('resolveSelfService uses the loaded task when available', () => {
+    const result = Task.methods.resolveSelfService.call({
+      task: {
+        process_request: { status: 'ACTIVE' },
+        is_self_service: 1,
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  test('setSelfService prefers the current task over the initial window flag', () => {
+    const context = {
+      task: {
+        process_request: { status: 'ACTIVE' },
+        is_self_service: 1,
+      },
+      isSelfService: false,
+      resolveSelfService: Task.methods.resolveSelfService,
+      $nextTick: (callback) => callback(),
+    };
+
+    sandbox.window.ProcessMaker = {
+      isSelfService: false,
+    };
+
+    Task.methods.setSelfService.call(context, context.task);
+
+    expect(context.isSelfService).toBe(true);
+  });
+
+  test('checkTaskStatus refreshes self-service state before rendering the task screen', () => {
+    const setSelfService = jest.fn();
+    const prepareTask = jest.fn();
+    const closeTask = jest.fn();
+    const screen = { config: [] };
+    const context = {
+      task: {
+        status: 'ACTIVE',
+        screen,
+      },
+      screen: null,
+      setSelfService,
+      prepareTask,
+      closeTask,
+    };
+
+    Task.methods.checkTaskStatus.call(context);
+
+    expect(setSelfService).toHaveBeenCalledWith(context.task);
+    expect(context.screen).toBe(screen);
+    expect(prepareTask).toHaveBeenCalled();
+    expect(closeTask).not.toHaveBeenCalled();
+  });
+
+  test('loadTask refreshes self-service state as soon as task data arrives', async () => {
+    const task = {
+      id: 223,
+      process_request: { status: 'ACTIVE' },
+      is_self_service: 1,
+      screen: { config: [] },
+    };
+    const setSelfService = jest.fn();
+    const linkTask = jest.fn();
+    const checkTaskStatus = jest.fn();
+    const getTasks = jest.fn().mockResolvedValue({ data: task });
+    const context = {
+      taskId: 223,
+      nodeId: 'node_1',
+      screenVersion: null,
+      beforeLoadTask: jest.fn().mockResolvedValue(),
+      $dataProvider: { getTasks },
+      setSelfService,
+      linkTask,
+      checkTaskStatus,
+      loadingTask: true,
+      hasErrors: false,
+    };
+
+    await Task.methods.loadTask.call(context, false);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getTasks).toHaveBeenCalled();
+    expect(context.task).toBe(task);
+    expect(setSelfService).toHaveBeenCalledWith(task);
+    expect(linkTask).toHaveBeenCalledWith(false);
+    expect(checkTaskStatus).toHaveBeenCalled();
+    expect(context.loadingTask).toBe(false);
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps
When the Start Event interstitial is enabled, launching a case first loads the start event token and then transitions client-side to the real self-service task.

1. Enable the Start Event interstitial on the process.
2. Launch a new case.
3. Land on the task edit page after the interstitial redirect.
4. Notice the task is editable on first load.
5. Refresh the page.
6. Notice the self-service overlay appears and the task becomes blocked.

Expected behavior:
The self-service task should be blocked immediately on first load after the interstitial redirect, without requiring a manual refresh.

Actual behavior:
The task is editable on first load, and only becomes blocked after refreshing the page.

## Solution
- Recalculate the self-service lock state from the currently loaded task instead of relying on the initial `window.ProcessMaker.isSelfService` flag.
- Refresh `isSelfService` immediately after `loadTask()` receives the real task payload and again during `checkTaskStatus()`.
- Add regression coverage for `resolveSelfService`, `setSelfService`, `checkTaskStatus`, and `loadTask`.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-28994](https://processmaker.atlassian.net/browse/FOUR-28994)

ci:deploy



[FOUR-28994]: https://processmaker.atlassian.net/browse/FOUR-28994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ