### PR TITLE
FOUR-30726 REGRESSION >> Public files are not displayed on screens

### DIFF
--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -154,6 +154,24 @@ export default {
   components: { ...uploader, RequiredAsterisk },
   mixins: [uniqIdsMixin],
   props: ['label', 'error', 'helper', 'name', 'value', 'controlClass', 'endpoint', 'accept', 'validation', 'parent', 'config', 'multipleUpload', 'screenType'],
+  created() {
+    const vm = this;
+    // After merge with chunk getParams(), query includes `filename` for this chunk's file — fix
+    // data_name per request without replacing opts.query with a function or serializing uploads.
+    this.options.processParams = (params, file) => {
+      if (!vm.name) {
+        params.data_name = params.filename || file.name;
+      } else if (
+        vm.multipleUpload
+        && (_.has(window, 'PM4ConfigOverrides.postFileEndpoint')
+          || (typeof vm.endpoint === 'string'
+            && /file-manager|package-files|public-files/i.test(vm.endpoint)))
+      ) {
+        params.data_name = params.filename || file.name;
+      }
+      return params;
+    };
+  },
   updated() {
     this.removeDefaultClasses();
   },
@@ -573,9 +591,6 @@ export default {
         }
       }
       file.ignored = false;
-      if (!this.name) {
-        this.options.query.data_name = file.name;
-      }
       return true;
     },
     removeDefaultClasses() {

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -386,14 +386,13 @@ export default {
   },
   methods: {
     isFileManagerPublicInterface() {
-      try {
-        const p = String(window.location.pathname || '');
-        const h = String(window.location.hash || '');
-        return p.includes('/file-manager/public')
-          || (/\/file-manager\/?$/i.test(p) && /^#\/public(\/|$)/i.test(h));
-      } catch (e) {
+      if (typeof window === 'undefined' || !window.location) {
+        return false;
       }
-      return false;
+      const p = String(window.location.pathname || '');
+      const h = String(window.location.hash || '');
+      return p.includes('/file-manager/public')
+        || (/\/file-manager\/?$/i.test(p) && /^#\/public(\/|$)/i.test(h));
     },
     clearFiles() {
       this.showComponent = false;

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -392,8 +392,8 @@ export default {
         return p.includes('/file-manager/public')
           || (/\/file-manager\/?$/i.test(p) && /^#\/public(\/|$)/i.test(h));
       } catch (e) {
-        return false;
       }
+      return false;
     },
     clearFiles() {
       this.showComponent = false;

--- a/src/components/renderer/file-upload.vue
+++ b/src/components/renderer/file-upload.vue
@@ -156,19 +156,13 @@ export default {
   props: ['label', 'error', 'helper', 'name', 'value', 'controlClass', 'endpoint', 'accept', 'validation', 'parent', 'config', 'multipleUpload', 'screenType'],
   created() {
     const vm = this;
-    // After merge with chunk getParams(), query includes `filename` for this chunk's file — fix
-    // data_name per request without replacing opts.query with a function or serializing uploads.
+    // File Manager > Public + multi: see isFileManagerPublicInterface(); processParams fixes
+    // data_name per chunk (processParams runs after getParams merges `filename` for this chunk).
     this.options.processParams = (params, file) => {
-      if (!vm.name) {
-        params.data_name = params.filename || file.name;
-      } else if (
-        vm.multipleUpload
-        && (_.has(window, 'PM4ConfigOverrides.postFileEndpoint')
-          || (typeof vm.endpoint === 'string'
-            && /file-manager|package-files|public-files/i.test(vm.endpoint)))
-      ) {
-        params.data_name = params.filename || file.name;
+      if (!vm.isFileManagerPublicInterface() || !vm.multipleUpload) {
+        return params;
       }
+      params.data_name = params.filename || file.name;
       return params;
     };
   },
@@ -391,6 +385,16 @@ export default {
     };
   },
   methods: {
+    isFileManagerPublicInterface() {
+      try {
+        const p = String(window.location.pathname || '');
+        const h = String(window.location.hash || '');
+        return p.includes('/file-manager/public')
+          || (/\/file-manager\/?$/i.test(p) && /^#\/public(\/|$)/i.test(h));
+      } catch (e) {
+        return false;
+      }
+    },
     clearFiles() {
       this.showComponent = false;
       this.$nextTick(() => {
@@ -591,6 +595,9 @@ export default {
         }
       }
       file.ignored = false;
+      if (!this.name && !(this.isFileManagerPublicInterface() && this.multipleUpload)) {
+        this.options.query.data_name = file.name;
+      }
       return true;
     },
     removeDefaultClasses() {


### PR DESCRIPTION
Description:
Issue: multiple uploads were sending the same data_name, causing incorrect values in media custom properties.

Related tickets:
https://processmaker.atlassian.net/browse/FOUR-30726

rerun

