### PR TITLE
Clear signature field when reopening the Record List Add modal

### DIFF
--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -1030,6 +1030,7 @@ export default {
     },
     handleHideAddModal() {
       this.addItem = this.initFormValues;
+      window.ProcessMaker.EventBus.$emit("record-list-add-modal-hidden");
       this.$refs.addRenderer.hasSubmitted(false);
     },
     async handleOk(bvModalEvt) {


### PR DESCRIPTION
## Issue & Reproduction Steps
This PR fixes an issue where the Signature component kept its previous value after closing the Record List Add modal with the Cancel button and reopening it.

The modal now emits a `record-list-add-modal-hidden` event when it is hidden so components can react and reset their state as needed.

## Solution
- Emit `record-list-add-modal-hidden` on `window.ProcessMaker.EventBus` when the Add modal is hidden.

## How to Test

1. Configure a Record List.
2. Add a Signature component to the Record List’s Add screen.
3. Preview the Record List.
4. Click Add.
5. Fill out the Signature field.
6. Click Cancel to close the modal.
7. Reopen the Add modal.
8. Verify the Signature field is cleared.

## Related Tickets & PRs
- [ FOUR-32231](https://processmaker.atlassian.net/browse/FOUR-32231)
- [Signature Package PR](https://github.com/ProcessMaker/package-signature/pull/60)

ci:deploy

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
