### PR TITLE
FOUR-32224: Prevent Web Entry temporary file download errors

### DIFF
--- a/src/components/renderer/file-download.vue
+++ b/src/components/renderer/file-download.vue
@@ -121,6 +121,9 @@ export default {
     this.setFilesInfo();
   },
   methods: {
+    isWebEntryTemporaryFileId(fileId) {
+      return typeof fileId === "string" && fileId.startsWith("webentry_");
+    },
     downloadFile(file) {
       if (this.collection) {
         this.downloadCollectionFile(file);
@@ -209,6 +212,12 @@ export default {
       const fileId = this.value
         ? this.value
         : _.get(this.requestData, this.fileDataName, null);
+
+      if (this.isWebEntryTemporaryFileId(fileId)) {
+        this.filesInfo = [];
+        return;
+      }
+
       let { endpoint } = this;
 
       if (this.requestFiles) {

--- a/tests/unit/FileDownloadUtils.spec.js
+++ b/tests/unit/FileDownloadUtils.spec.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const componentPath = path.join(
+  process.cwd(),
+  "src/components/renderer/file-download.vue"
+);
+
+const source = fs.readFileSync(componentPath, "utf8");
+
+function getComponentOptions() {
+  const scriptMatch = source.match(/<script>([\s\S]*?)<\/script>/);
+
+  if (!scriptMatch) {
+    throw new Error("Unable to find file-download.vue script block");
+  }
+
+  const executableScript = scriptMatch[1]
+    .replace(/^import .*$/gm, "")
+    .replace("export default", "module.exports =");
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {}
+  };
+
+  vm.runInNewContext(executableScript, sandbox, { filename: componentPath });
+
+  return sandbox.module.exports;
+}
+
+describe("File Download Web Entry temporary files", () => {
+  const FileDownload = getComponentOptions();
+  const { isWebEntryTemporaryFileId } = FileDownload.methods;
+
+  test("recognizes a Web Entry temporary file ID", () => {
+    expect(isWebEntryTemporaryFileId("webentry_upload_123_document.pdf")).toBe(
+      true
+    );
+  });
+
+  test.each([123, "123", "request_file_123", null, undefined, {}, []])(
+    "does not classify %p as a temporary file ID",
+    (fileId) => {
+      expect(isWebEntryTemporaryFileId(fileId)).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
## Issue & Reproduction Steps
In an intermediate Web Entry task, configure File Upload, File Preview, and File Download controls to use the same variable. Open the Web Entry and upload a file. File Preview loads successfully, but File Download treats the temporary `webentry_*` identifier as a persisted Request Media ID, calls the persisted-file endpoint, receives a `404`, and displays an error alert.

## Solution
- Detect temporary Web Entry file identifiers before requesting persisted file metadata.
- Clear stale File Download metadata and skip the invalid persisted-file request for `webentry_*` values.
- Preserve the existing behavior for persisted Request Media IDs.
- Add unit coverage for temporary, persisted, empty, and unsupported identifier values.

Downloading temporary files before submission remains outside the scope of this fix.

## How to Test
1. Run `npx jest tests/unit/FileDownloadUtils.spec.js --no-coverage --runInBand`.
2. Run `npx eslint src/components/renderer/file-download.vue tests/unit/FileDownloadUtils.spec.js`.
3. Run `npm run build`.
4. Configure an intermediate Web Entry with File Upload, File Preview, and File Download controls using the same variable.
5. Upload a file and verify that File Preview loads, no error alert appears, and no persisted-file request containing a `webentry_*` identifier is made.
6. Verify that File Download shows no available files until the upload is persisted.
7. Verify that an existing persisted Request file remains downloadable.

Manual local verification was completed successfully.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32224

ci:deploy