### PR TITLE
FOUR-30436 | Record List Column Selector Does Not Show All Collection Fields When Configuring a Collection Source

### DIFF
--- a/src/components/inspector/collection-data-source.vue
+++ b/src/components/inspector/collection-data-source.vue
@@ -185,13 +185,24 @@ export default {
       }
     },
     getCollectionColumns(records) {
+      this.singleFieldOptions = [];
+
+      // Prefer the collection schema when CollectionRecordsList has
+      // forwarded it on the v-model payload.
+      if (Array.isArray(records?.fields) && records.fields.length > 0) {
+        records.fields.forEach((field) => {
+          this.singleFieldOptions.push({
+            text: field.text || field.value,
+            value: field.value
+          });
+        });
+        return;
+      }
+
+      // Fallback: get columns from the first record's populated keys.
       const [firstRecord] = records?.dataRecordList || [];
-
       if (firstRecord?.data) {
-        this.singleFieldOptions = [];
-        const dataObject = firstRecord.data;
-
-        for (const [key] of Object.entries(dataObject)) {
+        for (const [key] of Object.entries(firstRecord.data)) {
           this.singleFieldOptions.push({ text: key, value: key });
         }
       }

--- a/src/components/inspector/collection-records-list.vue
+++ b/src/components/inspector/collection-records-list.vue
@@ -35,7 +35,8 @@ import ScreenVariableSelector from "../screen-variable-selector.vue";
 const CONFIG_FIELDS = [
   "collectionId",
   "pmql",
-  "dataRecordList"
+  "dataRecordList",
+  "fields"
 ];
 
 export default {
@@ -144,22 +145,18 @@ export default {
     },
     getFields() {
       if (!this.collectionId) {
+        this.fields = [];
         return;
       }
 
       this.$dataProvider
         .getCollectionFields(this.collectionId)
         .then((response) => {
-          this.fields = [
-            { value: null, text: this.$t("Select a field") },
-            { value: "id", text: this.$t("Collection Record ID") },
-            ...response.data.data.map((field) => {
-              return {
-                text: field.label,
-                value: field.field
-              };
-            })
-          ];
+          const dataColumns = response?.data?.data || [];
+          this.fields = dataColumns.map((field) => ({
+            text: field.label || field.field,
+            value: field.field
+          }));
 
           this.onCollectionChange();
         });

--- a/src/components/inspector/column-setup.vue
+++ b/src/components/inspector/column-setup.vue
@@ -395,12 +395,23 @@ export default {
     },
     getCollectionColumns(collection) {
       this.collectionOptions = [{ text: "All columns", value: "all" }];
+
+      // Prefer the collection schema when CollectionRecordsList
+      // has forwarded it on the v-model payload.
+      if (Array.isArray(collection?.fields) && collection.fields.length > 0) {
+        collection.fields.forEach((field) => {
+          this.collectionOptions.push({
+            text: field.text || field.value,
+            value: field.value
+          });
+        });
+        return;
+      }
+
+      // Fallback: get columns from the first record's populated keys.
       const [firstRecord] = collection?.dataRecordList || [];
-
       if (firstRecord?.data) {
-        const dataObject = firstRecord.data;
-
-        for (const [key, value] of Object.entries(dataObject)) {
+        for (const [key] of Object.entries(firstRecord.data)) {
           this.collectionOptions.push({ text: key, value: key });
         }
       }


### PR DESCRIPTION
# Issue
Ticket: [FOUR-30436](https://processmaker.atlassian.net/browse/FOUR-30436)

When a Record List screen control is configured with Collection as its Source of Record List, the column selector dropdown in the inspector silently drops fields once the chosen collection has more than ~12 columns. Fields that are unset/null on the first record are missing from the dropdown even though they exist on the collection.

# Solution
`getCollectionColumns()` in `column-setup.vue` and `collection-data-source.vue` derived columns from `Object.entries(firstRecord.data)`, so any field that was null/empty on the first record was invisible. The schema endpoint (`GET /collections/{id}/columns`) was already being fetched in `collection-records-list.vue::getFields()`, but the result never reached the dropdowns.

This PR threads the schema through the existing data flow:
- **`collection-records-list.vue`**: added `"fields"` to `CONFIG_FIELDS` so the schema rides along on the v-model payload alongside `collectionId`, `pmql`, and `dataRecordList`. Reshaped `getFields()` to populate `this.fields` as `[{ text, value }, …]` from the columns endpoint, and reset it on `collectionId` clear to avoid stale leakage across collection swaps.
- **`collection-data-source.vue`** and **`column-setup.vue`**: `getCollectionColumns()` now prefers the schema from the payload when populating the dropdown, with the first-record-derived path kept as a legacy fallback.
The dropdown now reflects the collection's defined schema rather than just the keys present on the first record.
  
# How To Test
1. Import or create a collection with more than 12 columns. (You can use the `Staff Claim Collection Workshop` collection that is attached in the JIRA ticket).
2. Import the screen `50358 Data Collection Records` (also attached in the JIRA ticket).
3. Inside the screen, select the existing record list control named `GetDataCollectionRecords`.
4. In the Record List configuration panel, set Source of Record List to Collection.
5. Select the collection Staff Claim Collection Workshop.
6. Open the Columns section and click Add Column to display the column selector dropdown.
7. Review the list of available fields shown in the dropdown and compare it with the actual columns configured in the collection.
8. All of the columns configured in the collection should be shown in the Columns dropdown.


# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to ProcessMaker Coding Guidelines.
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-30436]: https://processmaker.atlassian.net/browse/FOUR-30436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ