### PR TITLE
Record list does not retrieve the selected value/data in the next task.

### DIFF
--- a/src/components/renderer/form-record-list-selection.js
+++ b/src/components/renderer/form-record-list-selection.js
@@ -1,0 +1,171 @@
+/**
+ * Pure helpers for FormRecordList collection radio/checkbox selection.
+ * Kept outside the Vue SFC so unit tests can exercise production logic
+ * without mounting the heavy FormRecordList component tree.
+ */
+
+export function isSingleFieldSelectionMode(source) {
+  return (
+    source?.dataSelectionOptions === "single-field" ||
+    (source?.dataSelectionOptions == null && !!source?.singleField)
+  );
+}
+
+/**
+ * Resolve the configured singleField value from a collection row.
+ * Rows are remapped from collection field names (content) to column keys,
+ * so singleField may not match Object.keys(row) directly.
+ */
+export function getSingleFieldValue(selectedItem, source, fields) {
+  const field = source?.singleField;
+  if (!field || !selectedItem || typeof selectedItem !== "object") {
+    return undefined;
+  }
+
+  if (Object.hasOwn(selectedItem, field)) {
+    return selectedItem[field];
+  }
+
+  const optionsList = fields?.optionsList || [];
+  const byContent = optionsList.find((opt) => opt.content === field);
+  if (byContent && Object.hasOwn(selectedItem, byContent.key)) {
+    return selectedItem[byContent.key];
+  }
+
+  const byKey = optionsList.find((opt) => opt.key === field);
+  if (byKey && Object.hasOwn(selectedItem, byKey.key)) {
+    return selectedItem[byKey.key];
+  }
+
+  const lower = String(field).toLowerCase();
+  const matchedKey = Object.keys(selectedItem).find(
+    (key) => String(key).toLowerCase() === lower
+  );
+  return matchedKey ? selectedItem[matchedKey] : undefined;
+}
+
+export function rowMatchesSingleFieldValue(row, value, source, fields) {
+  return getSingleFieldValue(row, source, fields) === value;
+}
+
+/**
+ * Convert a b-table page-relative cell index into a global row index.
+ * @change already provides a page-relative index; do not pass a global
+ * index here or the page offset will be applied twice.
+ */
+export function toGlobalRowIndex(pageRelativeIndex, currentPage, perPage) {
+  return (currentPage - 1) * perPage + pageRelativeIndex;
+}
+
+/**
+ * Build the value emitted for a radio selection.
+ * Returns undefined for missing single-field values (caller should not emit).
+ */
+export function buildRadioSelectionValue(
+  selectedItem,
+  pageRelativeIndex,
+  currentPage,
+  perPage,
+  source,
+  fields
+) {
+  if (isSingleFieldSelectionMode(source) && source?.singleField) {
+    return getSingleFieldValue(selectedItem, source, fields);
+  }
+
+  return {
+    ...selectedItem,
+    selectedRowIndex: toGlobalRowIndex(
+      pageRelativeIndex,
+      currentPage,
+      perPage
+    )
+  };
+}
+
+export function getCollectionRowKey(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const entries = Object.entries(item).filter(
+    ([key]) => key !== "selectedRowsIndex" && key !== "selectedRowIndex"
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  entries.sort(([keyA], [keyB]) => {
+    if (keyA > keyB) return 1;
+    if (keyA < keyB) return -1;
+    return 0;
+  });
+  return JSON.stringify(entries);
+}
+
+export function findSingleRecordRadioMatch(value, rows) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+
+  const valueKey = getCollectionRowKey(value);
+  if (valueKey) {
+    const byContent = rows.find(
+      (row) => getCollectionRowKey(row) === valueKey
+    );
+    if (byContent) {
+      return byContent;
+    }
+  }
+
+  const idx = value.selectedRowIndex;
+  if (idx != null && idx >= 0 && idx < rows.length) {
+    return rows[idx];
+  }
+  return null;
+}
+
+export function findRadioSelectionMatch(value, rows, source, fields) {
+  if (value == null || value === "" || !Array.isArray(rows) || rows.length === 0) {
+    return null;
+  }
+
+  if (isSingleFieldSelectionMode(source) && source?.singleField) {
+    return (
+      rows.find((row) =>
+        rowMatchesSingleFieldValue(row, value, source, fields)
+      ) || null
+    );
+  }
+
+  if (typeof value === "object" && !Array.isArray(value)) {
+    return findSingleRecordRadioMatch(value, rows);
+  }
+
+  return null;
+}
+
+/**
+ * Remap collection API rows from field content names to column keys,
+ * always preserving the configured singleField under its original name.
+ */
+export function remapCollectionRowData(dataObject, optionsList, singleField) {
+  const sourceData = dataObject || {};
+  const newDataObject = {};
+
+  Object.keys(sourceData).forEach((dataKey) => {
+    const matchingOption = (optionsList || []).find(
+      (option) => option.content === dataKey
+    );
+    if (matchingOption) {
+      newDataObject[matchingOption.key] = sourceData[dataKey];
+    }
+  });
+
+  if (singleField && Object.hasOwn(sourceData, singleField)) {
+    newDataObject[singleField] = sourceData[singleField];
+  }
+
+  return newDataObject;
+}

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -646,11 +646,7 @@ export default {
     onRadioChange(selectedItem, index) {
       const globalIndex = (this.currentPage - 1) * this.perPage + index;
       // Prefer dataSelectionOptions; fall back to singleField for legacy configs.
-      const isSingleField =
-        this.source?.dataSelectionOptions === "single-field" ||
-        (this.source?.dataSelectionOptions == null && !!this.source?.singleField);
-
-      if (isSingleField && this.source?.singleField) {
+      if (this.isSingleFieldSelectionMode() && this.source?.singleField) {
         this.componentOutput(this.getSingleFieldValue(selectedItem));
       } else {
         this.componentOutput({
@@ -670,24 +666,18 @@ export default {
         return undefined;
       }
 
-      if (Object.prototype.hasOwnProperty.call(selectedItem, field)) {
+      if (Object.hasOwn(selectedItem, field)) {
         return selectedItem[field];
       }
 
       const optionsList = this.fields?.optionsList || [];
       const byContent = optionsList.find((opt) => opt.content === field);
-      if (
-        byContent &&
-        Object.prototype.hasOwnProperty.call(selectedItem, byContent.key)
-      ) {
+      if (byContent && Object.hasOwn(selectedItem, byContent.key)) {
         return selectedItem[byContent.key];
       }
 
       const byKey = optionsList.find((opt) => opt.key === field);
-      if (
-        byKey &&
-        Object.prototype.hasOwnProperty.call(selectedItem, byKey.key)
-      ) {
+      if (byKey && Object.hasOwn(selectedItem, byKey.key)) {
         return selectedItem[byKey.key];
       }
 
@@ -699,6 +689,12 @@ export default {
     },
     rowMatchesSingleFieldValue(row, value) {
       return this.getSingleFieldValue(row) === value;
+    },
+    isSingleFieldSelectionMode() {
+      return (
+        this.source?.dataSelectionOptions === "single-field" ||
+        (this.source?.dataSelectionOptions == null && !!this.source?.singleField)
+      );
     },
     onMultipleSelectionChange(selIndex) {
       this.collectionData.forEach((item, index) => {
@@ -858,10 +854,7 @@ export default {
 
         // Keep the configured single-field under its original collection field name
         // so radio selection can read it even if the column was remapped or hidden.
-        if (
-          singleField &&
-          Object.prototype.hasOwnProperty.call(dataObject, singleField)
-        ) {
+        if (singleField && Object.hasOwn(dataObject, singleField)) {
           newDataObject[singleField] = dataObject[singleField];
         }
 
@@ -944,49 +937,46 @@ export default {
         return;
       }
 
-      const isSingleField =
-        this.source?.dataSelectionOptions === "single-field" ||
-        (this.source?.dataSelectionOptions == null && !!this.source?.singleField);
-
-      if (isSingleField && this.source?.singleField) {
-        // singleField mode emits a scalar; find the row whose field matches
+      if (this.isSingleFieldSelectionMode() && this.source?.singleField) {
         const match = rows.find((row) =>
           this.rowMatchesSingleFieldValue(row, this.value)
         );
-        if (match) {
-          this.restoringSelection = true;
-          this.selectedRow = match;
-          this.$nextTick(() => {
-            this.restoringSelection = false;
-          });
-        }
+        this.applyRestoredRadioSelection(match);
         return;
       }
 
       if (typeof this.value === "object" && !Array.isArray(this.value)) {
-        // Prefer matching by row content so selection survives collection refreshes
-        // even when selectedRowIndex is missing or rows were reordered.
-        const valueKey = this.getCollectionRowKey(this.value);
-        let match = null;
-        if (valueKey) {
-          match = rows.find(
-            (row) => this.getCollectionRowKey(row) === valueKey
-          );
-        }
-        if (!match) {
-          const idx = this.value.selectedRowIndex;
-          if (idx != null && idx >= 0 && idx < rows.length) {
-            match = rows[idx];
-          }
-        }
-        if (match) {
-          this.restoringSelection = true;
-          this.selectedRow = match;
-          this.$nextTick(() => {
-            this.restoringSelection = false;
-          });
+        this.applyRestoredRadioSelection(this.findSingleRecordRadioMatch(rows));
+      }
+    },
+    applyRestoredRadioSelection(match) {
+      if (!match) {
+        return;
+      }
+      this.restoringSelection = true;
+      this.selectedRow = match;
+      this.$nextTick(() => {
+        this.restoringSelection = false;
+      });
+    },
+    findSingleRecordRadioMatch(rows) {
+      // Prefer matching by row content so selection survives collection refreshes
+      // even when selectedRowIndex is missing or rows were reordered.
+      const valueKey = this.getCollectionRowKey(this.value);
+      if (valueKey) {
+        const byContent = rows.find(
+          (row) => this.getCollectionRowKey(row) === valueKey
+        );
+        if (byContent) {
+          return byContent;
         }
       }
+
+      const idx = this.value.selectedRowIndex;
+      if (idx != null && idx >= 0 && idx < rows.length) {
+        return rows[idx];
+      }
+      return null;
     },
     shouldPersistCollectionSelection() {
       const pmql = this.getCollectionPmql();

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -259,6 +259,7 @@ import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
+import { normalizeCollectionFieldPath } from "../../collectionFieldUtils";
 import {
   buildRadioSelectionValue,
   findRadioSelectionMatch,

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -259,6 +259,12 @@ import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
+import {
+  buildRadioSelectionValue,
+  findRadioSelectionMatch,
+  getCollectionRowKey,
+  remapCollectionRowData
+} from "./form-record-list-selection";
 
 const jsonOptionsActionsColumn = {
   key: "__actions",
@@ -329,8 +335,7 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' },
-      restoringSelection: false
+      popoverPosition: { top: '0px', left: '0px' }
     };
   },
   computed: {
@@ -472,31 +477,6 @@ export default {
           this.restoreRadioSelection(this.collectionData);
         }
       }
-    },
-    // Backup for b-form-radio inside b-table: @change can miss clicks, but v-model still updates.
-    selectedRow(newVal, oldVal) {
-      if (
-        this.restoringSelection ||
-        !newVal ||
-        newVal === oldVal ||
-        this.source?.sourceOptions !== "Collection"
-      ) {
-        return;
-      }
-      if (
-        !["single-field", "single-record"].includes(
-          this.source?.dataSelectionOptions
-        )
-      ) {
-        return;
-      }
-      const pageIndex = Array.isArray(this.tableData?.data)
-        ? this.tableData.data.indexOf(newVal)
-        : -1;
-      if (pageIndex < 0) {
-        return;
-      }
-      this.onRadioChange(newVal, pageIndex);
     },
     // Watch for changes in validationData to handle any Mustache variable changes
     validationData: {
@@ -643,57 +623,17 @@ export default {
       }
       return this.source?.pmql || "";
     },
-    onRadioChange(selectedItem, index) {
-      const globalIndex = (this.currentPage - 1) * this.perPage + index;
-      // Prefer dataSelectionOptions; fall back to singleField for legacy configs.
-      if (this.isSingleFieldSelectionMode() && this.source?.singleField) {
-        this.componentOutput(this.getSingleFieldValue(selectedItem));
-      } else {
-        this.componentOutput({
-          ...selectedItem,
-          selectedRowIndex: globalIndex
-        });
-      }
-    },
-    /**
-     * Resolve the configured singleField value from a collection row.
-     * Rows are remapped from collection field names (content) to column keys,
-     * so singleField may not match Object.keys(row) directly.
-     */
-    getSingleFieldValue(selectedItem) {
-      const field = this.source?.singleField;
-      if (!field || !selectedItem || typeof selectedItem !== "object") {
-        return undefined;
-      }
-
-      if (Object.hasOwn(selectedItem, field)) {
-        return selectedItem[field];
-      }
-
-      const optionsList = this.fields?.optionsList || [];
-      const byContent = optionsList.find((opt) => opt.content === field);
-      if (byContent && Object.hasOwn(selectedItem, byContent.key)) {
-        return selectedItem[byContent.key];
-      }
-
-      const byKey = optionsList.find((opt) => opt.key === field);
-      if (byKey && Object.hasOwn(selectedItem, byKey.key)) {
-        return selectedItem[byKey.key];
-      }
-
-      const lower = String(field).toLowerCase();
-      const matchedKey = Object.keys(selectedItem).find(
-        (key) => String(key).toLowerCase() === lower
-      );
-      return matchedKey ? selectedItem[matchedKey] : undefined;
-    },
-    rowMatchesSingleFieldValue(row, value) {
-      return this.getSingleFieldValue(row) === value;
-    },
-    isSingleFieldSelectionMode() {
-      return (
-        this.source?.dataSelectionOptions === "single-field" ||
-        (this.source?.dataSelectionOptions == null && !!this.source?.singleField)
+    onRadioChange(selectedItem, pageRelativeIndex) {
+      // b-table cell slot `index` is page-relative; convert once here.
+      this.componentOutput(
+        buildRadioSelectionValue(
+          selectedItem,
+          pageRelativeIndex,
+          this.currentPage,
+          this.perPage,
+          this.source,
+          this.fields
+        )
       );
     },
     onMultipleSelectionChange(selIndex) {
@@ -839,27 +779,12 @@ export default {
       const singleField = this.source?.singleField;
 
       collectionFieldsColumns.forEach((column) => {
-        const dataObject = column.data || {};
-        const newDataObject = {};
-
-        Object.keys(dataObject).forEach((dataKey) => {
-          const matchingOption = optionsList.find(
-            (option) => option.content === dataKey
-          );
-
-          if (matchingOption) {
-            newDataObject[matchingOption.key] = dataObject[dataKey];
-          }
-        });
-
-        // Keep the configured single-field under its original collection field name
-        // so radio selection can read it even if the column was remapped or hidden.
-        if (singleField && Object.hasOwn(dataObject, singleField)) {
-          newDataObject[singleField] = dataObject[singleField];
-        }
-
         // eslint-disable-next-line no-param-reassign
-        column.data = newDataObject;
+        column.data = remapCollectionRowData(
+          column.data,
+          optionsList,
+          singleField
+        );
       });
 
       this.setCollectionIntoList(collectionFieldsColumns);
@@ -933,50 +858,15 @@ export default {
     // Restore selectedRow after collection data (re)loads or when value prop changes.
     // Mirrors reapplyCollectionSelections for the single-record (radio) case.
     restoreRadioSelection(rows) {
-      if (this.value == null || this.value === "" || !Array.isArray(rows) || rows.length === 0) {
-        return;
+      const match = findRadioSelectionMatch(
+        this.value,
+        rows,
+        this.source,
+        this.fields
+      );
+      if (match) {
+        this.selectedRow = match;
       }
-
-      if (this.isSingleFieldSelectionMode() && this.source?.singleField) {
-        const match = rows.find((row) =>
-          this.rowMatchesSingleFieldValue(row, this.value)
-        );
-        this.applyRestoredRadioSelection(match);
-        return;
-      }
-
-      if (typeof this.value === "object" && !Array.isArray(this.value)) {
-        this.applyRestoredRadioSelection(this.findSingleRecordRadioMatch(rows));
-      }
-    },
-    applyRestoredRadioSelection(match) {
-      if (!match) {
-        return;
-      }
-      this.restoringSelection = true;
-      this.selectedRow = match;
-      this.$nextTick(() => {
-        this.restoringSelection = false;
-      });
-    },
-    findSingleRecordRadioMatch(rows) {
-      // Prefer matching by row content so selection survives collection refreshes
-      // even when selectedRowIndex is missing or rows were reordered.
-      const valueKey = this.getCollectionRowKey(this.value);
-      if (valueKey) {
-        const byContent = rows.find(
-          (row) => this.getCollectionRowKey(row) === valueKey
-        );
-        if (byContent) {
-          return byContent;
-        }
-      }
-
-      const idx = this.value.selectedRowIndex;
-      if (idx != null && idx >= 0 && idx < rows.length) {
-        return rows[idx];
-      }
-      return null;
     },
     shouldPersistCollectionSelection() {
       const pmql = this.getCollectionPmql();
@@ -988,24 +878,7 @@ export default {
       );
     },
     getCollectionRowKey(item) {
-      if (!item || typeof item !== "object") {
-        return null;
-      }
-
-      const entries = Object.entries(item).filter(
-        ([key]) => key !== "selectedRowsIndex" && key !== "selectedRowIndex"
-      );
-
-      if (entries.length === 0) {
-        return null;
-      }
-
-      entries.sort(([keyA], [keyB]) => {
-        if (keyA > keyB) return 1;
-        if (keyA < keyB) return -1;
-        return 0;
-      });
-      return JSON.stringify(entries);
+      return getCollectionRowKey(item);
     },
     updateRowDataNamePrefix() {
       this.setUploadDataNamePrefix(this.currentRowIndex);

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -329,7 +329,8 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' }
+      popoverPosition: { top: '0px', left: '0px' },
+      restoringSelection: false
     };
   },
   computed: {
@@ -472,14 +473,42 @@ export default {
         }
       }
     },
+    // Backup for b-form-radio inside b-table: @change can miss clicks, but v-model still updates.
+    selectedRow(newVal, oldVal) {
+      if (
+        this.restoringSelection ||
+        !newVal ||
+        newVal === oldVal ||
+        this.source?.sourceOptions !== "Collection"
+      ) {
+        return;
+      }
+      if (
+        !["single-field", "single-record"].includes(
+          this.source?.dataSelectionOptions
+        )
+      ) {
+        return;
+      }
+      const pageIndex = Array.isArray(this.tableData?.data)
+        ? this.tableData.data.indexOf(newVal)
+        : -1;
+      if (pageIndex < 0) {
+        return;
+      }
+      this.onRadioChange(newVal, pageIndex);
+    },
     // Watch for changes in validationData to handle any Mustache variable changes
     validationData: {
-      handler(newValue, oldValue) {
-        if (this.source?.sourceOptions === "Collection" && this.source?.collectionFields?.pmql) {
-          this.onCollectionChange(
-            this.source?.collectionFields?.collectionId,
-            this.source?.collectionFields?.pmql
-          );
+      handler() {
+        if (this.source?.sourceOptions === "Collection") {
+          const pmql = this.getCollectionPmql();
+          if (pmql) {
+            this.onCollectionChange(
+              this.source?.collectionFields?.collectionId,
+              pmql
+            );
+          }
         }
       },
       deep: true,
@@ -500,7 +529,10 @@ export default {
     }
 
     if(this.source?.sourceOptions === "Collection") {
-      this.onCollectionChange(this.source?.collectionFields?.collectionId, this.source?.collectionFields?.pmql);
+      this.onCollectionChange(
+        this.source?.collectionFields?.collectionId,
+        this.getCollectionPmql()
+      );
     }
 
     this.setStyleMode(this.designerMode?.designerOptions);
@@ -576,17 +608,97 @@ export default {
       }
     },
     componentOutput(data) {
-      this.$emit('input',  data);
+      // Avoid emitting undefined, which would leave the bound variable as null
+      // and lose the selection when submitting to the next task.
+      if (typeof data === "undefined") {
+        return;
+      }
+      this.$emit("input", data);
+      // Also write directly to validationData (screen vdata). Submit reads vdata, and
+      // v-model/@input listener order can drop object selections before they sync.
+      this.persistValueToFormData(data);
+    },
+    persistValueToFormData(data) {
+      if (
+        !this.name ||
+        !this.validationData ||
+        typeof this.validationData !== "object"
+      ) {
+        return;
+      }
+      if (String(this.name).includes(".")) {
+        _.set(this.validationData, this.name, data);
+        const rootKey = String(this.name).split(".")[0];
+        this.$set(this.validationData, rootKey, this.validationData[rootKey]);
+        return;
+      }
+      this.$set(this.validationData, this.name, data);
+    },
+    getCollectionPmql() {
+      // PMQL can live on source.pmql and/or source.collectionFields.pmql depending
+      // on how the inspector synced the config; prefer the nested copy when present.
+      const nestedPmql = this.source?.collectionFields?.pmql;
+      if (typeof nestedPmql === "string") {
+        return nestedPmql;
+      }
+      return this.source?.pmql || "";
     },
     onRadioChange(selectedItem, index) {
       const globalIndex = (this.currentPage - 1) * this.perPage + index;
-      if(this.source?.singleField) {
-        let valueOfColumn = selectedItem[this.source.singleField];
-        this.componentOutput(valueOfColumn);
+      // Prefer dataSelectionOptions; fall back to singleField for legacy configs.
+      const isSingleField =
+        this.source?.dataSelectionOptions === "single-field" ||
+        (this.source?.dataSelectionOptions == null && !!this.source?.singleField);
+
+      if (isSingleField && this.source?.singleField) {
+        this.componentOutput(this.getSingleFieldValue(selectedItem));
       } else {
-        selectedItem = { ...selectedItem, selectedRowIndex: globalIndex};
-        this.componentOutput(selectedItem);
+        this.componentOutput({
+          ...selectedItem,
+          selectedRowIndex: globalIndex
+        });
       }
+    },
+    /**
+     * Resolve the configured singleField value from a collection row.
+     * Rows are remapped from collection field names (content) to column keys,
+     * so singleField may not match Object.keys(row) directly.
+     */
+    getSingleFieldValue(selectedItem) {
+      const field = this.source?.singleField;
+      if (!field || !selectedItem || typeof selectedItem !== "object") {
+        return undefined;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(selectedItem, field)) {
+        return selectedItem[field];
+      }
+
+      const optionsList = this.fields?.optionsList || [];
+      const byContent = optionsList.find((opt) => opt.content === field);
+      if (
+        byContent &&
+        Object.prototype.hasOwnProperty.call(selectedItem, byContent.key)
+      ) {
+        return selectedItem[byContent.key];
+      }
+
+      const byKey = optionsList.find((opt) => opt.key === field);
+      if (
+        byKey &&
+        Object.prototype.hasOwnProperty.call(selectedItem, byKey.key)
+      ) {
+        return selectedItem[byKey.key];
+      }
+
+      const lower = String(field).toLowerCase();
+      const matchedKey = Object.keys(selectedItem).find(
+        (key) => String(key).toLowerCase() === lower
+      );
+      return matchedKey ? selectedItem[matchedKey] : undefined;
+    },
+    rowMatchesSingleFieldValue(row, value) {
+      return this.getSingleFieldValue(row) === value;
     },
     onMultipleSelectionChange(selIndex) {
       this.collectionData.forEach((item, index) => {
@@ -725,30 +837,39 @@ export default {
         .catch(() => {
           this.collectionData = [];
         });
-
-      this.$emit("change", this.field);
     },
-    changeCollectionColumns(collectionFieldsColumns,columnsSelected) {
+    changeCollectionColumns(collectionFieldsColumns, columnsSelected) {
+      const optionsList = columnsSelected?.optionsList || [];
+      const singleField = this.source?.singleField;
 
-      const optionsList = columnsSelected.optionsList;
+      collectionFieldsColumns.forEach((column) => {
+        const dataObject = column.data || {};
+        const newDataObject = {};
 
-      collectionFieldsColumns.forEach(column => {
-        let dataObject = column.data;
-        let newDataObject = {};
-
-        Object.keys(dataObject).forEach(dataKey => {
-          const matchingOption = optionsList.find(option => option.content === dataKey);
+        Object.keys(dataObject).forEach((dataKey) => {
+          const matchingOption = optionsList.find(
+            (option) => option.content === dataKey
+          );
 
           if (matchingOption) {
             newDataObject[matchingOption.key] = dataObject[dataKey];
           }
         });
 
+        // Keep the configured single-field under its original collection field name
+        // so radio selection can read it even if the column was remapped or hidden.
+        if (
+          singleField &&
+          Object.prototype.hasOwnProperty.call(dataObject, singleField)
+        ) {
+          newDataObject[singleField] = dataObject[singleField];
+        }
+
+        // eslint-disable-next-line no-param-reassign
         column.data = newDataObject;
       });
 
-       this.setCollectionIntoList(collectionFieldsColumns);
-
+      this.setCollectionIntoList(collectionFieldsColumns);
     },
     setCollectionIntoList(arrayCollection) {
       const result = [];
@@ -819,26 +940,56 @@ export default {
     // Restore selectedRow after collection data (re)loads or when value prop changes.
     // Mirrors reapplyCollectionSelections for the single-record (radio) case.
     restoreRadioSelection(rows) {
-      if (!this.value || !Array.isArray(rows) || rows.length === 0) {
+      if (this.value == null || this.value === "" || !Array.isArray(rows) || rows.length === 0) {
         return;
       }
 
-      if (this.source?.singleField) {
+      const isSingleField =
+        this.source?.dataSelectionOptions === "single-field" ||
+        (this.source?.dataSelectionOptions == null && !!this.source?.singleField);
+
+      if (isSingleField && this.source?.singleField) {
         // singleField mode emits a scalar; find the row whose field matches
-        const match = rows.find(row => row[this.source.singleField] === this.value);
+        const match = rows.find((row) =>
+          this.rowMatchesSingleFieldValue(row, this.value)
+        );
         if (match) {
+          this.restoringSelection = true;
           this.selectedRow = match;
+          this.$nextTick(() => {
+            this.restoringSelection = false;
+          });
         }
-      } else if (typeof this.value === "object" && !Array.isArray(this.value)) {
-        // Regular single-record mode emits { ...item, selectedRowIndex: N }
-        const idx = this.value.selectedRowIndex;
-        if (idx != null && idx >= 0 && idx < rows.length) {
-          this.selectedRow = rows[idx];
+        return;
+      }
+
+      if (typeof this.value === "object" && !Array.isArray(this.value)) {
+        // Prefer matching by row content so selection survives collection refreshes
+        // even when selectedRowIndex is missing or rows were reordered.
+        const valueKey = this.getCollectionRowKey(this.value);
+        let match = null;
+        if (valueKey) {
+          match = rows.find(
+            (row) => this.getCollectionRowKey(row) === valueKey
+          );
+        }
+        if (!match) {
+          const idx = this.value.selectedRowIndex;
+          if (idx != null && idx >= 0 && idx < rows.length) {
+            match = rows[idx];
+          }
+        }
+        if (match) {
+          this.restoringSelection = true;
+          this.selectedRow = match;
+          this.$nextTick(() => {
+            this.restoringSelection = false;
+          });
         }
       }
     },
     shouldPersistCollectionSelection() {
-      const pmql = this.source?.collectionFields?.pmql;
+      const pmql = this.getCollectionPmql();
       return (
         this.source?.sourceOptions === "Collection" &&
         this.source?.dataSelectionOptions === "multiple-records" &&
@@ -852,7 +1003,7 @@ export default {
       }
 
       const entries = Object.entries(item).filter(
-        ([key]) => key !== "selectedRowsIndex"
+        ([key]) => key !== "selectedRowsIndex" && key !== "selectedRowIndex"
       );
 
       if (entries.length === 0) {

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -220,17 +220,11 @@ export default {
         value = null;
       } else if (component === "FormLoop") {
         value = this.emptyLoopValue(config);
-      } else if (component === "FormRecordList") {
-        const selectionMode = config?.source?.dataSelectionOptions;
-        const isCollectionSelection =
-          config?.source?.sourceOptions === "Collection" &&
-          selectionMode &&
-          selectionMode !== "no-selection";
-        // Collection radio/checkbox modes store a selection (object/scalar/array of
-        // selected rows), not the full list. Start with null until the user selects.
-        // Variable-mode record lists store rows as an array.
-        value = isCollectionSelection ? null : [];
       }
+      // FormRecordList keeps the default `null` empty state (Variable and Collection).
+      // Do not initialize Variable mode as []: historical screens/tests/processes treat
+      // an untouched record list as null. Collection radio/checkbox selection also
+      // relies on null until the user selects a row.
       return value;
     },
     emptyLoopValue(config) {

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -251,13 +251,14 @@ export default {
       }
       this.setValueDebounced(variable, value, this.vdata);
     },
-    updateScreenDataNow(safeDotName, variable, setWasFilled = true, eventValue) {
+    updateScreenDataNow(safeDotName, variable, setWasFilled = true, eventValue = undefined) {
       if (setWasFilled) {
         this[`${safeDotName}_was_filled__`] = true;
       }
       // Prefer $event from @input so we don't depend on v-model listener order.
       // Without this, updateScreenDataNow can run before v-model assigns and write
       // the previous value (e.g. []/null) back into vdata, wiping the selection.
+      // Use arguments.length so explicit falsy values (0, '', false, null) are kept.
       const hasEventValue = arguments.length >= 4;
       const value = hasEventValue ? eventValue : this[safeDotName];
       if (hasEventValue) {

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -220,6 +220,16 @@ export default {
         value = null;
       } else if (component === "FormLoop") {
         value = this.emptyLoopValue(config);
+      } else if (component === "FormRecordList") {
+        const selectionMode = config?.source?.dataSelectionOptions;
+        const isCollectionSelection =
+          config?.source?.sourceOptions === "Collection" &&
+          selectionMode &&
+          selectionMode !== "no-selection";
+        // Collection radio/checkbox modes store a selection (object/scalar/array of
+        // selected rows), not the full list. Start with null until the user selects.
+        // Variable-mode record lists store rows as an array.
+        value = isCollectionSelection ? null : [];
       }
       return value;
     },
@@ -234,16 +244,32 @@ export default {
       }
       return loopVariable;
     },
-    updateScreenData(safeDotName, variable) {
+    updateScreenData(safeDotName, variable, eventValue) {
       this[`${safeDotName}_was_filled__`] = true;
       this.blockUpdate(safeDotName, 210);
-      this.setValueDebounced(variable, this[safeDotName], this.vdata);
+      // Prefer $event from @input so we don't depend on v-model listener order.
+      // Without this, updateScreenData can run before v-model assigns and write
+      // the previous value (e.g. []/null) back into vdata, wiping the selection.
+      const hasEventValue = arguments.length >= 3;
+      const value = hasEventValue ? eventValue : this[safeDotName];
+      if (hasEventValue) {
+        this[safeDotName] = eventValue;
+      }
+      this.setValueDebounced(variable, value, this.vdata);
     },
-    updateScreenDataNow(safeDotName, variable, setWasFilled = true) {
+    updateScreenDataNow(safeDotName, variable, setWasFilled = true, eventValue) {
       if (setWasFilled) {
         this[`${safeDotName}_was_filled__`] = true;
       }
-      this.setValue(variable, this[safeDotName], this.vdata);
+      // Prefer $event from @input so we don't depend on v-model listener order.
+      // Without this, updateScreenDataNow can run before v-model assigns and write
+      // the previous value (e.g. []/null) back into vdata, wiping the selection.
+      const hasEventValue = arguments.length >= 4;
+      const value = hasEventValue ? eventValue : this[safeDotName];
+      if (hasEventValue) {
+        this[safeDotName] = eventValue;
+      }
+      this.setValue(variable, value, this.vdata);
       this.unblockUpdate(safeDotName);
     },
     blockUpdate(safeDotName, time) {

--- a/src/mixins/extensions/DataManager.js
+++ b/src/mixins/extensions/DataManager.js
@@ -8,12 +8,15 @@ export default {
         const { component } = v.element;
         const dataFormat = v.config.dataFormat || null;
         const safeDotName = this.safeDotName(v.name);
+        // Use nullish coalescing so valid falsy values (0, '', [], false) are preserved.
+        // The previous `||` chain treated those as missing and fell back to initialValue
+        // (e.g. FormRecordList collection radio/single-field selections became null).
         this.addData(
           screen,
           safeDotName,
           `
-            this.getValue(${JSON.stringify(v.name)}, this.vdata) || 
-            this.getValue(${JSON.stringify(v.name)}, data) || 
+            this.getValue(${JSON.stringify(v.name)}, this.vdata) ??
+            this.getValue(${JSON.stringify(v.name)}, data) ??
             this.initialValue(
               '${component}',
               '${dataFormat}',

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -50,21 +50,24 @@ export default {
           // `person.content` when `person`=null
           const safeDotName = this.safeDotName(element.config.name);
           properties["v-model"] = safeDotName;
-          // Debounce input from FormTextArea and FormInput
+          // Debounce input from FormTextArea and FormInput.
+          // Pass $event on @input so vdata is updated with the emitted value even
+          // if this handler runs before the v-model assignment (listener order race).
+          // Keep @change without $event: change payloads are not always the field value.
           if (
             componentName === "FormTextArea" ||
             componentName === "FormInput"
           ) {
             properties[
               "@input"
-            ] = `updateScreenData('${safeDotName}', '${element.config.name}')`;
+            ] = `updateScreenData('${safeDotName}', '${element.config.name}', $event)`;
             properties[
               "@change"
             ] = `updateScreenDataNow('${safeDotName}', '${element.config.name}')`;
           } else {
             properties[
               "@input"
-            ] = `updateScreenDataNow('${safeDotName}', '${element.config.name}')`;
+            ] = `updateScreenDataNow('${safeDotName}', '${element.config.name}', true, $event)`;
             properties[
               "@change"
             ] = `updateScreenDataNow('${safeDotName}', '${element.config.name}')`;

--- a/tests/unit/FormRecordListCollectionSelection.spec.js
+++ b/tests/unit/FormRecordListCollectionSelection.spec.js
@@ -1,86 +1,16 @@
 /**
- * Lightweight tests for collection radio selection helpers.
- * Avoids mounting the full FormRecordList (heavy deps) by exercising the
- * same selection/restore logic via a minimal stand-in.
+ * Unit tests for FormRecordList collection radio selection helpers.
+ * Imports the same production module used by form-record-list.vue so drift
+ * between component behavior and tests is not possible.
  */
 
-function getCollectionRowKey(item) {
-  if (!item || typeof item !== "object") {
-    return null;
-  }
-
-  const entries = Object.entries(item).filter(
-    ([key]) => key !== "selectedRowsIndex" && key !== "selectedRowIndex"
-  );
-
-  if (entries.length === 0) {
-    return null;
-  }
-
-  entries.sort(([keyA], [keyB]) => {
-    if (keyA > keyB) return 1;
-    if (keyA < keyB) return -1;
-    return 0;
-  });
-  return JSON.stringify(entries);
-}
-
-function restoreRadioSelection(ctx, rows) {
-  if (ctx.value == null || ctx.value === "" || !Array.isArray(rows) || rows.length === 0) {
-    return;
-  }
-
-  const isSingleField =
-    ctx.source?.dataSelectionOptions === "single-field" ||
-    (ctx.source?.dataSelectionOptions == null && !!ctx.source?.singleField);
-
-  if (isSingleField && ctx.source?.singleField) {
-    const match = rows.find(
-      (row) => row[ctx.source.singleField] === ctx.value
-    );
-    if (match) {
-      ctx.selectedRow = match;
-    }
-    return;
-  }
-
-  if (typeof ctx.value === "object" && !Array.isArray(ctx.value)) {
-    const valueKey = getCollectionRowKey(ctx.value);
-    let match = null;
-    if (valueKey) {
-      match = rows.find((row) => getCollectionRowKey(row) === valueKey);
-    }
-    if (!match) {
-      const idx = ctx.value.selectedRowIndex;
-      if (idx != null && idx >= 0 && idx < rows.length) {
-        match = rows[idx];
-      }
-    }
-    if (match) {
-      ctx.selectedRow = match;
-    }
-  }
-}
-
-function onRadioChange(ctx, selectedItem, index) {
-  const globalIndex = (ctx.currentPage - 1) * ctx.perPage + index;
-  const isSingleField =
-    ctx.source?.dataSelectionOptions === "single-field" ||
-    (ctx.source?.dataSelectionOptions == null && !!ctx.source?.singleField);
-
-  if (isSingleField && ctx.source?.singleField) {
-    const valueOfColumn = selectedItem[ctx.source.singleField];
-    if (typeof valueOfColumn === "undefined") {
-      return undefined;
-    }
-    return valueOfColumn;
-  }
-
-  return {
-    ...selectedItem,
-    selectedRowIndex: globalIndex
-  };
-}
+import {
+  buildRadioSelectionValue,
+  findRadioSelectionMatch,
+  getSingleFieldValue,
+  remapCollectionRowData,
+  toGlobalRowIndex
+} from "../../src/components/renderer/form-record-list-selection";
 
 const collectionRows = [
   { name: "Alice", code: "A1" },
@@ -90,119 +20,109 @@ const collectionRows = [
 
 describe("FormRecordList collection radio selection", () => {
   it("emits the selected record for single-record mode", () => {
-    const ctx = {
-      currentPage: 1,
-      perPage: 5,
-      source: { dataSelectionOptions: "single-record", singleField: null }
-    };
+    const value = buildRadioSelectionValue(
+      collectionRows[1],
+      1,
+      1,
+      5,
+      { dataSelectionOptions: "single-record", singleField: null },
+      null
+    );
 
-    expect(onRadioChange(ctx, collectionRows[1], 1)).toEqual({
+    expect(value).toEqual({
       name: "Bob",
       code: "B2",
       selectedRowIndex: 1
     });
   });
 
-  it("emits falsy single-field values like 0", () => {
-    const ctx = {
-      currentPage: 1,
-      perPage: 5,
-      source: { dataSelectionOptions: "single-field", singleField: "code" },
-      fields: { optionsList: [{ content: "code", key: "code" }] }
-    };
+  it("uses page-relative index from @change without double-offset on page 2+", () => {
+    // b-table cell index on page 2 with perPage 5 is 0 for global row 5.
+    // Passing a global index (5) into the same formula would wrongly yield 10.
+    expect(toGlobalRowIndex(0, 2, 5)).toBe(5);
+    expect(toGlobalRowIndex(5, 2, 5)).toBe(10);
 
-    expect(onRadioChange(ctx, collectionRows[2], 2)).toBe(0);
+    const value = buildRadioSelectionValue(
+      { name: "Row6", code: "R6" },
+      0,
+      2,
+      5,
+      { dataSelectionOptions: "single-record" },
+      null
+    );
+
+    expect(value.selectedRowIndex).toBe(5);
+  });
+
+  it("emits falsy single-field values like 0", () => {
+    const value = buildRadioSelectionValue(
+      collectionRows[2],
+      2,
+      1,
+      5,
+      { dataSelectionOptions: "single-field", singleField: "code" },
+      { optionsList: [{ content: "code", key: "code" }] }
+    );
+
+    expect(value).toBe(0);
   });
 
   it("resolves single-field when row keys were remapped from content to key", () => {
-    const getSingleFieldValue = (source, fields, selectedItem) => {
-      const field = source?.singleField;
-      if (!field || !selectedItem) return undefined;
-      if (Object.prototype.hasOwnProperty.call(selectedItem, field)) {
-        return selectedItem[field];
-      }
-      const optionsList = fields?.optionsList || [];
-      const byContent = optionsList.find((opt) => opt.content === field);
-      if (
-        byContent &&
-        Object.prototype.hasOwnProperty.call(selectedItem, byContent.key)
-      ) {
-        return selectedItem[byContent.key];
-      }
-      return undefined;
-    };
-
     const remappedRow = { col_name: "Bob", col_code: "B2" };
     const value = getSingleFieldValue(
+      remappedRow,
       { singleField: "name" },
       {
         optionsList: [
           { content: "name", key: "col_name" },
           { content: "code", key: "col_code" }
         ]
-      },
-      remappedRow
+      }
     );
 
     expect(value).toBe("Bob");
   });
 
   it("preserves original singleField key when columns are remapped", () => {
-    const changeCollectionColumns = (rows, optionsList, singleField) => {
-      return rows.map((column) => {
-        const dataObject = column.data || {};
-        const newDataObject = {};
-        Object.keys(dataObject).forEach((dataKey) => {
-          const matchingOption = optionsList.find(
-            (option) => option.content === dataKey
-          );
-          if (matchingOption) {
-            newDataObject[matchingOption.key] = dataObject[dataKey];
-          }
-        });
-        if (
-          singleField &&
-          Object.prototype.hasOwnProperty.call(dataObject, singleField)
-        ) {
-          newDataObject[singleField] = dataObject[singleField];
-        }
-        return { ...column, data: newDataObject };
-      });
-    };
-
-    const result = changeCollectionColumns(
-      [{ data: { name: "Alice", code: "A1", secret: "x" } }],
+    const result = remapCollectionRowData(
+      { name: "Alice", code: "A1", secret: "x" },
       [{ content: "name", key: "col_name" }],
       "code"
     );
 
-    expect(result[0].data).toEqual({
+    expect(result).toEqual({
       col_name: "Alice",
       code: "A1"
     });
   });
 
-  it("does not emit when single-field key is missing", () => {
-    const ctx = {
-      currentPage: 1,
-      perPage: 5,
-      source: { dataSelectionOptions: "single-field", singleField: "missing" }
-    };
+  it("does not emit a usable value when single-field key is missing", () => {
+    const value = buildRadioSelectionValue(
+      collectionRows[0],
+      0,
+      1,
+      5,
+      { dataSelectionOptions: "single-field", singleField: "missing" },
+      null
+    );
 
-    expect(onRadioChange(ctx, collectionRows[0], 0)).toBeUndefined();
+    expect(value).toBeUndefined();
   });
 
   it("uses single-record path when leftover singleField exists", () => {
-    const ctx = {
-      currentPage: 1,
-      perPage: 5,
-      source: {
+    const value = buildRadioSelectionValue(
+      collectionRows[0],
+      0,
+      1,
+      5,
+      {
         dataSelectionOptions: "single-record",
         singleField: "name"
-      }
-    };
+      },
+      null
+    );
 
-    expect(onRadioChange(ctx, collectionRows[0], 0)).toEqual({
+    expect(value).toEqual({
       name: "Alice",
       code: "A1",
       selectedRowIndex: 0
@@ -210,36 +130,36 @@ describe("FormRecordList collection radio selection", () => {
   });
 
   it("restores selection from saved value by content", () => {
-    const ctx = {
-      value: { name: "Bob", code: "B2", selectedRowIndex: 1 },
-      source: { dataSelectionOptions: "single-record" },
-      selectedRow: null
-    };
+    const match = findRadioSelectionMatch(
+      { name: "Bob", code: "B2", selectedRowIndex: 1 },
+      collectionRows,
+      { dataSelectionOptions: "single-record" },
+      null
+    );
 
-    restoreRadioSelection(ctx, collectionRows);
-    expect(ctx.selectedRow).toEqual(collectionRows[1]);
+    expect(match).toEqual(collectionRows[1]);
   });
 
   it("restores selection by content when index is stale", () => {
-    const ctx = {
-      value: { name: "Carol", code: 0, selectedRowIndex: 99 },
-      source: { dataSelectionOptions: "single-record" },
-      selectedRow: null
-    };
+    const match = findRadioSelectionMatch(
+      { name: "Carol", code: 0, selectedRowIndex: 99 },
+      collectionRows,
+      { dataSelectionOptions: "single-record" },
+      null
+    );
 
-    restoreRadioSelection(ctx, collectionRows);
-    expect(ctx.selectedRow).toEqual(collectionRows[2]);
+    expect(match).toEqual(collectionRows[2]);
   });
 
   it("restores single-field selection when value is 0", () => {
-    const ctx = {
-      value: 0,
-      source: { dataSelectionOptions: "single-field", singleField: "code" },
-      selectedRow: null
-    };
+    const match = findRadioSelectionMatch(
+      0,
+      collectionRows,
+      { dataSelectionOptions: "single-field", singleField: "code" },
+      { optionsList: [{ content: "code", key: "code" }] }
+    );
 
-    restoreRadioSelection(ctx, collectionRows);
-    expect(ctx.selectedRow).toEqual(collectionRows[2]);
+    expect(match).toEqual(collectionRows[2]);
   });
 
   it("preserves falsy values with nullish coalescing (DataManager fix)", () => {
@@ -261,10 +181,10 @@ describe("FormRecordList collection radio selection", () => {
       safeDotName,
       variable,
       setWasFilled = true,
+      eventValue = undefined,
       ...rest
     ) => {
-      const hasEventValue = rest.length >= 1;
-      const eventValue = rest[0];
+      const hasEventValue = arguments.length >= 5;
       const value = hasEventValue ? eventValue : ctx[safeDotName];
       if (hasEventValue) {
         ctx[safeDotName] = eventValue;
@@ -278,7 +198,6 @@ describe("FormRecordList collection radio selection", () => {
     };
     const selected = { name: "Bob", code: "B2", selectedRowIndex: 1 };
 
-    // Simulate @input running BEFORE v-model assigns local data.
     updateScreenDataNow(ctx, "record_list_1", "record_list_1", true, selected);
 
     expect(ctx.record_list_1).toEqual(selected);

--- a/tests/unit/FormRecordListCollectionSelection.spec.js
+++ b/tests/unit/FormRecordListCollectionSelection.spec.js
@@ -1,0 +1,299 @@
+/**
+ * Lightweight tests for collection radio selection helpers.
+ * Avoids mounting the full FormRecordList (heavy deps) by exercising the
+ * same selection/restore logic via a minimal stand-in.
+ */
+
+function getCollectionRowKey(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+
+  const entries = Object.entries(item).filter(
+    ([key]) => key !== "selectedRowsIndex" && key !== "selectedRowIndex"
+  );
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  entries.sort(([keyA], [keyB]) => {
+    if (keyA > keyB) return 1;
+    if (keyA < keyB) return -1;
+    return 0;
+  });
+  return JSON.stringify(entries);
+}
+
+function restoreRadioSelection(ctx, rows) {
+  if (ctx.value == null || ctx.value === "" || !Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  const isSingleField =
+    ctx.source?.dataSelectionOptions === "single-field" ||
+    (ctx.source?.dataSelectionOptions == null && !!ctx.source?.singleField);
+
+  if (isSingleField && ctx.source?.singleField) {
+    const match = rows.find(
+      (row) => row[ctx.source.singleField] === ctx.value
+    );
+    if (match) {
+      ctx.selectedRow = match;
+    }
+    return;
+  }
+
+  if (typeof ctx.value === "object" && !Array.isArray(ctx.value)) {
+    const valueKey = getCollectionRowKey(ctx.value);
+    let match = null;
+    if (valueKey) {
+      match = rows.find((row) => getCollectionRowKey(row) === valueKey);
+    }
+    if (!match) {
+      const idx = ctx.value.selectedRowIndex;
+      if (idx != null && idx >= 0 && idx < rows.length) {
+        match = rows[idx];
+      }
+    }
+    if (match) {
+      ctx.selectedRow = match;
+    }
+  }
+}
+
+function onRadioChange(ctx, selectedItem, index) {
+  const globalIndex = (ctx.currentPage - 1) * ctx.perPage + index;
+  const isSingleField =
+    ctx.source?.dataSelectionOptions === "single-field" ||
+    (ctx.source?.dataSelectionOptions == null && !!ctx.source?.singleField);
+
+  if (isSingleField && ctx.source?.singleField) {
+    const valueOfColumn = selectedItem[ctx.source.singleField];
+    if (typeof valueOfColumn === "undefined") {
+      return undefined;
+    }
+    return valueOfColumn;
+  }
+
+  return {
+    ...selectedItem,
+    selectedRowIndex: globalIndex
+  };
+}
+
+const collectionRows = [
+  { name: "Alice", code: "A1" },
+  { name: "Bob", code: "B2" },
+  { name: "Carol", code: 0 }
+];
+
+describe("FormRecordList collection radio selection", () => {
+  it("emits the selected record for single-record mode", () => {
+    const ctx = {
+      currentPage: 1,
+      perPage: 5,
+      source: { dataSelectionOptions: "single-record", singleField: null }
+    };
+
+    expect(onRadioChange(ctx, collectionRows[1], 1)).toEqual({
+      name: "Bob",
+      code: "B2",
+      selectedRowIndex: 1
+    });
+  });
+
+  it("emits falsy single-field values like 0", () => {
+    const ctx = {
+      currentPage: 1,
+      perPage: 5,
+      source: { dataSelectionOptions: "single-field", singleField: "code" },
+      fields: { optionsList: [{ content: "code", key: "code" }] }
+    };
+
+    expect(onRadioChange(ctx, collectionRows[2], 2)).toBe(0);
+  });
+
+  it("resolves single-field when row keys were remapped from content to key", () => {
+    const getSingleFieldValue = (source, fields, selectedItem) => {
+      const field = source?.singleField;
+      if (!field || !selectedItem) return undefined;
+      if (Object.prototype.hasOwnProperty.call(selectedItem, field)) {
+        return selectedItem[field];
+      }
+      const optionsList = fields?.optionsList || [];
+      const byContent = optionsList.find((opt) => opt.content === field);
+      if (
+        byContent &&
+        Object.prototype.hasOwnProperty.call(selectedItem, byContent.key)
+      ) {
+        return selectedItem[byContent.key];
+      }
+      return undefined;
+    };
+
+    const remappedRow = { col_name: "Bob", col_code: "B2" };
+    const value = getSingleFieldValue(
+      { singleField: "name" },
+      {
+        optionsList: [
+          { content: "name", key: "col_name" },
+          { content: "code", key: "col_code" }
+        ]
+      },
+      remappedRow
+    );
+
+    expect(value).toBe("Bob");
+  });
+
+  it("preserves original singleField key when columns are remapped", () => {
+    const changeCollectionColumns = (rows, optionsList, singleField) => {
+      return rows.map((column) => {
+        const dataObject = column.data || {};
+        const newDataObject = {};
+        Object.keys(dataObject).forEach((dataKey) => {
+          const matchingOption = optionsList.find(
+            (option) => option.content === dataKey
+          );
+          if (matchingOption) {
+            newDataObject[matchingOption.key] = dataObject[dataKey];
+          }
+        });
+        if (
+          singleField &&
+          Object.prototype.hasOwnProperty.call(dataObject, singleField)
+        ) {
+          newDataObject[singleField] = dataObject[singleField];
+        }
+        return { ...column, data: newDataObject };
+      });
+    };
+
+    const result = changeCollectionColumns(
+      [{ data: { name: "Alice", code: "A1", secret: "x" } }],
+      [{ content: "name", key: "col_name" }],
+      "code"
+    );
+
+    expect(result[0].data).toEqual({
+      col_name: "Alice",
+      code: "A1"
+    });
+  });
+
+  it("does not emit when single-field key is missing", () => {
+    const ctx = {
+      currentPage: 1,
+      perPage: 5,
+      source: { dataSelectionOptions: "single-field", singleField: "missing" }
+    };
+
+    expect(onRadioChange(ctx, collectionRows[0], 0)).toBeUndefined();
+  });
+
+  it("uses single-record path when leftover singleField exists", () => {
+    const ctx = {
+      currentPage: 1,
+      perPage: 5,
+      source: {
+        dataSelectionOptions: "single-record",
+        singleField: "name"
+      }
+    };
+
+    expect(onRadioChange(ctx, collectionRows[0], 0)).toEqual({
+      name: "Alice",
+      code: "A1",
+      selectedRowIndex: 0
+    });
+  });
+
+  it("restores selection from saved value by content", () => {
+    const ctx = {
+      value: { name: "Bob", code: "B2", selectedRowIndex: 1 },
+      source: { dataSelectionOptions: "single-record" },
+      selectedRow: null
+    };
+
+    restoreRadioSelection(ctx, collectionRows);
+    expect(ctx.selectedRow).toEqual(collectionRows[1]);
+  });
+
+  it("restores selection by content when index is stale", () => {
+    const ctx = {
+      value: { name: "Carol", code: 0, selectedRowIndex: 99 },
+      source: { dataSelectionOptions: "single-record" },
+      selectedRow: null
+    };
+
+    restoreRadioSelection(ctx, collectionRows);
+    expect(ctx.selectedRow).toEqual(collectionRows[2]);
+  });
+
+  it("restores single-field selection when value is 0", () => {
+    const ctx = {
+      value: 0,
+      source: { dataSelectionOptions: "single-field", singleField: "code" },
+      selectedRow: null
+    };
+
+    restoreRadioSelection(ctx, collectionRows);
+    expect(ctx.selectedRow).toEqual(collectionRows[2]);
+  });
+
+  it("preserves falsy values with nullish coalescing (DataManager fix)", () => {
+    const resolve = (existing, fallback, initial) =>
+      existing ?? fallback ?? initial;
+
+    expect(resolve(0, undefined, null)).toBe(0);
+    expect(resolve("", undefined, null)).toBe("");
+    expect(resolve([], undefined, null)).toEqual([]);
+    expect(resolve({ name: "Bob" }, undefined, [])).toEqual({ name: "Bob" });
+    expect(resolve(null, undefined, [])).toEqual([]);
+    expect(resolve(undefined, undefined, [])).toEqual([]);
+  });
+
+  it("updateScreenDataNow prefers $event over stale local value (v-model race)", () => {
+    // Mirrors ScreenBase.updateScreenDataNow when @input passes $event.
+    const updateScreenDataNow = (
+      ctx,
+      safeDotName,
+      variable,
+      setWasFilled = true,
+      ...rest
+    ) => {
+      const hasEventValue = rest.length >= 1;
+      const eventValue = rest[0];
+      const value = hasEventValue ? eventValue : ctx[safeDotName];
+      if (hasEventValue) {
+        ctx[safeDotName] = eventValue;
+      }
+      ctx.vdata[variable] = value;
+    };
+
+    const ctx = {
+      record_list_1: [],
+      vdata: { record_list_1: [] }
+    };
+    const selected = { name: "Bob", code: "B2", selectedRowIndex: 1 };
+
+    // Simulate @input running BEFORE v-model assigns local data.
+    updateScreenDataNow(ctx, "record_list_1", "record_list_1", true, selected);
+
+    expect(ctx.record_list_1).toEqual(selected);
+    expect(ctx.vdata.record_list_1).toEqual(selected);
+  });
+
+  it("persistValueToFormData writes selection into validationData/vdata", () => {
+    const validationData = { record_list_1: null };
+    const persistValueToFormData = (name, data) => {
+      validationData[name] = data;
+    };
+    const selected = { name: "Alice", code: "A1", selectedRowIndex: 0 };
+
+    persistValueToFormData("record_list_1", selected);
+
+    expect(validationData.record_list_1).toEqual(selected);
+  });
+});


### PR DESCRIPTION
## Solution
- When a record is selected from the Record List, the value persists when moving to the next task.

## How to Test
1. Create/import process attachaed in ticket
2. Create a simple screen
3. Add record list and add a collection to the configuration
4. Create a case, select an option in the record list, complete task 1

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-27264

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy