### PR TITLE
bugfix/FOUR-27646 First Financial Bank - Validation Rules for Hidden Required Fields Inside Loops Are Inconsistently Applied

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -239,32 +239,41 @@ class PageNavigateValidations extends Validations {
  * Add validations for a form element
  */
 class FormElementValidations extends Validations {
-  async addValidations(validations) {
+  /**
+   * Returns true when this field should be skipped entirely (not validated).
+   * Inside loops, conditionalHide is per-row and handled by the runtime closure,
+   * so only the device-level visibleInDevice flag is checked statically.
+   */
+  shouldSkipValidation() {
     if (this.insideLoop) {
-      // Inside loops, conditionalHide depends on per-row data and is evaluated
-      // correctly in the runtime closure. Skip that check here.
-      // However, visibleInDevice is device-level (not per-row) and is reliably
-      // set by the VisibilityRule extension, so we still honor it.
       const visibleInDevice =
         this.element.visibleInDevice === null || this.element.visibleInDevice === undefined
           ? true
           : this.element.visibleInDevice;
-      if (!visibleInDevice) {
-        return;
-      }
-    } else if (!this.isVisible()) {
+      return !visibleInDevice;
+    }
+    return !this.isVisible();
+  }
+
+  /**
+   * Returns true when the element has a usable config with a valid variable name
+   * and is neither readonly nor disabled.
+   */
+  isValidElement() {
+    const { config } = this.element;
+    if (!config || config.readonly || config.disabled) {
+      return false;
+    }
+    return config.name &&
+      typeof config.name === 'string' &&
+      config.name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/);
+  }
+
+  async addValidations(validations) {
+    if (this.shouldSkipValidation()) {
       return;
     }
-    if (this.element.config && this.element.config.readonly) {
-      //readonly elements do not need validation
-      return;
-    }
-    if (this.element.config && this.element.config.disabled) {
-      //disabled elements do not need validation
-      return;
-    }
-    if (!(this.element.config && this.element.config.name && typeof this.element.config.name === 'string' && this.element.config.name.match(/^[a-zA-Z_][0-9a-zA-Z_.]*$/))) {
-      //element invalid
+    if (!this.isValidElement()) {
       return;
     }
     const fieldName = this.element.config.name;

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -157,7 +157,7 @@ class FormLoopValidations extends Validations {
         return;
       }
       page.items.filter(item => {
-        if (item.component === 'FormLoop' && item.config.name === this.element.config.name) {
+        if (item.component === 'FormLoop' && item.config.name === this.element.config.name && item !== this.element) {
           siblings.push(item);
         }
       });
@@ -240,8 +240,10 @@ class PageNavigateValidations extends Validations {
  */
 class FormElementValidations extends Validations {
   async addValidations(validations) {
-    // Disable validations if field is hidden
-    if (!this.isVisible()) {
+    // When inside a loop, each row may have different data so the static isVisible()
+    // check (which uses only the first row's data) cannot reliably determine visibility.
+    // The runtime closure evaluates conditionalHide per-row with the correct data.
+    if (!this.insideLoop && !this.isVisible()) {
       return;
     }
     if (this.element.config && this.element.config.readonly) {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -269,12 +269,13 @@ class FormElementValidations extends Validations {
     }
     const fieldName = this.element.config.name;
     const validationConfig = this.element.config.validation;
-    const conditionalHide = this.element.config.conditionalHide;
-    const parentVisibilityRule = this.parentVisibilityRule;
-    const insideLoop = this.insideLoop || false;
-    const deviceConfig = this.element.config.deviceVisibility
-      ? this.element.config.deviceVisibility
-      : { showForDesktop: true, showForMobile: true };
+    const closureOptions = {
+      fieldName,
+      conditionalHide: this.element.config.conditionalHide,
+      parentVisibilityRule: this.parentVisibilityRule,
+      insideLoop: this.insideLoop || false,
+      deviceConfig: this.element.config.deviceVisibility || { showForDesktop: true, showForMobile: true },
+    };
 
     set(validations, fieldName, get(validations, fieldName, {}));
     const fieldValidation = get(validations, fieldName);
@@ -286,109 +287,77 @@ class FormElementValidations extends Validations {
         }
         let validationFn = validators[rule];
         if (!validationFn) {
-          // eslint-disable-next-line no-console
           return;
         }
         if (validation.configs instanceof Array) {
-          const params = [];
-          validation.configs.forEach((cnf) => {
-            params.push(cnf.value);
-          });
+          const params = validation.configs.map((cnf) => cnf.value);
           params.push(fieldName);
           validationFn = validationFn(...params);
         }
-        fieldValidation[rule] = function(...props) {
-          const data = props[1];
-          const level = fieldName.split('.').length - 1;
-          const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
-          if (parentVisibilityRule) {
-            const nextParentLevel = insideLoop ? 1 : 0;
-            const parentDataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level + nextParentLevel);
-            let isParentVisible = true;
-            try {
-              isParentVisible = !!Parser.evaluate(parentVisibilityRule, parentDataWithParent);
-            } catch (error) {
-              isParentVisible = false;
-            }
-
-            if (!isParentVisible ) {
-              return true;
-            }
-          }
-
-          // Check Device Visibility
-          let visibleInDevice = true;
-          try {
-            const isMobileScreen = this.$root.$children[0].$refs.renderer.definition.isMobile;
-            visibleInDevice =
-              (isMobileScreen && deviceConfig.showForMobile) ||
-              (!isMobileScreen && deviceConfig.showForDesktop);
-          } catch (error) {
-            visibleInDevice = true;
-          }
-          if (!visibleInDevice) {
-            return true;
-          }
-
-          // Check Field Visibility
-          let visible = true;
-          if (conditionalHide) {
-            try {
-              visible = !!Parser.evaluate(conditionalHide, dataWithParent);
-            } catch (error) {
-              visible = false;
-            }
-          }
-          if (!visible) {
-            return true;
-          }
-          return validationFn.apply(this,props);
-        };
+        fieldValidation[rule] = this.buildClosure(validationFn, closureOptions);
       });
     } else if (typeof validationConfig === 'string' && validationConfig) {
-      let validationFn = validators[validationConfig];
+      const validationFn = validators[validationConfig];
       if (!validationFn) {
-        // eslint-disable-next-line no-console
         return;
       }
-      fieldValidation[validationConfig] = function(...props) {
-        const data = props[1];
-        const level = fieldName.split('.').length - 1;
-        const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
-        // Check Parent Visibility
-        if (parentVisibilityRule) {
-          const nextParentLevel = insideLoop ? 1 : 0;
-          const parentDataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level + nextParentLevel);
-          let isParentVisible = true;
-          try {
-            isParentVisible = !!Parser.evaluate(parentVisibilityRule, parentDataWithParent);
-          } catch (error) {
-            isParentVisible = false;
-          }
-
-          if (!isParentVisible) {
-            return true;
-          }
-        }
-        // Check Field Visibility
-        let visible = true;
-        if (conditionalHide) {
-          try {
-            visible = !!Parser.evaluate(conditionalHide, dataWithParent);
-          } catch (error) {
-            visible = false;
-          }
-        }
-        if (!visible) {
-          return true;
-        }
-        return validationFn.apply(this,props);
-      };
+      fieldValidation[validationConfig] = this.buildClosure(validationFn, closureOptions);
     }
     if (this.element.items) {
       ValidationsFactory(this.element.items, { screen: this.screen, data: this.data }).addValidations(validations);
     }
   }
+
+  buildClosure(validationFn, { fieldName, parentVisibilityRule, insideLoop, deviceConfig, conditionalHide }) {
+    return function (...props) {
+      const data = props[1];
+      const level = fieldName.split('.').length - 1;
+      const dataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level);
+
+      if (parentVisibilityRule) {
+        const nextParentLevel = insideLoop ? 1 : 0;
+        const parentDataWithParent = this.getDataAccordingToFieldLevel(this.getRootScreen().addReferenceToParents(data), level + nextParentLevel);
+        let isParentVisible = true;
+        try {
+          isParentVisible = !!Parser.evaluate(parentVisibilityRule, parentDataWithParent);
+        } catch (error) {
+          isParentVisible = false;
+        }
+        if (!isParentVisible) {
+          return true;
+        }
+      }
+
+      // Check Device Visibility
+      let visibleInDevice = true;
+      try {
+        const isMobileScreen = this.$root.$children[0].$refs.renderer.definition.isMobile;
+        visibleInDevice =
+          (isMobileScreen && deviceConfig.showForMobile) ||
+          (!isMobileScreen && deviceConfig.showForDesktop);
+      } catch (error) {
+        visibleInDevice = true;
+      }
+      if (!visibleInDevice) {
+        return true;
+      }
+
+      // Check Field Visibility
+      let visible = true;
+      if (conditionalHide) {
+        try {
+          visible = !!Parser.evaluate(conditionalHide, dataWithParent);
+        } catch (error) {
+          visible = false;
+        }
+      }
+      if (!visible) {
+        return true;
+      }
+      return validationFn.apply(this, props);
+    };
+  }
+
   camelCase(name) {
     return name.replace(/_\w/g, m => m.substr(1, 1).toUpperCase());
   }

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -240,10 +240,19 @@ class PageNavigateValidations extends Validations {
  */
 class FormElementValidations extends Validations {
   async addValidations(validations) {
-    // When inside a loop, each row may have different data so the static isVisible()
-    // check (which uses only the first row's data) cannot reliably determine visibility.
-    // The runtime closure evaluates conditionalHide per-row with the correct data.
-    if (!this.insideLoop && !this.isVisible()) {
+    if (this.insideLoop) {
+      // Inside loops, conditionalHide depends on per-row data and is evaluated
+      // correctly in the runtime closure. Skip that check here.
+      // However, visibleInDevice is device-level (not per-row) and is reliably
+      // set by the VisibilityRule extension, so we still honor it.
+      const visibleInDevice =
+        this.element.visibleInDevice === null || this.element.visibleInDevice === undefined
+          ? true
+          : this.element.visibleInDevice;
+      if (!visibleInDevice) {
+        return;
+      }
+    } else if (!this.isVisible()) {
       return;
     }
     if (this.element.config && this.element.config.readonly) {


### PR DESCRIPTION
## Issue & Reproduction Steps
First Financial Bank - Validation Rules for Hidden Required Fields Inside Loops Are Inconsistently Applied

Expected behavior: 
Hidden required fields should not be validated.
Validation should only apply to inputs that are visible and active at the time of submission.

Actual behavior: 
When the screen loads, all three loop instances are created (because the default count is 3).
Even if the input fields are hidden (checkbox unchecked), the system still tries to validate them.
As a result:

Clicking Submit triggers “The field is required” errors for all hidden inputs.
If you check only the second or third checkbox and fill that input, the hidden ones still fail validation.
If you check and fill only the first input, the form submits successfully — even though the others remain hidden and empty.

This makes validation inconsistent depending on which iteration is visible or filled.

## Solution
Added isVisible and insideLoop validation
<img width="2608" height="1414" alt="image" src="https://github.com/user-attachments/assets/c40d37b1-312c-4e44-91c1-c288c03bc3d9" />


## How to Test
Create a new screen.

Add a Loop container  loop_1.
Set Default Loop Count: 3

Inside loop_1, add:

A Checkbox form_checkbox_1.
A Required Line Input form_input_1.

For the Visibility Rule of form_input_1, set:

form_checkbox_1
(so the input only appears when the checkbox is checked).
Add a Submit button outside the loop.

In Preview mode:

Leave all checkboxes unchecked
Click Submit → all hidden required fields fail validation.
Check only the second or third checkbox and fill the input → hidden instances still fail validation.
Check and fill only the first instance → submission succeeds, even if other hidden fields exist.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-27646
 
ci:deploy
