### PR TITLE
FOUR-31978 SCREEN BUILDER Use apiClient cache for repeated GET list options

### DIFF
--- a/src/DataProvider.js
+++ b/src/DataProvider.js
@@ -217,6 +217,7 @@ export default {
   getDataSource(dataSourceId, params, nonce = null) {
     // keep backwards compatibility
     if (
+      !params.cache &&
       !window.ProcessMaker.screen.cacheEnabled &&
       !window.ProcessMaker.screen.cacheTimeout
     ) {
@@ -226,6 +227,7 @@ export default {
     url += this.authQueryString();
     return this.get(url, {
       useCache: window.ProcessMaker.screen.cacheEnabled,
+      cache: params.cache,
       params: {
         pmds_config: JSON.stringify(params.config),
         pmds_data: JSON.stringify(params.data)

--- a/src/main.js
+++ b/src/main.js
@@ -203,6 +203,17 @@ window.ProcessMaker = {
               }
             }
           });
+        } else if (url === "/requests/data_sources/1/resources/list/data") {
+          resolve({
+            data: {
+              response: [
+                { value: 1, content: "James" },
+                { value: 2, content: "John" },
+                { value: 3, content: "Mary" },
+                { value: 4, content: "Patricia" }
+              ]
+            }
+          });
         } else if (url === "/data_sources") {
           resolve({
             data: {

--- a/tests/e2e/specs/SelectListCollection.spec.js
+++ b/tests/e2e/specs/SelectListCollection.spec.js
@@ -1,80 +1,87 @@
 describe("select list mustache", () => {
   beforeEach(() => {
     cy.visit("/");
+    const dataSourceResponse = {
+      status: 200,
+      response: {
+        data: [
+          {
+            id: 1,
+            created_by_id: 2,
+            updated_by_id: 2,
+            created_at: "2021-11-08 10:29:56",
+            updated_at: "2021-11-08 10:29:56",
+            data: {
+              dni: "1234",
+              name: {
+                last: "Smith",
+                first: "Oliver"
+              },
+              id: 1
+            },
+            collection_id: 1,
+            title: "1",
+            created_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            },
+            updated_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            }
+          },
+          {
+            id: 2,
+            created_by_id: 2,
+            updated_by_id: 2,
+            created_at: "2021-11-08 10:29:56",
+            updated_at: "2021-11-08 10:29:56",
+            data: {
+              dni: "5678",
+              name: {
+                last: "Doe",
+                first: "John"
+              },
+              id: 2
+            },
+            collection_id: 1,
+            title: "2",
+            created_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            },
+            updated_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            }
+          }
+        ],
+        meta: {
+          filter: "",
+          sort_by: "",
+          sort_order: "",
+          count: 2,
+          total_pages: 1,
+          current_page: 1,
+          from: 1,
+          last_page: 1,
+          path: "/api/1.0/collections/1/records",
+          per_page: 9223372036854775807,
+          to: 2,
+          total: 2
+        }
+      }
+    };
+
     cy.intercept(
       "POST",
       "/api/1.0/requests/data_sources/2",
-      JSON.stringify({
-        status: 200,
-        response: {
-          data: [
-            {
-              id: 1,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                dni: "1234",
-                name: {
-                  last: "Smith",
-                  first: "Oliver"
-                },
-                id: 1
-              },
-              collection_id: 1,
-              title: "1",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            },
-            {
-              id: 2,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                dni: "5678",
-                name: {
-                  last: "Doe",
-                  first: "John"
-                },
-                id: 2
-              },
-              collection_id: 1,
-              title: "2",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            }
-          ],
-          meta: {
-            filter: "",
-            sort_by: "",
-            sort_order: "",
-            count: 2,
-            total_pages: 1,
-            current_page: 1,
-            from: 1,
-            last_page: 1,
-            path: "/api/1.0/collections/1/records",
-            per_page: 9223372036854775807,
-            to: 2,
-            total: 2
-          }
-        }
-      })
+      JSON.stringify(dataSourceResponse)
+    ).as("executeScript");
+    cy.intercept(
+      "GET",
+      "/api/1.0/requests/data_sources/2/resources/ListAll/data*",
+      JSON.stringify(dataSourceResponse)
     ).as("executeScript");
   });
 

--- a/tests/e2e/specs/SelectListDataSource.spec.js
+++ b/tests/e2e/specs/SelectListDataSource.spec.js
@@ -2,8 +2,8 @@ describe("Select List with DataSource", () => {
   beforeEach(() => {
     cy.visit("/");
     cy.intercept(
-      "POST",
-      "/api/1.0/requests/data_sources/2",
+      "GET",
+      "/api/1.0/requests/data_sources/2/resources/ListAll/data*",
       JSON.stringify({
         status: 200,
         response: {

--- a/tests/e2e/specs/SelectListDependent.spec.js
+++ b/tests/e2e/specs/SelectListDependent.spec.js
@@ -1,13 +1,37 @@
 describe("select list mustache", () => {
   beforeEach(() => {
     cy.visit("/");
+    const getOutboundConfigValue = (req) => {
+      const config = JSON.parse(req.query.pmds_config || "{}");
+      return config.outboundConfig && config.outboundConfig[0]
+        ? config.outboundConfig[0].value
+        : null;
+    };
+
+    const dataSourceResponse = (data, path) => ({
+      data,
+      meta: {
+        filter: "",
+        sort_by: "",
+        sort_order: "",
+        count: data.length,
+        total_pages: 1,
+        current_page: 1,
+        from: 1,
+        last_page: 1,
+        path,
+        per_page: 9223372036854775807,
+        to: data.length,
+        total: data.length
+      }
+    });
+
     cy.intercept(
-      "POST",
-      "/api/1.0/requests/data_sources/3",
-      JSON.stringify({
-        status: 200,
-        response: {
-          data: [
+      "GET",
+      "/api/1.0/requests/data_sources/3/resources/ListAll/data*",
+      {
+        response: dataSourceResponse(
+          [
             {
               id: 1,
               created_by_id: 2,
@@ -51,22 +75,9 @@ describe("select list mustache", () => {
               }
             }
           ],
-          meta: {
-            filter: "",
-            sort_by: "",
-            sort_order: "",
-            count: 2,
-            total_pages: 1,
-            current_page: 1,
-            from: 1,
-            last_page: 1,
-            path: "/api/1.0/collections/3/records",
-            per_page: 9223372036854775807,
-            to: 2,
-            total: 2
-          }
-        }
-      })
+          "/api/1.0/collections/3/records"
+        )
+      }
     ).as("executeScript");
     // Bolivia Cities
     const BoliviaCities = [
@@ -159,8 +170,8 @@ describe("select list mustache", () => {
       }
     ];
     let cities = [];
-    cy.intercept("POST", "/api/1.0/requests/data_sources/4", (req) => {
-      switch (req.body.config.outboundConfig[0].value) {
+    cy.intercept("GET", "/api/1.0/requests/data_sources/4/resources/ListAll/data*", (req) => {
+      switch (getOutboundConfigValue(req)) {
         case "data.country_id=1":
           cities = BoliviaCities;
           break;
@@ -170,23 +181,7 @@ describe("select list mustache", () => {
         default:
           cities = [];
       }
-      const response = {
-        data: cities,
-        meta: {
-          filter: "",
-          sort_by: "",
-          sort_order: "",
-          count: cities.length,
-          total_pages: 1,
-          current_page: 1,
-          from: 1,
-          last_page: 1,
-          path: "/api/1.0/collections/4/records",
-          per_page: 9223372036854775807,
-          to: cities.length,
-          total: cities.length
-        }
-      };
+      const response = dataSourceResponse(cities, "/api/1.0/collections/4/records");
       req.reply({
         headers: {
           "X-Cypress-Response": `"response":${JSON.stringify(response)}}`
@@ -381,8 +376,8 @@ describe("select list mustache", () => {
     ];
 
     let addresses = [];
-    cy.intercept("POST", "/api/1.0/requests/data_sources/5", (req) => {
-      switch (req.body.config.outboundConfig[0].value) {
+    cy.intercept("GET", "/api/1.0/requests/data_sources/5/resources/ListAll/data*", (req) => {
+      switch (getOutboundConfigValue(req)) {
         case "data.city_id=1":
           addresses = LaPazAddresses;
           break;
@@ -398,23 +393,7 @@ describe("select list mustache", () => {
         default:
           addresses = [];
       }
-      const response = {
-        data: addresses,
-        meta: {
-          filter: "",
-          sort_by: "",
-          sort_order: "",
-          count: addresses.length,
-          total_pages: 1,
-          current_page: 1,
-          from: 1,
-          last_page: 1,
-          path: "/api/1.0/collections/5/records",
-          per_page: 9223372036854775807,
-          to: addresses.length,
-          total: addresses.length
-        }
-      };
+      const response = dataSourceResponse(addresses, "/api/1.0/collections/5/records");
       req.reply({
         headers: {
           "X-Cypress-Response": `"response":${JSON.stringify(response)}}`

--- a/tests/e2e/specs/SelectListMustache.spec.js
+++ b/tests/e2e/specs/SelectListMustache.spec.js
@@ -1,80 +1,87 @@
 describe("select list mustache", () => {
   beforeEach(() => {
     cy.visit("/");
+    const dataSourceResponse = {
+      status: 200,
+      response: {
+        data: [
+          {
+            id: 1,
+            created_by_id: 2,
+            updated_by_id: 2,
+            created_at: "2021-11-08 10:29:56",
+            updated_at: "2021-11-08 10:29:56",
+            data: {
+              dni: "1234",
+              name: {
+                last: "Callizaya",
+                first: "David"
+              },
+              id: 1
+            },
+            collection_id: 1,
+            title: "1",
+            created_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            },
+            updated_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            }
+          },
+          {
+            id: 2,
+            created_by_id: 2,
+            updated_by_id: 2,
+            created_at: "2021-11-08 10:29:56",
+            updated_at: "2021-11-08 10:29:56",
+            data: {
+              dni: "5678",
+              name: {
+                last: "Loayza",
+                first: "Dante"
+              },
+              id: 2
+            },
+            collection_id: 1,
+            title: "2",
+            created_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            },
+            updated_by: {
+              id: 2,
+              email: "admin@processmaker.com"
+            }
+          }
+        ],
+        meta: {
+          filter: "",
+          sort_by: "",
+          sort_order: "",
+          count: 2,
+          total_pages: 1,
+          current_page: 1,
+          from: 1,
+          last_page: 1,
+          path: "/api/1.0/collections/1/records",
+          per_page: 9223372036854775807,
+          to: 2,
+          total: 2
+        }
+      }
+    };
+
     cy.intercept(
       "POST",
       "/api/1.0/requests/data_sources/2",
-      JSON.stringify({
-        status: 200,
-        response: {
-          data: [
-            {
-              id: 1,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                dni: "1234",
-                name: {
-                  last: "Callizaya",
-                  first: "David"
-                },
-                id: 1
-              },
-              collection_id: 1,
-              title: "1",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            },
-            {
-              id: 2,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                dni: "5678",
-                name: {
-                  last: "Loayza",
-                  first: "Dante"
-                },
-                id: 2
-              },
-              collection_id: 1,
-              title: "2",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            }
-          ],
-          meta: {
-            filter: "",
-            sort_by: "",
-            sort_order: "",
-            count: 2,
-            total_pages: 1,
-            current_page: 1,
-            from: 1,
-            last_page: 1,
-            path: "/api/1.0/collections/1/records",
-            per_page: 9223372036854775807,
-            to: 2,
-            total: 2
-          }
-        }
-      })
+      JSON.stringify(dataSourceResponse)
+    ).as("executeScript");
+    cy.intercept(
+      "GET",
+      "/api/1.0/requests/data_sources/2/resources/ListAll/data*",
+      JSON.stringify(dataSourceResponse)
     ).as("executeScript");
   });
 


### PR DESCRIPTION
## Issue & Reproduction Steps

### SCREEN BUILDER Use apiClient cache for repeated GET list options

## Solution

https://github.com/user-attachments/assets/4dbd8aac-1427-4379-ae37-eea475378a39

## Related Tickets & Packages
[FOUR-31978](https://processmaker.atlassian.net/browse/FOUR-31978)
https://github.com/ProcessMaker/vue-form-elements/pull/474

[FOUR-31978]: https://processmaker.atlassian.net/browse/FOUR-31978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:processmaker:feature/FOUR-30918
ci:vue-form-elements:feature/FOUR-30918
ci:deploy
