### PR TITLE
FOUR-30463 | Record List Delete Confirmation Popup is Misaligned and Appears Outside the Viewport

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -118,8 +118,11 @@
                   <i v-if="styleMode === 'Classic'" class="fas fa-trash-alt" />
                   <img v-else src="../../assets/Shape.svg" alt="delete" />
                 </button>
-
-                <div v-show="isPopoverVisible === index" class="popover-content">
+                <div
+                  v-show="isPopoverVisible === index"
+                  class="popover-content"
+                  :style="popoverPosition"
+                >
                   <p>Are you sure you want to delete it?</p>
                   <button class="btn btn-light" @click="hidePopover">CANCEL</button>
                   <button class="btn btn-danger" @click="popover_remove()">DELETE</button>
@@ -508,10 +511,29 @@ export default {
       this.deleteIndex = _.find(this.tableData.data, { row_id: rowId });
       this.isPopoverVisible = this.isPopoverVisible === index ? null : index;
       if (this.isPopoverVisible !== null) {
-        const rect = event.target.getBoundingClientRect();
+        // event.target may be the <img> inside the button; walk up to the button itself
+        const buttonEl = event.target.closest("button") || event.target;
+        const rect = buttonEl.getBoundingClientRect();
+        const popoverWidth = 285;
+        const estimatedPopoverHeight = 130;
+        const viewportMargin = 8;
+
+        // Default: anchor below the button, aligned to its left edge
+        let top = rect.bottom + viewportMargin;
+        let left = rect.left;
+
+        // Flip above the button if there isn't enough room below
+        if (top + estimatedPopoverHeight > window.innerHeight - viewportMargin) {
+          top = Math.max(viewportMargin, rect.top - estimatedPopoverHeight - viewportMargin);
+        }
+
+        // Clamp horizontally so the popover never overflows the viewport
+        const maxLeft = window.innerWidth - popoverWidth - viewportMargin;
+        left = Math.max(viewportMargin, Math.min(left, maxLeft));
+
         this.popoverPosition = {
-          top: `${rect.bottom + window.scrollY}px`,
-          left: `${rect.left + window.scrollX}px`
+          top: `${top}px`,
+          left: `${left}px`,
         };
       }
     },
@@ -1075,8 +1097,9 @@ export default {
   position: fixed;
   z-index: 1000;
   width: 285px;
+  max-width: calc(100vw - 16px);
   text-align: center;
-  margin-top: 30px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 .popover-content p {
   margin: 0 0 10px;

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -329,7 +329,9 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' }
+      popoverPosition: { top: '0px', left: '0px' },
+      popoverAnchorEl: null,
+      popoverReposition: null
     };
   },
   computed: {
@@ -506,39 +508,74 @@ export default {
     this.setStyleMode(this.designerMode?.designerOptions);
     this.$root.$emit("record-list-option", this.source?.sourceOptions);
   },
+  beforeDestroy() {
+    this.detachPopoverListeners();
+  },
   methods: {
     togglePopover(index, event, rowId) {
       this.deleteIndex = _.find(this.tableData.data, { row_id: rowId });
-      this.isPopoverVisible = this.isPopoverVisible === index ? null : index;
-      if (this.isPopoverVisible !== null) {
-        // event.target may be the <img> inside the button; walk up to the button itself
-        const buttonEl = event.target.closest("button") || event.target;
-        const rect = buttonEl.getBoundingClientRect();
-        const popoverWidth = 285;
-        const estimatedPopoverHeight = 130;
-        const viewportMargin = 8;
+      const willBeVisible = this.isPopoverVisible !== index;
+      this.isPopoverVisible = willBeVisible ? index : null;
 
-        // Default: anchor below the button, aligned to its left edge
-        let top = rect.bottom + viewportMargin;
-        let left = rect.left;
-
-        // Flip above the button if there isn't enough room below
-        if (top + estimatedPopoverHeight > window.innerHeight - viewportMargin) {
-          top = Math.max(viewportMargin, rect.top - estimatedPopoverHeight - viewportMargin);
-        }
-
-        // Clamp horizontally so the popover never overflows the viewport
-        const maxLeft = window.innerWidth - popoverWidth - viewportMargin;
-        left = Math.max(viewportMargin, Math.min(left, maxLeft));
-
-        this.popoverPosition = {
-          top: `${top}px`,
-          left: `${left}px`,
-        };
+      if (willBeVisible) {
+        this.popoverAnchorEl = event.target.closest("button") || event.target;
+        this.updatePopoverPosition();
+        this.attachPopoverListeners();
+      } else {
+        this.detachPopoverListeners();
       }
+    },
+    updatePopoverPosition() {
+      if (!this.popoverAnchorEl || !this.popoverAnchorEl.isConnected) {
+        // Anchor was removed from the DOM (e.g. row deleted, table re-rendered)
+        this.hidePopover();
+        return;
+      }
+
+      const rect = this.popoverAnchorEl.getBoundingClientRect();
+      const popoverWidth = 285;
+      const estimatedPopoverHeight = 130;
+      const viewportMargin = 8;
+
+      // Default: anchor below the button, aligned to its left edge
+      let top = rect.bottom + viewportMargin;
+      let left = rect.left;
+
+      // Flip above the button if there isn't enough room below
+      if (top + estimatedPopoverHeight > window.innerHeight - viewportMargin) {
+        top = Math.max(viewportMargin, rect.top - estimatedPopoverHeight - viewportMargin);
+      }
+
+      // Clamp horizontally so the popover never overflows the viewport
+      const maxLeft = window.innerWidth - popoverWidth - viewportMargin;
+      left = Math.max(viewportMargin, Math.min(left, maxLeft));
+
+      this.popoverPosition = {
+        top: `${top}px`,
+        left: `${left}px`,
+      };
+    },
+    attachPopoverListeners() {
+      if (this.popoverReposition) {
+        return;
+      }
+      this.popoverReposition = () => this.updatePopoverPosition();
+      window.addEventListener("resize", this.popoverReposition);
+      // Capture phase so we catch scrolling on any ancestor (table wrapper, modal body, etc.)
+      window.addEventListener("scroll", this.popoverReposition, true);
+    },
+    detachPopoverListeners() {
+      if (!this.popoverReposition) {
+        return;
+      }
+      window.removeEventListener("resize", this.popoverReposition);
+      window.removeEventListener("scroll", this.popoverReposition, true);
+      this.popoverReposition = null;
+      this.popoverAnchorEl = null;
     },
     hidePopover() {
       this.isPopoverVisible = null;
+      this.detachPopoverListeners();
     },
     popover_remove() {
       this.remove();

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -329,9 +329,7 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' },
-      popoverAnchorEl: null,
-      popoverReposition: null
+      popoverPosition: { top: '0px', left: '0px' }
     };
   },
   computed: {
@@ -508,74 +506,44 @@ export default {
     this.setStyleMode(this.designerMode?.designerOptions);
     this.$root.$emit("record-list-option", this.source?.sourceOptions);
   },
-  beforeDestroy() {
-    this.detachPopoverListeners();
-  },
   methods: {
     togglePopover(index, event, rowId) {
       this.deleteIndex = _.find(this.tableData.data, { row_id: rowId });
-      const willBeVisible = this.isPopoverVisible !== index;
-      this.isPopoverVisible = willBeVisible ? index : null;
+      this.isPopoverVisible = this.isPopoverVisible === index ? null : index;
+      if (this.isPopoverVisible !== null) {
+        const buttonEl = event.target.closest("button") || event.target;
+        const rect = buttonEl.getBoundingClientRect();
+        const popoverWidth = 285;
+        const estimatedPopoverHeight = 130;
+        const viewportMargin = 8;
 
-      if (willBeVisible) {
-        this.popoverAnchorEl = event.target.closest("button") || event.target;
-        this.updatePopoverPosition();
-        this.attachPopoverListeners();
-      } else {
-        this.detachPopoverListeners();
+        // Default: anchor below the button, aligned to its left edge
+        let top = rect.bottom + viewportMargin;
+        let left = rect.left;
+
+        // Flip above the button if there isn't enough room below
+        if (
+          top + estimatedPopoverHeight >
+          window.innerHeight - viewportMargin
+        ) {
+          top = Math.max(
+            viewportMargin,
+            rect.top - estimatedPopoverHeight - viewportMargin
+          );
+        }
+
+        // Clamp horizontally so the popover never overflows the viewport
+        const maxLeft = window.innerWidth - popoverWidth - viewportMargin;
+        left = Math.max(viewportMargin, Math.min(left, maxLeft));
+
+        this.popoverPosition = {
+          top: `${top}px`,
+          left: `${left}px`
+        };
       }
-    },
-    updatePopoverPosition() {
-      if (!this.popoverAnchorEl || !this.popoverAnchorEl.isConnected) {
-        // Anchor was removed from the DOM (e.g. row deleted, table re-rendered)
-        this.hidePopover();
-        return;
-      }
-
-      const rect = this.popoverAnchorEl.getBoundingClientRect();
-      const popoverWidth = 285;
-      const estimatedPopoverHeight = 130;
-      const viewportMargin = 8;
-
-      // Default: anchor below the button, aligned to its left edge
-      let top = rect.bottom + viewportMargin;
-      let left = rect.left;
-
-      // Flip above the button if there isn't enough room below
-      if (top + estimatedPopoverHeight > window.innerHeight - viewportMargin) {
-        top = Math.max(viewportMargin, rect.top - estimatedPopoverHeight - viewportMargin);
-      }
-
-      // Clamp horizontally so the popover never overflows the viewport
-      const maxLeft = window.innerWidth - popoverWidth - viewportMargin;
-      left = Math.max(viewportMargin, Math.min(left, maxLeft));
-
-      this.popoverPosition = {
-        top: `${top}px`,
-        left: `${left}px`,
-      };
-    },
-    attachPopoverListeners() {
-      if (this.popoverReposition) {
-        return;
-      }
-      this.popoverReposition = () => this.updatePopoverPosition();
-      window.addEventListener("resize", this.popoverReposition);
-      // Capture phase so we catch scrolling on any ancestor (table wrapper, modal body, etc.)
-      window.addEventListener("scroll", this.popoverReposition, true);
-    },
-    detachPopoverListeners() {
-      if (!this.popoverReposition) {
-        return;
-      }
-      window.removeEventListener("resize", this.popoverReposition);
-      window.removeEventListener("scroll", this.popoverReposition, true);
-      this.popoverReposition = null;
-      this.popoverAnchorEl = null;
     },
     hidePopover() {
       this.isPopoverVisible = null;
-      this.detachPopoverListeners();
     },
     popover_remove() {
       this.remove();


### PR DESCRIPTION
# Issue
Ticket: [FOUR-30463](https://processmaker.atlassian.net/browse/FOUR-30463)

The delete confirmation popover for a row in `FormRecordList` was rendering in an unpredictable viewport location (most commonly anchored to the bottom of the screen) instead of next to the trash button that opened it. The popover was also not constrained to the viewport, so on small windows or zoomed-out displays it could disappear off-screen entirely.

This PR fixes the popover so it:

- Anchors directly below the delete button that triggered it.
- Flips above the button when there isn't enough room below.
- Is clamped horizontally and vertically so it never overflows the viewport.
- Uses a coordinate system that is consistent with `position: fixed`.

# Solution
In `src/components/renderer/form-record-list.vue`:

- Added `:style="popoverPosition"` to `.popover-content` so the position calculated in JS actually applies to the element.
- Removed `window.scrollY` / `window.scrollX` from the math so the values match `position: fixed` (viewport coordinates).
- Added a flip-above-the-button fallback when there isn't room below, plus a horizontal clamp so the popover can't overflow the right edge. Also added `max-width: calc(100vw - 16px)` and removed the misleading `margin-top: 30px` from the SCSS.

# How To Test
1. In a screen with `FormRecordList` inside a `NewFormMultiColumn` (you can use the Screen attached in the ticket): 
		- Go to the screen preview tab.
		- Add a record
		- Click the trash button on the Delete modal
		- Confirm the popover anchors below the button
2. Repeat near the bottom of the viewport and confirm the popover flips above.
3. Zoom in (125%) and out (75%, 50%) and confirm the popover stays on-screen at every zoom level.

** Note: ** Position is calculated once at click time. If the user resizes the browser or scrolls while the popover is open, the popover does not follow the button. They would need to close and reopen it.

ci:deploy

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-30463]: https://processmaker.atlassian.net/browse/FOUR-30463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ