### PR TITLE
FOUR-32683: Preserve PM Block task context in Web Entry redirects

### DIFF
--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -534,41 +534,46 @@ export default {
       // If the task has not an origin source it should re redirected top the tasks List as default.
       return document.referrer || '/tasks';
     },
-    loadNextAssignedTask(requestId = null) {
+    loadNextAssignedTask(requestId = null, taskId = null) {
       if (!requestId) {
         requestId = this.requestId;
       }
       if (!this.userId) {
-        return;
+        return false;
       }
       const timestamp = !window.Cypress ? `&t=${Date.now()}` : "";
-      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${timestamp}`;
+      const taskIdFilter = taskId ? `&task_id=${encodeURIComponent(taskId)}` : "";
+      const url = `?user_id=${this.userId}&status=ACTIVE&process_request_id=${requestId}&include_sub_tasks=1${taskIdFilter}${timestamp}`;
       return this.$dataProvider
         .getTasks(url).then((response) => {
           this.$emit("load-data-task", response);
-          if (response.data.data.length > 0) {
-            let task = response.data.data[0];
+          const tasks = response.data.data;
+          const task = taskId
+            ? tasks.find(({ id }) => String(id) === String(taskId))
+            : tasks[0];
+          if (task) {
             const requiresWebEntryFallback = this.isWebEntry
               && task.web_entry_available === false;
             if (task.process_request_id !== this.requestId || requiresWebEntryFallback) {
               // Cross-request transitions and non-Web Entry tasks require a hard redirect.
               if (this.redirecting === task.process_request_id) {
-                return;
+                return true;
               }
               this.unsubscribeSocketListeners();
               this.redirecting = task.process_request_id;
               this.$emit('redirect', this.isWebEntry ? task : task.id, true);
-              return;
+              return true;
             } else {
               this.emitIfTaskCompleted(requestId);
             }
             this.taskId = task.id;
             this.nodeId = task.element_id;
             this.loadTask();
-          } else if (this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
+          } else if (!taskId && this.parentRequest && ['COMPLETED', 'CLOSED'].includes(this.task.process_request.status)) {
             this.$emit('completed', this.getAllowedRequestId());
           }
           this.disabled = false;
+          return Boolean(task);
         });
     },
     emitIfTaskCompleted(requestId) {
@@ -643,24 +648,27 @@ export default {
      * @param {Function} apiCall - The API call to be made.
      * @param {number} retries - The number of retry attempts.
      * @param {number} delay - The delay between retries in milliseconds.
+     * @param {Function} shouldRetry - Determines whether a successful response should be retried.
      * @returns {Promise} - The response from the API call.
      */
     // eslint-disable-next-line consistent-return
-    async retryApiCall(apiCall, retries = 3, delay = 1000) {
+    async retryApiCall(apiCall, retries = 3, delay = 1000, shouldRetry = () => false) {
       for (let attempt = 0; attempt < retries; attempt++) {
         try {
           // eslint-disable-next-line no-await-in-loop
           const response = await apiCall();
-          return response;
+          if (!shouldRetry(response) || attempt === retries - 1) {
+            return response;
+          }
         } catch (error) {
           if (attempt === retries - 1) {
             throw error;
           }
-          // eslint-disable-next-line no-await-in-loop
-          await new Promise((resolve) => {
-            setTimeout(resolve, delay);
-          });
         }
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => {
+          setTimeout(resolve, delay);
+        });
       }
     },
     /**
@@ -921,6 +929,31 @@ export default {
       }
     },
 
+    async handleWebEntryTaskRedirect(data, tokenId) {
+      let taskHandled = false;
+      try {
+        taskHandled = await this.retryApiCall(
+          () => this.loadNextAssignedTask(this.requestId, tokenId),
+          3,
+          1000,
+          (handled) => handled !== true
+        );
+      } catch (error) {
+        taskHandled = false;
+      } finally {
+        if (!taskHandled) {
+          this.loadingTask = false;
+          this.disabled = false;
+        }
+      }
+
+      if (!taskHandled) {
+        const fallbackUrl = data?.params?.[0]?.payloadUrl
+          || (tokenId ? `/tasks/${tokenId}/edit` : `/requests/${this.requestId}`);
+        window.location.href = fallbackUrl;
+      }
+    },
+
     /**
      * Handles the 'redirectToTask' event by loading the specified task.
      * Updates the current task ID and reloads the task data.
@@ -952,7 +985,7 @@ export default {
 
           // Web Entry needs the complete task to preserve the target request context.
           if (this.isWebEntry) {
-            await this.loadNextAssignedTask(this.requestId);
+            await this.handleWebEntryTaskRedirect(data, tokenId);
             return;
           }
 

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -561,7 +561,8 @@ export default {
               }
               this.unsubscribeSocketListeners();
               this.redirecting = task.process_request_id;
-              this.$emit('redirect', this.isWebEntry ? task : task.id, true);
+              // Screen Builder uses Vue 2, where emitted events have no runtime emits contract.
+              this.$emit('redirect', this.isWebEntry ? task : task.id, true); // NOSONAR
               return true;
             } else {
               this.emitIfTaskCompleted(requestId);

--- a/src/components/task.vue
+++ b/src/components/task.vue
@@ -548,14 +548,16 @@ export default {
           this.$emit("load-data-task", response);
           if (response.data.data.length > 0) {
             let task = response.data.data[0];
-            if (task.process_request_id !== this.requestId) {
-              // Next task is in a subprocess, do a hard redirect
+            const requiresWebEntryFallback = this.isWebEntry
+              && task.web_entry_available === false;
+            if (task.process_request_id !== this.requestId || requiresWebEntryFallback) {
+              // Cross-request transitions and non-Web Entry tasks require a hard redirect.
               if (this.redirecting === task.process_request_id) {
                 return;
               }
               this.unsubscribeSocketListeners();
               this.redirecting = task.process_request_id;
-              this.$emit('redirect', task.id, true);
+              this.$emit('redirect', this.isWebEntry ? task : task.id, true);
               return;
             } else {
               this.emitIfTaskCompleted(requestId);
@@ -947,6 +949,13 @@ export default {
             window.location.href = await this.getDestinationUrl();
             return;
           }
+
+          // Web Entry needs the complete task to preserve the target request context.
+          if (this.isWebEntry) {
+            await this.loadNextAssignedTask(this.requestId);
+            return;
+          }
+
           this.nodeId = nodeId;
           this.taskId = tokenId;
   

--- a/tests/unit/TaskWebEntryRedirect.spec.js
+++ b/tests/unit/TaskWebEntryRedirect.spec.js
@@ -1,0 +1,171 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const componentPath = path.join(process.cwd(), 'src/components/task.vue');
+const source = fs.readFileSync(componentPath, 'utf8');
+
+function getComponentOptions() {
+  const scriptMatch = source.match(/<script>([\s\S]*?)<\/script>/);
+
+  if (!scriptMatch) {
+    throw new Error('Unable to find task.vue script block');
+  }
+
+  const executableScript = scriptMatch[1]
+    .replace(/^import .*$/gm, '')
+    .replace('export default', 'module.exports =');
+
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    window: {
+      ProcessMaker: {},
+      Cypress: true,
+      location: { href: '' },
+    },
+    VueFormRenderer: {},
+    simpleErrorMessage: {},
+    Promise,
+    setTimeout,
+    clearTimeout,
+    console,
+    _: {
+      get: (target, accessor, defaultValue = null) => {
+        if (!target || !accessor) {
+          return defaultValue;
+        }
+
+        return accessor.split('.').reduce((value, key) => {
+          if (value === undefined || value === null) {
+            return undefined;
+          }
+
+          return value[key];
+        }, target) ?? defaultValue;
+      },
+      merge: (...args) => Object.assign({}, ...args),
+    },
+  };
+
+  vm.runInNewContext(executableScript, sandbox, { filename: componentPath });
+
+  return sandbox.module.exports;
+}
+
+describe('Task Web Entry redirects', () => {
+  const Task = getComponentOptions();
+
+  function nextTaskContext(task, isWebEntry = true) {
+    return {
+      requestId: 10,
+      userId: 7,
+      isWebEntry,
+      redirecting: null,
+      disabled: true,
+      parentRequest: null,
+      task: null,
+      $dataProvider: {
+        getTasks: jest.fn().mockResolvedValue({ data: { data: [task] } }),
+      },
+      $emit: jest.fn(),
+      unsubscribeSocketListeners: jest.fn(),
+      emitIfTaskCompleted: jest.fn(),
+      loadTask: jest.fn(),
+    };
+  }
+
+  test('emits the complete child task for Web Entry redirects', async () => {
+    const task = {
+      id: 44,
+      process_request_id: 11,
+      element_id: 'node_2',
+      web_entry_available: true,
+    };
+    const context = nextTaskContext(task);
+
+    await Task.methods.loadNextAssignedTask.call(context);
+
+    expect(context.$emit).toHaveBeenCalledWith('redirect', task, true);
+    expect(context.unsubscribeSocketListeners).toHaveBeenCalled();
+    expect(context.loadTask).not.toHaveBeenCalled();
+  });
+
+  test('preserves the numeric redirect contract outside Web Entry', async () => {
+    const task = {
+      id: 44,
+      process_request_id: 11,
+      element_id: 'node_2',
+    };
+    const context = nextTaskContext(task, false);
+
+    await Task.methods.loadNextAssignedTask.call(context);
+
+    expect(context.$emit).toHaveBeenCalledWith('redirect', 44, true);
+  });
+
+  test('hard redirects a same-request task that is not Web Entry enabled', async () => {
+    const task = {
+      id: 45,
+      process_request_id: 10,
+      element_id: 'node_3',
+      web_entry_available: false,
+    };
+    const context = nextTaskContext(task);
+
+    await Task.methods.loadNextAssignedTask.call(context);
+
+    expect(context.$emit).toHaveBeenCalledWith('redirect', task, true);
+    expect(context.loadTask).not.toHaveBeenCalled();
+  });
+
+  test('resolves the complete task before handling a Web Entry socket redirect', async () => {
+    const loadNextAssignedTask = jest.fn().mockResolvedValue();
+    const context = {
+      requestId: 10,
+      userId: 7,
+      isWebEntry: true,
+      loadingTask: false,
+      nodeId: 'node_1',
+      taskId: 43,
+      task: {
+        allow_interstitial: true,
+        elementDestination: { type: 'taskSource' },
+      },
+      renderComponent: 'task-screen',
+      loadNextAssignedTask,
+      reload: jest.fn(),
+    };
+
+    await Task.methods.handleRedirectToTask.call(context, {
+      params: [{ tokenId: 44, userId: 7, nodeId: 'node_2' }],
+    });
+
+    expect(loadNextAssignedTask).toHaveBeenCalledWith(10);
+    expect(context.nodeId).toBe('node_1');
+    expect(context.taskId).toBe(43);
+    expect(context.reload).not.toHaveBeenCalled();
+  });
+
+  test('ignores socket redirects intended for another user', async () => {
+    const context = {
+      requestId: 10,
+      userId: 7,
+      isWebEntry: true,
+      loadingTask: false,
+      task: {
+        allow_interstitial: true,
+        elementDestination: { type: null },
+      },
+      loadNextAssignedTask: jest.fn(),
+      reload: jest.fn(),
+    };
+
+    await Task.methods.handleRedirectToTask.call(context, {
+      params: [{ tokenId: 44, userId: 8, nodeId: 'node_2' }],
+    });
+
+    expect(context.loadNextAssignedTask).not.toHaveBeenCalled();
+    expect(context.reload).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/TaskWebEntryRedirect.spec.js
+++ b/tests/unit/TaskWebEntryRedirect.spec.js
@@ -4,6 +4,7 @@ const vm = require('vm');
 
 const componentPath = path.join(process.cwd(), 'src/components/task.vue');
 const source = fs.readFileSync(componentPath, 'utf8');
+let browserWindow;
 
 function getComponentOptions() {
   const scriptMatch = source.match(/<script>([\s\S]*?)<\/script>/);
@@ -49,6 +50,7 @@ function getComponentOptions() {
   };
 
   vm.runInNewContext(executableScript, sandbox, { filename: componentPath });
+  browserWindow = sandbox.window;
 
   return sandbox.module.exports;
 }
@@ -57,6 +59,7 @@ describe('Task Web Entry redirects', () => {
   const Task = getComponentOptions();
 
   function nextTaskContext(task, isWebEntry = true) {
+    const tasks = Array.isArray(task) ? task : [task];
     return {
       requestId: 10,
       userId: 7,
@@ -66,7 +69,7 @@ describe('Task Web Entry redirects', () => {
       parentRequest: null,
       task: null,
       $dataProvider: {
-        getTasks: jest.fn().mockResolvedValue({ data: { data: [task] } }),
+        getTasks: jest.fn().mockResolvedValue({ data: { data: tasks } }),
       },
       $emit: jest.fn(),
       unsubscribeSocketListeners: jest.fn(),
@@ -74,6 +77,10 @@ describe('Task Web Entry redirects', () => {
       loadTask: jest.fn(),
     };
   }
+
+  beforeEach(() => {
+    browserWindow.location.href = '';
+  });
 
   test('emits the complete child task for Web Entry redirects', async () => {
     const task = {
@@ -119,8 +126,62 @@ describe('Task Web Entry redirects', () => {
     expect(context.loadTask).not.toHaveBeenCalled();
   });
 
+  test('selects the task identified by the socket token', async () => {
+    const otherTask = {
+      id: 43,
+      process_request_id: 12,
+      element_id: 'node_other',
+      web_entry_available: true,
+    };
+    const targetTask = {
+      id: 44,
+      process_request_id: 11,
+      element_id: 'node_target',
+      web_entry_available: true,
+    };
+    const context = nextTaskContext([otherTask, targetTask]);
+
+    const handled = await Task.methods.loadNextAssignedTask.call(context, 10, '44');
+
+    expect(handled).toBe(true);
+    expect(context.$dataProvider.getTasks).toHaveBeenCalledWith(
+      expect.stringContaining('&task_id=44')
+    );
+    expect(context.$emit).toHaveBeenCalledWith('redirect', targetTask, true);
+  });
+
+  test('retries successful lookups that do not resolve the target task', async () => {
+    const apiCall = jest.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    const handled = await Task.methods.retryApiCall(
+      apiCall,
+      3,
+      0,
+      (result) => result !== true
+    );
+
+    expect(handled).toBe(true);
+    expect(apiCall).toHaveBeenCalledTimes(3);
+  });
+
+  test('retries rejected target task lookups', async () => {
+    const apiCall = jest.fn()
+      .mockRejectedValueOnce(new Error('Not ready'))
+      .mockRejectedValueOnce(new Error('Not ready'))
+      .mockResolvedValueOnce(true);
+
+    const handled = await Task.methods.retryApiCall(apiCall, 3, 0);
+
+    expect(handled).toBe(true);
+    expect(apiCall).toHaveBeenCalledTimes(3);
+  });
+
   test('resolves the complete task before handling a Web Entry socket redirect', async () => {
-    const loadNextAssignedTask = jest.fn().mockResolvedValue();
+    const loadNextAssignedTask = jest.fn().mockResolvedValue(true);
+    const retryApiCall = jest.fn((apiCall) => apiCall());
     const context = {
       requestId: 10,
       userId: 7,
@@ -134,17 +195,79 @@ describe('Task Web Entry redirects', () => {
       },
       renderComponent: 'task-screen',
       loadNextAssignedTask,
+      retryApiCall,
       reload: jest.fn(),
     };
+    context.handleWebEntryTaskRedirect = Task.methods.handleWebEntryTaskRedirect.bind(context);
 
     await Task.methods.handleRedirectToTask.call(context, {
       params: [{ tokenId: 44, userId: 7, nodeId: 'node_2' }],
     });
 
-    expect(loadNextAssignedTask).toHaveBeenCalledWith(10);
+    expect(loadNextAssignedTask).toHaveBeenCalledWith(10, 44);
+    expect(retryApiCall).toHaveBeenCalled();
     expect(context.nodeId).toBe('node_1');
     expect(context.taskId).toBe(43);
     expect(context.reload).not.toHaveBeenCalled();
+  });
+
+  test('uses the event fallback and clears loading when the target remains unavailable', async () => {
+    const context = {
+      requestId: 10,
+      userId: 7,
+      isWebEntry: true,
+      loadingTask: false,
+      disabled: true,
+      task: {
+        allow_interstitial: true,
+        elementDestination: { type: 'taskSource' },
+      },
+      renderComponent: 'task-screen',
+      loadNextAssignedTask: jest.fn(),
+      retryApiCall: jest.fn().mockResolvedValue(false),
+      reload: jest.fn(),
+    };
+    context.handleWebEntryTaskRedirect = Task.methods.handleWebEntryTaskRedirect.bind(context);
+
+    await Task.methods.handleRedirectToTask.call(context, {
+      params: [{
+        tokenId: 44,
+        userId: 7,
+        nodeId: 'node_2',
+        payloadUrl: '/requests/11',
+      }],
+    });
+
+    expect(browserWindow.location.href).toBe('/requests/11');
+    expect(context.loadingTask).toBe(false);
+    expect(context.disabled).toBe(false);
+  });
+
+  test('falls back to the exact task URL after a lookup error', async () => {
+    const context = {
+      requestId: 10,
+      userId: 7,
+      isWebEntry: true,
+      loadingTask: false,
+      disabled: true,
+      task: {
+        allow_interstitial: true,
+        elementDestination: { type: 'taskSource' },
+      },
+      renderComponent: 'task-screen',
+      loadNextAssignedTask: jest.fn(),
+      retryApiCall: jest.fn().mockRejectedValue(new Error('Network error')),
+      reload: jest.fn(),
+    };
+    context.handleWebEntryTaskRedirect = Task.methods.handleWebEntryTaskRedirect.bind(context);
+
+    await Task.methods.handleRedirectToTask.call(context, {
+      params: [{ tokenId: 44, userId: 7, nodeId: 'node_2' }],
+    });
+
+    expect(browserWindow.location.href).toBe('/tasks/44/edit');
+    expect(context.loadingTask).toBe(false);
+    expect(context.disabled).toBe(false);
   });
 
   test('ignores socket redirects intended for another user', async () => {


### PR DESCRIPTION
## Issue & Reproduction Steps
An authenticated Web Entry that transitions into a PM Block creates the child request and task correctly, but the redirect flow retains the parent request ID while applying the child task node ID. This produces an invalid Web Entry URL, a 404 configuration request, and an interstitial that remains loading indefinitely.

1. Import the `test_pm_block_6789.json` fixture attached to FOUR-32683.
2. Start the parent process through its authenticated Web Entry.
3. Submit the first form and continue until the PM Block creates its child task.
4. Observe that the failing flow combines the parent request ID with the child task node ID.

## Solution
- Resolve the complete next assigned task before processing Web Entry socket redirects.
- Pass the target task ID, element ID, and process request ID through Web Entry hard redirects.
- Preserve the existing numeric task-ID redirect contract outside Web Entry.
- Redirect tasks without Web Entry availability to the standard task form.
- Add focused regression tests for child-request, fallback, websocket, and compatibility paths.

## How to Test
- Run `TaskWebEntryRedirect.spec.js` and `TaskSelfServiceLock.spec.js`.
- Start the attached process through its authenticated Web Entry and submit until it reaches the PM Block.
- Confirm that the child task opens without a stale request ID, 404 response, or infinite interstitial.
- Complete the child task and confirm that the parent request resumes and can finish.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32683
- https://processmaker.atlassian.net/browse/FOUR-29254
- Companion Package Web Entry PR: https://github.com/ProcessMaker/package-webentry/pull/302

ci:deploy
ci:package-webentry:task/FOUR-32683
.