### PR TITLE
FOUR-31894 SCREEN BUILDER >> Repeated calls of vocabularies

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -283,10 +283,7 @@ export default {
         url += `&screen_version=${this.screenVersion}`;
       }
 
-      // For Vocabularies
-      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
-        window.ProcessMaker.VocabulariesSchemaUrl = `vocabularies/task_schema/${this.taskId}`;
-      }
+      this.setVocabulariesSchemaUrl();
 
       return this.beforeLoadTask(this.taskId, this.nodeId).then(() => {
         this.$dataProvider
@@ -692,6 +689,19 @@ export default {
       const queryString = new URLSearchParams(queryParams).toString();
 
       return this.$dataProvider.getTasks(`?${queryString}`);
+    },
+    setVocabulariesSchemaUrl() {
+      if (
+        window.ProcessMaker
+        && window.ProcessMaker.packages
+        && window.ProcessMaker.packages.includes("package-vocabularies")
+      ) {
+        const schemaUrl = `vocabularies/task_schema/${this.taskId}`;
+        if (window.ProcessMaker.VocabulariesSchemaUrl !== schemaUrl) {
+          window.ProcessMaker.VocabulariesSchemaCache = null;
+        }
+        window.ProcessMaker.VocabulariesSchemaUrl = schemaUrl;
+      }
     },
     /**
      * Parses a JSON string and returns the result.

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -10,25 +10,56 @@ import { findRootScreen } from "./DataReference";
 const stringFormats = ['string', 'datetime', 'date', 'password'];
 const parentReference = [];
 
+const getVocabulariesSchema = () => {
+  if (
+    window.ProcessMaker &&
+    window.ProcessMaker.packages &&
+    window.ProcessMaker.packages.includes("package-vocabularies")
+  ) {
+    if (window.ProcessMaker.VocabulariesSchemaUrl) {
+      const schemaUrl = window.ProcessMaker.VocabulariesSchemaUrl;
+      const cache = window.ProcessMaker.VocabulariesSchemaCache;
+
+      if (cache && cache.url === schemaUrl) {
+        return cache.promise || cache.data;
+      }
+
+      const promise = window.ProcessMaker.apiClient
+        .get(schemaUrl)
+        .then((response) => {
+          if (window.ProcessMaker.VocabulariesSchemaUrl === schemaUrl) {
+            window.ProcessMaker.VocabulariesSchemaCache = {
+              url: schemaUrl,
+              data: response.data
+            };
+          }
+          return response.data;
+        })
+        .catch((error) => {
+          if (window.ProcessMaker.VocabulariesSchemaCache?.url === schemaUrl) {
+            window.ProcessMaker.VocabulariesSchemaCache = null;
+          }
+          throw error;
+        });
+
+      window.ProcessMaker.VocabulariesSchemaCache = {
+        url: schemaUrl,
+        promise
+      };
+
+      return promise;
+    }
+    if (window.ProcessMaker.VocabulariesPreview) {
+      return window.ProcessMaker.VocabulariesPreview;
+    }
+  }
+  return {};
+};
+
 export default {
   name: "ScreenContent",
   mixins: [DataReference, computedFields, VariablesToSubmitFilter],
-  schema: [
-    function() {
-      if (window.ProcessMaker && window.ProcessMaker.packages && window.ProcessMaker.packages.includes('package-vocabularies')) {
-        if (window.ProcessMaker.VocabulariesSchemaUrl) {
-          let response = window.ProcessMaker.apiClient.get(window.ProcessMaker.VocabulariesSchemaUrl);
-          return response.then(response => {
-            return response.data;
-          });
-        }
-        if (window.ProcessMaker.VocabulariesPreview) {
-          return window.ProcessMaker.VocabulariesPreview;
-        }
-      }
-      return {};
-    },
-  ],
+  schema: [getVocabulariesSchema],
   data() {
     return {
       ValidationRules__: {},

--- a/tests/unit/TaskSelfServiceLock.spec.js
+++ b/tests/unit/TaskSelfServiceLock.spec.js
@@ -133,6 +133,7 @@ describe('Task self-service lock', () => {
       screenVersion: null,
       beforeLoadTask: jest.fn().mockResolvedValue(),
       $dataProvider: { getTasks },
+      setVocabulariesSchemaUrl: jest.fn(),
       setSelfService,
       linkTask,
       checkTaskStatus,
@@ -149,5 +150,43 @@ describe('Task self-service lock', () => {
     expect(linkTask).toHaveBeenCalledWith(false);
     expect(checkTaskStatus).toHaveBeenCalled();
     expect(context.loadingTask).toBe(false);
+  });
+
+  test("setVocabulariesSchemaUrl invalidates cache when task changes", () => {
+    sandbox.window.ProcessMaker = {
+      packages: ["package-vocabularies"],
+      VocabulariesSchemaUrl: "vocabularies/task_schema/222",
+      VocabulariesSchemaCache: {
+        url: "vocabularies/task_schema/222",
+        data: { current: true }
+      }
+    };
+
+    Task.methods.setVocabulariesSchemaUrl.call({ taskId: 223 });
+
+    expect(sandbox.window.ProcessMaker.VocabulariesSchemaUrl).toBe(
+      "vocabularies/task_schema/223"
+    );
+    expect(sandbox.window.ProcessMaker.VocabulariesSchemaCache).toBeNull();
+  });
+
+  test("setVocabulariesSchemaUrl keeps cache when task has not changed", () => {
+    const cache = {
+      url: "vocabularies/task_schema/223",
+      data: { current: true }
+    };
+
+    sandbox.window.ProcessMaker = {
+      packages: ["package-vocabularies"],
+      VocabulariesSchemaUrl: "vocabularies/task_schema/223",
+      VocabulariesSchemaCache: cache
+    };
+
+    Task.methods.setVocabulariesSchemaUrl.call({ taskId: 223 });
+
+    expect(sandbox.window.ProcessMaker.VocabulariesSchemaUrl).toBe(
+      "vocabularies/task_schema/223"
+    );
+    expect(sandbox.window.ProcessMaker.VocabulariesSchemaCache).toBe(cache);
   });
 });

--- a/tests/unit/VocabulariesSchema.spec.js
+++ b/tests/unit/VocabulariesSchema.spec.js
@@ -1,0 +1,136 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const mixinPath = path.join(process.cwd(), "src/mixins/ScreenBase.js");
+
+const source = fs.readFileSync(mixinPath, "utf8");
+
+function getScreenBaseOptions() {
+  const executableScript = source
+    .replace(/^import .*$/gm, "")
+    .replace("export default", "module.exports =");
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    window: {
+      ProcessMaker: {}
+    },
+    DataReference: {},
+    VariablesToSubmitFilter: {},
+    computedFields: {},
+    ValidationMsg: {},
+    Mustache: { render: jest.fn() },
+    get: jest.fn(),
+    isEqual: jest.fn(),
+    set: jest.fn(),
+    debounce: jest.fn(),
+    findRootScreen: jest.fn(),
+    mapActions: jest.fn(() => ({})),
+    mapGetters: jest.fn(() => ({})),
+    mapState: jest.fn(() => ({}))
+  };
+
+  vm.runInNewContext(executableScript, sandbox, { filename: mixinPath });
+
+  return {
+    screenBase: sandbox.module.exports,
+    sandbox
+  };
+}
+
+describe("Vocabularies schema cache", () => {
+  const { screenBase: ScreenBase, sandbox } = getScreenBaseOptions();
+  const getVocabulariesSchema = ScreenBase.schema[0];
+
+  beforeEach(() => {
+    sandbox.window.ProcessMaker = {
+      packages: ["package-vocabularies"],
+      VocabulariesSchemaUrl: "vocabularies/task_schema/123",
+      apiClient: {
+        get: jest.fn()
+      }
+    };
+  });
+
+  test("shares one in-flight vocabulary schema request for the current task", async () => {
+    const schema = { properties: { course: { type: "string" } } };
+    let resolveRequest;
+    const request = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    sandbox.window.ProcessMaker.apiClient.get.mockReturnValue(request);
+
+    const firstSchema = getVocabulariesSchema();
+    const secondSchema = getVocabulariesSchema();
+
+    expect(secondSchema).toBe(firstSchema);
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenCalledTimes(1);
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenCalledWith(
+      "vocabularies/task_schema/123"
+    );
+
+    resolveRequest({ data: schema });
+    await expect(firstSchema).resolves.toBe(schema);
+
+    expect(getVocabulariesSchema()).toBe(schema);
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenCalledTimes(1);
+  });
+
+  test("loads a new vocabulary schema once when the task URL changes", async () => {
+    const firstSchema = { task: 123 };
+    const secondSchema = { task: 456 };
+
+    sandbox.window.ProcessMaker.apiClient.get
+      .mockResolvedValueOnce({ data: firstSchema })
+      .mockResolvedValueOnce({ data: secondSchema });
+
+    await expect(getVocabulariesSchema()).resolves.toBe(firstSchema);
+
+    sandbox.window.ProcessMaker.VocabulariesSchemaUrl =
+      "vocabularies/task_schema/456";
+
+    await expect(getVocabulariesSchema()).resolves.toBe(secondSchema);
+
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenCalledTimes(2);
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenNthCalledWith(
+      1,
+      "vocabularies/task_schema/123"
+    );
+    expect(sandbox.window.ProcessMaker.apiClient.get).toHaveBeenNthCalledWith(
+      2,
+      "vocabularies/task_schema/456"
+    );
+    expect(getVocabulariesSchema()).toBe(secondSchema);
+  });
+
+  test("does not let a stale task response overwrite the current schema cache", async () => {
+    let resolveFirstRequest;
+    const firstRequest = new Promise((resolve) => {
+      resolveFirstRequest = resolve;
+    });
+    const secondSchema = { task: 456 };
+
+    sandbox.window.ProcessMaker.apiClient.get
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce({ data: secondSchema });
+
+    const firstSchema = getVocabulariesSchema();
+
+    sandbox.window.ProcessMaker.VocabulariesSchemaUrl =
+      "vocabularies/task_schema/456";
+    sandbox.window.ProcessMaker.VocabulariesSchemaCache = null;
+
+    await expect(getVocabulariesSchema()).resolves.toBe(secondSchema);
+
+    resolveFirstRequest({ data: { task: 123 } });
+    await expect(firstSchema).resolves.toEqual({ task: 123 });
+
+    expect(sandbox.window.ProcessMaker.VocabulariesSchemaCache).toEqual({
+      url: "vocabularies/task_schema/456",
+      data: secondSchema
+    });
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps

### SCREEN BUILDER >> Repeated calls of vocabularies

## Solution
Moved the vocabulary schema URL setup in task.vue into setVocabulariesSchemaUrl(), which invalidates the cache only when the task changes. Updated ScreenBase.js to use window.ProcessMaker.VocabulariesSchemaCache, keyed by VocabulariesSchemaUrl, so nested renderers share one schema request instead of triggering duplicate calls.

<img width="2664" height="2472" alt="FOUR-31894" src="https://github.com/user-attachments/assets/af53d21d-49db-463f-a0a0-8e0efac4536d" />

## Related Tickets & Packages
[FOUR-31894](https://processmaker.atlassian.net/browse/FOUR-31894)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.



[FOUR-31894]: https://processmaker.atlassian.net/browse/FOUR-31894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ