### PR TITLE
[WIP] Isolate FormRecordList modal validations

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -236,6 +236,15 @@ class PageNavigateValidations extends Validations {
 }
 
 /**
+ * No-op validations (e.g. FormRecordList — modal fields validate separately)
+ */
+class NoOpValidations extends Validations {
+  async addValidations() {
+    // intentionally empty
+  }
+}
+
+/**
  * Add validations for a form element
  */
 class FormElementValidations extends Validations {
@@ -400,8 +409,9 @@ function ValidationsFactory(element, options) {
     return new FormLoopValidations(element, options);
   }
   if (element.component === 'FormRecordList') {
-    //not required
-    //return new FormRecordListValidations(element, screen);
+    // Record list modal fields are validated only when submitting the modal,
+    // not as part of the parent screen's validation rules.
+    return new NoOpValidations(element, options);
   }
   if (element.component === 'FormButton' && element.config.event === 'pageNavigate') {
     return new PageNavigateValidations(element, options);

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -182,6 +182,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :isolated="true"
         debug-context="Record List Add"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -198,7 +199,7 @@
       header-close-content="&times;"
       data-cy="modal-edit"
       @ok="edit"
-      @hidden="$refs.addRenderer.hasSubmitted(false)"
+      @hidden="handleHideEditModal"
       @shown="emitShownEvent"
     >
       <vue-form-renderer
@@ -210,6 +211,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :isolated="true"
         debug-context="Record List Edit"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -254,11 +256,13 @@
 
 <script>
 import _ from "lodash";
+import { mapActions } from "vuex";
 import { dateUtils } from "@processmaker/vue-form-elements";
 import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
+import { findRootScreen } from "@/mixins/DataReference";
 
 const jsonOptionsActionsColumn = {
   key: "__actions",
@@ -507,6 +511,7 @@ export default {
     this.$root.$emit("record-list-option", this.source?.sourceOptions);
   },
   methods: {
+    ...mapActions("globalErrorsModule", ["validateNow", "close"]),
     togglePopover(index, event, rowId) {
       this.deleteIndex = _.find(this.tableData.data, { row_id: rowId });
       this.isPopoverVisible = this.isPopoverVisible === index ? null : index;
@@ -991,7 +996,7 @@ export default {
       });
     },
     edit(event) {
-      this.$refs.addRenderer.hasSubmitted(true);
+      this.$refs.editRenderer.hasSubmitted(true);
       if (
         this.$refs.editRenderer.$refs.renderer.$refs.component.$v.vdata.$invalid
       ) {
@@ -1030,7 +1035,25 @@ export default {
     },
     handleHideAddModal() {
       this.addItem = this.initFormValues;
-      this.$refs.addRenderer.hasSubmitted(false);
+      if (this.$refs.addRenderer) {
+        this.$refs.addRenderer.hasSubmitted(false);
+      }
+      this.restoreParentValidationState();
+    },
+    handleHideEditModal() {
+      if (this.$refs.editRenderer) {
+        this.$refs.editRenderer.hasSubmitted(false);
+      }
+      this.restoreParentValidationState();
+    },
+    restoreParentValidationState() {
+      // Clear modal-driven global submit flags and refresh parent validity
+      // so required modal fields (e.g. FormCheckbox) never block parent submit.
+      this.close();
+      const rootScreen = findRootScreen(this);
+      if (rootScreen && typeof rootScreen.loadValidationRules === "function") {
+        this.validateNow(rootScreen);
+      }
     },
     async handleOk(bvModalEvt) {
       this.$refs.addRenderer.hasSubmitted(true);

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -64,7 +64,10 @@ export default {
     "showErrors",
     "testScreenDefinition",
     "deviceScreen",
-    "taskdraft"
+    "taskdraft",
+    // When true, local $v is still used (e.g. record list modals) but data
+    // changes do not update the parent form's global valid/submit state.
+    "isolated"
   ],
   data() {
     return {
@@ -152,6 +155,9 @@ export default {
       deep: true,
       handler() {
         this.$emit("update", this.data);
+        if (this.isolated) {
+          return;
+        }
         const mainScreen = this.getMainScreen();
         if (mainScreen) {
           this.validate(mainScreen);


### PR DESCRIPTION
Prevent record-list modal fields from affecting parent screen validation. Add NoOpValidations and return it for FormRecordList in ValidationsFactory so modal fields are not included in parent validation rules. Add an "isolated" prop to vue-form-renderer to stop modal renderers from propagating validation updates to the parent, and set isolated=true for add/edit renderers in form-record-list.

## Issue & Reproduction Steps

Expected behavior: 

Actual behavior: 

## Solution
-

## How to Test
Test the steps above

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
