### PR TITLE
FOUR-32638: Fix Collection record list fields and values

### DIFF
--- a/src/collectionFieldUtils.js
+++ b/src/collectionFieldUtils.js
@@ -1,0 +1,89 @@
+const COLLECTION_DATA_PREFIX = "data.";
+
+export function normalizeCollectionFieldPath(fieldPath) {
+  if (typeof fieldPath !== "string") {
+    return fieldPath;
+  }
+
+  return fieldPath.startsWith(COLLECTION_DATA_PREFIX)
+    ? fieldPath.slice(COLLECTION_DATA_PREFIX.length)
+    : fieldPath;
+}
+
+export function getCollectionFieldOptions(collection = {}) {
+  const options = [];
+  const values = new Set();
+
+  const addOption = ({ text, value }) => {
+    const normalizedValue = normalizeCollectionFieldPath(value);
+
+    if (!normalizedValue || values.has(normalizedValue)) {
+      return;
+    }
+
+    values.add(normalizedValue);
+    options.push({
+      text: text || normalizedValue,
+      value: normalizedValue
+    });
+  };
+
+  if (Array.isArray(collection?.fields) && collection.fields.length > 0) {
+    collection.fields.forEach((field) => {
+      if (!field) {
+        return;
+      }
+
+      addOption({
+        text: field.text || field.value,
+        value: field.value
+      });
+    });
+  } else {
+    const [firstRecord] = collection?.dataRecordList || [];
+
+    if (firstRecord?.data) {
+      Object.keys(firstRecord.data).forEach((field) => {
+        addOption({ text: field, value: field });
+      });
+    }
+  }
+
+  addOption({ text: "id", value: "id" });
+
+  return options;
+}
+
+export function mapCollectionRecordData(data = {}, options = []) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return {};
+  }
+
+  if (!Array.isArray(options) || options.length === 0) {
+    return { ...data };
+  }
+
+  const mappedData = {};
+
+  options.forEach((option) => {
+    if (!option) {
+      return;
+    }
+
+    const targetKey = normalizeCollectionFieldPath(
+      option.key || option.content
+    );
+    const sourceKey = [option.content, option.key]
+      .map(normalizeCollectionFieldPath)
+      .find(
+        (candidate) =>
+          candidate && Object.prototype.hasOwnProperty.call(data, candidate)
+      );
+
+    if (sourceKey && targetKey) {
+      mappedData[targetKey] = data[sourceKey];
+    }
+  });
+
+  return mappedData;
+}

--- a/src/components/inspector/collection-data-source.vue
+++ b/src/components/inspector/collection-data-source.vue
@@ -60,6 +60,7 @@
 <script>
 import { cloneDeep } from "lodash";
 import CollectionRecordsList from "./collection-records-list.vue";
+import { getCollectionFieldOptions } from "../../collectionFieldUtils";
 
 const CONFIG_FIELDS = [
   "collectionFields",
@@ -185,27 +186,7 @@ export default {
       }
     },
     getCollectionColumns(records) {
-      this.singleFieldOptions = [];
-
-      // Prefer the collection schema when CollectionRecordsList has
-      // forwarded it on the v-model payload.
-      if (Array.isArray(records?.fields) && records.fields.length > 0) {
-        records.fields.forEach((field) => {
-          this.singleFieldOptions.push({
-            text: field.text || field.value,
-            value: field.value
-          });
-        });
-        return;
-      }
-
-      // Fallback: get columns from the first record's populated keys.
-      const [firstRecord] = records?.dataRecordList || [];
-      if (firstRecord?.data) {
-        for (const [key] of Object.entries(firstRecord.data)) {
-          this.singleFieldOptions.push({ text: key, value: key });
-        }
-      }
+      this.singleFieldOptions = getCollectionFieldOptions(records);
     }
   }
 };

--- a/src/components/inspector/column-setup.vue
+++ b/src/components/inspector/column-setup.vue
@@ -216,6 +216,7 @@ import draggable from 'vuedraggable';
 import { dataSources, dataSourceValues } from './data-source-types';
 import MonacoEditor from 'vue-monaco';
 import { cloneDeep } from "lodash";
+import { getCollectionFieldOptions } from "../../collectionFieldUtils";
 
 export default {
   components: {
@@ -394,27 +395,10 @@ export default {
       }
     },
     getCollectionColumns(collection) {
-      this.collectionOptions = [{ text: "All columns", value: "all" }];
-
-      // Prefer the collection schema when CollectionRecordsList
-      // has forwarded it on the v-model payload.
-      if (Array.isArray(collection?.fields) && collection.fields.length > 0) {
-        collection.fields.forEach((field) => {
-          this.collectionOptions.push({
-            text: field.text || field.value,
-            value: field.value
-          });
-        });
-        return;
-      }
-
-      // Fallback: get columns from the first record's populated keys.
-      const [firstRecord] = collection?.dataRecordList || [];
-      if (firstRecord?.data) {
-        for (const [key] of Object.entries(firstRecord.data)) {
-          this.collectionOptions.push({ text: key, value: key });
-        }
-      }
+      this.collectionOptions = [
+        { text: "All columns", value: "all" },
+        ...getCollectionFieldOptions(collection)
+      ];
     },
     initData() {
       this.dataSource = this.options.dataSource;

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -585,7 +585,10 @@ export default {
     onRadioChange(selectedItem, index) {
       const globalIndex = (this.currentPage - 1) * this.perPage + index;
       if(this.source?.singleField) {
-        let valueOfColumn = selectedItem[this.source.singleField];
+        const singleField = normalizeCollectionFieldPath(
+          this.source.singleField
+        );
+        const valueOfColumn = selectedItem[singleField];
         this.componentOutput(valueOfColumn);
       } else {
         selectedItem = { ...selectedItem, selectedRowIndex: globalIndex};
@@ -816,7 +819,10 @@ export default {
 
       if (this.source?.singleField) {
         // singleField mode emits a scalar; find the row whose field matches
-        const match = rows.find(row => row[this.source.singleField] === this.value);
+        const singleField = normalizeCollectionFieldPath(
+          this.source.singleField
+        );
+        const match = rows.find(row => row[singleField] === this.value);
         if (match) {
           this.selectedRow = match;
         }

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -259,6 +259,10 @@ import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
+import {
+  mapCollectionRecordData,
+  normalizeCollectionFieldPath
+} from "../../collectionFieldUtils";
 
 const jsonOptionsActionsColumn = {
   key: "__actions",
@@ -728,27 +732,14 @@ export default {
 
       this.$emit("change", this.field);
     },
-    changeCollectionColumns(collectionFieldsColumns,columnsSelected) {
-
+    changeCollectionColumns(collectionFieldsColumns, columnsSelected) {
       const optionsList = columnsSelected.optionsList;
+      const mappedColumns = collectionFieldsColumns.map((column) => ({
+        ...column,
+        data: mapCollectionRecordData(column.data, optionsList)
+      }));
 
-      collectionFieldsColumns.forEach(column => {
-        let dataObject = column.data;
-        let newDataObject = {};
-
-        Object.keys(dataObject).forEach(dataKey => {
-          const matchingOption = optionsList.find(option => option.content === dataKey);
-
-          if (matchingOption) {
-            newDataObject[matchingOption.key] = dataObject[dataKey];
-          }
-        });
-
-        column.data = newDataObject;
-      });
-
-       this.setCollectionIntoList(collectionFieldsColumns);
-
+      this.setCollectionIntoList(mappedColumns);
     },
     setCollectionIntoList(arrayCollection) {
       const result = [];
@@ -915,17 +906,18 @@ export default {
       const { jsonData, key, value, dataName } = this.fields;
 
       let convertToVuetableFormat = {};
-      if(this.source?.sourceOptions === "Collection") {
-          convertToVuetableFormat = (option) => {
+      if (this.source?.sourceOptions === "Collection") {
+        convertToVuetableFormat = (option) => {
+          const keyValue = normalizeCollectionFieldPath(option[key || "key"]);
           return {
-            key: option[key || "key"],
+            key: keyValue,
             sortable: true,
-            label: option.label || option[key || "key"],
+            label: option.label || keyValue,
             tdClass: "table-column"
           };
         };
       } else {
-          convertToVuetableFormat = (option) => {
+        convertToVuetableFormat = (option) => {
           return {
             key: option[key || "value"],
             sortable: true,

--- a/tests/e2e/specs/CollectionRecordListColumns.spec.js
+++ b/tests/e2e/specs/CollectionRecordListColumns.spec.js
@@ -1,0 +1,182 @@
+const collectionId = 88;
+const fieldNames = [
+  "case_number",
+  "claimant_name",
+  "status",
+  "department",
+  "submitted_at",
+  "assigned_to",
+  "priority",
+  "amount",
+  "currency",
+  "country",
+  "region",
+  "category",
+  "description"
+];
+
+const recordData = {
+  id: 501,
+  ...Object.fromEntries(
+    fieldNames.map((field, index) => [field, `${field}-${index + 1}`])
+  )
+};
+
+function findRecordList(config) {
+  const pending = [...config];
+
+  while (pending.length) {
+    const item = pending.shift();
+
+    if (item?.component === "FormRecordList") {
+      return item;
+    }
+
+    if (Array.isArray(item?.items)) {
+      pending.push(...item.items.flat(Infinity));
+    }
+  }
+
+  return null;
+}
+
+function configureCollectionRecordList() {
+  cy.openAcordeon("collapse-3");
+  cy.openAcordeon("collapse-2");
+  cy.get("[data-cy=controls-FormRecordList]").drag(
+    "[data-cy=screen-drop-zone]",
+    { position: "bottom" }
+  );
+  cy.get("[data-cy=screen-element-container]").click();
+  cy.get("[data-cy=accordion-Configuration]").click();
+  cy.get("[data-cy=inspector-collection-data-source]").select("Collection");
+  cy.get("[data-cy=inspector-collection]").select("Synthetic Claims");
+  cy.wait(["@collectionFields", "@collectionRecords"]);
+}
+
+describe("Collection record list columns", () => {
+  beforeEach(() => {
+    cy.intercept("GET", "/api/1.0/collections*", {
+      data: [
+        {
+          id: collectionId,
+          name: "Synthetic Claims",
+          read_screen_id: null,
+          create_screen_id: null
+        }
+      ]
+    });
+    cy.intercept("GET", `/api/1.0/collections/${collectionId}/columns*`, {
+      data: fieldNames.map((field) => ({
+        label: field,
+        field: `data.${field}`
+      }))
+    }).as("collectionFields");
+    cy.intercept("GET", `/api/1.0/collections/${collectionId}/records*`, {
+      data: [{ id: recordData.id, data: recordData }],
+      meta: { total: 1 }
+    }).as("collectionRecords");
+    cy.visit("/");
+  });
+
+  it("offers schema fields and id, then generates flat All columns", () => {
+    configureCollectionRecordList();
+
+    cy.get('button:contains("Columns")').click();
+    cy.get(".col-2 > .fas").click();
+    cy.get("[data-cy=inspector-collection-columns]")
+      .find('option[value="case_number"]')
+      .should("have.text", "case_number");
+    cy.get("[data-cy=inspector-collection-columns]")
+      .find('option[value="id"]')
+      .should("have.text", "id");
+    cy.get("[data-cy=inspector-collection-columns]")
+      .find('option[value^="data."]')
+      .should("not.exist");
+
+    cy.get("[data-cy=inspector-collection-columns]").select("case_number");
+    cy.get("[data-cy=inspector-collection-columns]")
+      .closest(".card")
+      .find(".card-footer .btn-secondary")
+      .click();
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+
+      expect(recordList.config.fields.optionsList).to.deep.equal([
+        { content: "case_number", key: "case_number", label: "" }
+      ]);
+    });
+
+    cy.get(".col-2 > .fas").click();
+    cy.get("[data-cy=inspector-collection-columns]").select("all");
+    cy.get("[data-cy=inspector-collection-columns]")
+      .closest(".card")
+      .find(".card-footer .btn-secondary")
+      .click();
+
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+      const options = recordList.config.fields.optionsList;
+
+      expect(options).to.have.length(fieldNames.length + 1);
+      expect(options).to.deep.include({
+        content: "case_number",
+        key: "case_number"
+      });
+      expect(options).to.deep.include({ content: "id", key: "id" });
+      options.forEach((option) => {
+        expect(option.content).not.to.match(/^data\./);
+        expect(option.key).not.to.match(/^data\./);
+      });
+    });
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.wait("@collectionRecords");
+    cy.get('[data-cy="table"] thead').should("contain.text", "case_number");
+    cy.get('[data-cy="table"] thead').should("contain.text", "id");
+    cy.get('[data-cy="table"] tbody').should(
+      "contain.text",
+      recordData.case_number
+    );
+    cy.get('[data-cy="table"] tbody').should("contain.text", recordData.id);
+  });
+
+  it("renders legacy data-prefixed column configuration without rewriting it", () => {
+    configureCollectionRecordList();
+
+    const legacyOptions = [
+      { content: "data.case_number", key: "data.case_number" },
+      { content: "data.id", key: "data.id" }
+    ];
+
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+
+      recordList.config.fields.optionsList = legacyOptions;
+      recordList.config.fields.jsonData = JSON.stringify(legacyOptions);
+    });
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.wait("@collectionRecords");
+    cy.get('[data-cy="table"] thead').should("contain.text", "case_number");
+    cy.get('[data-cy="table"] tbody').should(
+      "contain.text",
+      recordData.case_number
+    );
+    cy.get('[data-cy="table"] tbody').should("contain.text", recordData.id);
+
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+
+      expect(recordList.config.fields.optionsList).to.deep.equal(legacyOptions);
+    });
+  });
+});

--- a/tests/e2e/specs/CollectionRecordListColumns.spec.js
+++ b/tests/e2e/specs/CollectionRecordListColumns.spec.js
@@ -21,6 +21,12 @@ const recordData = {
     fieldNames.map((field, index) => [field, `${field}-${index + 1}`])
   )
 };
+const secondRecordData = {
+  id: 502,
+  ...Object.fromEntries(
+    fieldNames.map((field, index) => [field, `${field}-${index + 101}`])
+  )
+};
 
 function findRecordList(config) {
   const pending = [...config];
@@ -73,8 +79,11 @@ describe("Collection record list columns", () => {
       }))
     }).as("collectionFields");
     cy.intercept("GET", `/api/1.0/collections/${collectionId}/records*`, {
-      data: [{ id: recordData.id, data: recordData }],
-      meta: { total: 1 }
+      data: [
+        { id: recordData.id, data: recordData },
+        { id: secondRecordData.id, data: secondRecordData }
+      ],
+      meta: { total: 2 }
     }).as("collectionRecords");
     cy.visit("/");
   });
@@ -177,6 +186,52 @@ describe("Collection record list columns", () => {
       const recordList = findRecordList(builder.config);
 
       expect(recordList.config.fields.optionsList).to.deep.equal(legacyOptions);
+    });
+  });
+
+  it("restores and emits legacy data-prefixed single-field selections", () => {
+    configureCollectionRecordList();
+
+    const legacySingleField = "data.case_number";
+    const legacyOptions = [
+      { content: legacySingleField, key: legacySingleField }
+    ];
+
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+
+      recordList.config.name = "claim_selection";
+      recordList.config.source.dataSelectionOptions = "single-field";
+      recordList.config.source.singleField = legacySingleField;
+      recordList.config.fields.optionsList = legacyOptions;
+      recordList.config.fields.jsonData = JSON.stringify(legacyOptions);
+      root.previewInput = JSON.stringify({
+        claim_selection: recordData.case_number
+      });
+    });
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.wait("@collectionRecords");
+    cy.get('[data-cy="table"] tbody input[type="radio"]')
+      .should("have.length", 2)
+      .eq(0)
+      .should("be.checked");
+
+    cy.get('[data-cy="table"] tbody input[type="radio"]')
+      .eq(1)
+      .check({ force: true });
+
+    cy.get("#screen-builder-container").then((container) => {
+      const [{ __vue__: root }] = container;
+      const { builder } = root.$refs;
+      const recordList = findRecordList(builder.config);
+
+      expect(root.previewData.claim_selection).to.equal(
+        secondRecordData.case_number
+      );
+      expect(recordList.config.source.singleField).to.equal(legacySingleField);
     });
   });
 });

--- a/tests/unit/CollectionFieldUtils.spec.js
+++ b/tests/unit/CollectionFieldUtils.spec.js
@@ -1,0 +1,115 @@
+import {
+  getCollectionFieldOptions,
+  mapCollectionRecordData,
+  normalizeCollectionFieldPath
+} from "../../src/collectionFieldUtils";
+
+describe("collection field utilities", () => {
+  describe("normalizeCollectionFieldPath", () => {
+    it("removes only the leading data prefix", () => {
+      expect(normalizeCollectionFieldPath("data.case_number")).toBe(
+        "case_number"
+      );
+      expect(normalizeCollectionFieldPath("data.data.case_number")).toBe(
+        "data.case_number"
+      );
+      expect(normalizeCollectionFieldPath("metadata.data.case_number")).toBe(
+        "metadata.data.case_number"
+      );
+    });
+
+    it("preserves non-string values", () => {
+      expect(normalizeCollectionFieldPath(null)).toBeNull();
+      expect(normalizeCollectionFieldPath(undefined)).toBeUndefined();
+      expect(normalizeCollectionFieldPath(42)).toBe(42);
+    });
+  });
+
+  describe("getCollectionFieldOptions", () => {
+    it("uses normalized schema fields, removes duplicates, and adds id", () => {
+      const result = getCollectionFieldOptions({
+        fields: [
+          { text: "Case Number", value: "data.case_number" },
+          { text: "Duplicate Case Number", value: "case_number" },
+          { text: "Status", value: "data.status" },
+          null
+        ],
+        dataRecordList: [
+          { data: { populated_record_only: "must not be included" } }
+        ]
+      });
+
+      expect(result).toEqual([
+        { text: "Case Number", value: "case_number" },
+        { text: "Status", value: "status" },
+        { text: "id", value: "id" }
+      ]);
+    });
+
+    it("does not duplicate id when it is present in the schema", () => {
+      expect(
+        getCollectionFieldOptions({
+          fields: [{ text: "Collection Record ID", value: "data.id" }]
+        })
+      ).toEqual([{ text: "Collection Record ID", value: "id" }]);
+    });
+
+    it("falls back to the first record when the schema is unavailable", () => {
+      expect(
+        getCollectionFieldOptions({
+          fields: [],
+          dataRecordList: [
+            { data: { case_number: "C-100", status: "open" } },
+            { data: { second_record_only: "must not be included" } }
+          ]
+        })
+      ).toEqual([
+        { text: "case_number", value: "case_number" },
+        { text: "status", value: "status" },
+        { text: "id", value: "id" }
+      ]);
+    });
+
+    it("offers id for an empty collection", () => {
+      expect(getCollectionFieldOptions()).toEqual([
+        { text: "id", value: "id" }
+      ]);
+    });
+  });
+
+  describe("mapCollectionRecordData", () => {
+    it("maps legacy prefixed options to flat keys without changing the input", () => {
+      const data = { id: 501, case_number: "C-100", status: "open" };
+
+      expect(
+        mapCollectionRecordData(data, [
+          { content: "data.case_number", key: "data.case_number" },
+          { content: "data.id", key: "data.id" }
+        ])
+      ).toEqual({ case_number: "C-100", id: 501 });
+      expect(data).toEqual({ id: 501, case_number: "C-100", status: "open" });
+    });
+
+    it("uses the key as a source fallback and keeps aliases", () => {
+      expect(
+        mapCollectionRecordData({ case_number: "C-100" }, [
+          { key: "data.case_number" }
+        ])
+      ).toEqual({ case_number: "C-100" });
+
+      expect(
+        mapCollectionRecordData({ case_number: "C-100" }, [
+          { content: "data.case_number", key: "claim" }
+        ])
+      ).toEqual({ claim: "C-100" });
+    });
+
+    it("preserves record data while columns are not ready", () => {
+      const data = { id: 501, case_number: "C-100" };
+      const result = mapCollectionRecordData(data, []);
+
+      expect(result).toEqual(data);
+      expect(result).not.toBe(data);
+    });
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps
Collection-backed Record Lists regressed after the Collection schema was introduced as the source for available fields.

To reproduce:

1. Import the Collection and Screen fixtures attached to FOUR-32640, or create a Collection with records and configure a Screen Record List to use it.
2. Open the Record List Columns inspector.
3. Add a column and verify that the Collection record `id` field is missing.
4. Select `All columns` and inspect the generated configuration.
5. Notice that `content` and `key` use the `data.` prefix.
6. Open Preview and notice that the configured headers are displayed but the record values are empty.

The exported fixtures remain attached to Jira and are not included in this repository.

## Solution
- Add a shared Collection field utility that uses the Collection schema as the primary source, removes only the leading `data.` prefix, deduplicates fields, always includes `id`, and falls back to the first record when no schema is available.
- Use the normalized fields in the Record List column and single-field selectors.
- Generate flat `content` and `key` values for individual fields and `All columns`.
- Normalize legacy `data.*` configurations while rendering so existing Screens display their values without rewriting their saved configuration.
- Map Collection records without mutating the API response.
- Add focused unit and Cypress coverage for schema fields, `id`, flat keys, empty Collections, fallback behavior, Preview values, and legacy configurations.

## How to Test
Run:

- `npx jest tests/unit/CollectionFieldUtils.spec.js --runInBand --no-coverage`
- `npm run run-cypress -- --spec tests/e2e/specs/CollectionRecordListColumns.spec.js --browser electron`
- `npm run build`

Manual validation:

1. Configure a Record List with a Collection source.
2. Open the Columns selector and confirm that `id` and the complete Collection schema are available without `data.` prefixes.
3. Select `All columns` and confirm the generated `content` and `key` values are flat.
4. Open Preview and confirm that headers and record values are displayed.
5. Load an existing Screen whose column configuration uses `data.*` and confirm it renders correctly without automatically rewriting the saved configuration.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32638
- https://processmaker.atlassian.net/browse/FOUR-32640
- https://processmaker.atlassian.net/browse/FOUR-30436
- https://processmaker.atlassian.net/browse/FOUR-32599
- https://github.com/ProcessMaker/package-collections/pull/488

ci:deploy
