### PR TITLE
FOUR-32670: Preserve Select List state during responsive changes

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -36,9 +36,10 @@ class Validations {
    * Check if element/container is visible.
    */
   isVisible() {
-    const deviceConfig = this.element.config && this.element.config.deviceVisibility
-      ? this.element.config.deviceVisibility
-      : { showForDesktop: true, showForMobile: true };
+    const deviceConfig = this.element.config?.deviceVisibility || {
+      showForDesktop: true,
+      showForMobile: true
+    };
     const visibleInDevice =
       (this.isMobile && deviceConfig.showForMobile) ||
       (!this.isMobile && deviceConfig.showForDesktop);

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -13,6 +13,7 @@ class Validations {
   firstPage = 0;
   data = {};
   insideLoop = false;
+  isMobile = false;
   constructor(element, options) {
     this.element = element;
     Object.assign(this, options);
@@ -35,11 +36,12 @@ class Validations {
    * Check if element/container is visible.
    */
   isVisible() {
-    // Disable validations if field is hidden
+    const deviceConfig = this.element.config && this.element.config.deviceVisibility
+      ? this.element.config.deviceVisibility
+      : { showForDesktop: true, showForMobile: true };
     const visibleInDevice =
-      this.element.visibleInDevice === null || this.element.visibleInDevice === undefined
-        ? true
-        : this.element.visibleInDevice;
+      (this.isMobile && deviceConfig.showForMobile) ||
+      (!this.isMobile && deviceConfig.showForDesktop);
     if (!visibleInDevice) {
       return false;
     }
@@ -62,7 +64,7 @@ class Validations {
 class ArrayOfFieldsValidations extends Validations {
   async addValidations(validations) {
     for (const item of this.element) {
-      await ValidationsFactory(item, { screen: this.screen, data: this.data, parentVisibilityRule: this.parentVisibilityRule, insideLoop: this.insideLoop }).addValidations(validations);
+      await ValidationsFactory(item, { screen: this.screen, data: this.data, parentVisibilityRule: this.parentVisibilityRule, insideLoop: this.insideLoop, isMobile: this.isMobile }).addValidations(validations);
     }
   }
 }
@@ -75,7 +77,7 @@ class ScreenValidations extends Validations {
     // add validations for page 1
     if (this.element.config[this.firstPage]) {
       pagesValidated = [this.firstPage];
-      const screenValidations = ValidationsFactory(this.element.config[this.firstPage].items, { screen: this.element, data: this.data });
+      const screenValidations = ValidationsFactory(this.element.config[this.firstPage].items, { screen: this.element, data: this.data, isMobile: this.isMobile });
       await screenValidations.addValidations(validations);
       pagesValidated = [];
     }
@@ -96,7 +98,7 @@ class FormNestedScreenValidations extends Validations {
       const definition = nestedScreen.config;
       let parentVisibilityRule = this.parentVisibilityRule ? this.parentVisibilityRule : this.element.config.conditionalHide;
       if (definition && definition[0] && definition[0].items) {
-        await ValidationsFactory(definition[0].items, { screen: nestedScreen, data: this.data, parentVisibilityRule }).addValidations(validations);
+        await ValidationsFactory(definition[0].items, { screen: nestedScreen, data: this.data, parentVisibilityRule, isMobile: this.isMobile }).addValidations(validations);
       }
     }
   }
@@ -146,7 +148,7 @@ class FormLoopValidations extends Validations {
     loopField['$each'] = {};
     this.checkForSiblings(validations);
     const firstRow = (get(this.data, this.element.config.name) || [{}])[0];
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, ...firstRow }, parentVisibilityRule: this.element.config.conditionalHide, insideLoop: true }).addValidations(loopField['$each']);
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: {_parent: this.data, ...firstRow }, parentVisibilityRule: this.element.config.conditionalHide, insideLoop: true, isMobile: this.isMobile }).addValidations(loopField['$each']);
   }
   checkForSiblings(validations) {
     const siblings = [];
@@ -207,7 +209,7 @@ class FormMultiColumnValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: this.data, parentVisibilityRule: this.element.config.conditionalHide }).addValidations(validations);
+    await ValidationsFactory(this.element.items, { screen: this.screen, data: this.data, parentVisibilityRule: this.element.config.conditionalHide, isMobile: this.isMobile }).addValidations(validations);
   }
 }
 
@@ -229,7 +231,7 @@ class PageNavigateValidations extends Validations {
     if (pagesValidated.length > 0 && !pagesValidated.includes(screenPageId)) {
       if (this.screen.config[screenNumber] && this.screen.config[screenNumber].items) {
         pagesValidated.push(screenPageId);
-        await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
+        await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data, isMobile: this.isMobile }).addValidations(validations);
       }
     }
   }
@@ -308,7 +310,7 @@ class FormElementValidations extends Validations {
           // Check Device Visibility
           let visibleInDevice = true;
           try {
-            const isMobileScreen = this.$root.$children[0].$refs.renderer.definition.isMobile;
+            const isMobileScreen = this.isMobile;
             visibleInDevice =
               (isMobileScreen && deviceConfig.showForMobile) ||
               (!isMobileScreen && deviceConfig.showForDesktop);
@@ -375,7 +377,7 @@ class FormElementValidations extends Validations {
       };
     }
     if (this.element.items) {
-      ValidationsFactory(this.element.items, { screen: this.screen, data: this.data }).addValidations(validations);
+      ValidationsFactory(this.element.items, { screen: this.screen, data: this.data, isMobile: this.isMobile }).addValidations(validations);
     }
   }
   camelCase(name) {

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -9,6 +9,7 @@
     :computed="computed"
     :custom-css="customCss"
     :watchers="watchers"
+    :is-mobile="isMobile"
     :_parent="_parent"
   />
 </template>
@@ -43,7 +44,8 @@ export default {
     collectionmode: {
       type: Object
     },
-    taskdraft: Object
+    taskdraft: Object,
+    isMobile: {type: Boolean, default: false}
   },
   data() {
     return {

--- a/src/components/renderer/form-collection-view-control.vue
+++ b/src/components/renderer/form-collection-view-control.vue
@@ -9,6 +9,7 @@
     :computed="computed"
     :custom-css="customCss"
     :watchers="watchers"
+    :is-mobile="isMobile"
     :_parent="_parent"
   />
 </template>
@@ -38,6 +39,7 @@ export default {
       type: Object
     },
     taskdraft: Object,
+    isMobile: {type: Boolean, default: false},
   },
   data() {
     return {

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -55,7 +55,9 @@ export default {
     VueFormRenderer
   },
   mixins: [],
-  props: ["value", "config", "transientData", "name", "mode", "formConfig", "isMobile"],
+  // Renderer props stay untyped because legacy screens may pass non-canonical runtime types.
+  // eslint-disable-next-line prettier/prettier
+  props: ["value", "config", "transientData", "name", "mode", "formConfig", "isMobile"], // NOSONAR
   data() {
     return {
       matrix: [],

--- a/src/components/renderer/form-loop.vue
+++ b/src/components/renderer/form-loop.vue
@@ -7,6 +7,7 @@
         :computed="null"
         :custom-css="null"
         :watchers="null"
+        :is-mobile="isMobile"
         :is-loop="true"
         :debug-context="'Loop #' + loopIndex"
         :mode="mode"
@@ -54,7 +55,7 @@ export default {
     VueFormRenderer
   },
   mixins: [],
-  props: ["value", "config", "transientData", "name", "mode", "formConfig"],
+  props: ["value", "config", "transientData", "name", "mode", "formConfig", "isMobile"],
   data() {
     return {
       matrix: [],

--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -11,6 +11,7 @@
     :computed="computed"
     :custom-css="customCSS"
     :watchers="watchers"
+    :is-mobile="isMobile"
     debug-context="Nested Screen"
     @css-errors="cssErrors = $event"
     :_parent="_parent"
@@ -42,6 +43,7 @@ export default {
     validationData: null,
     _parent: null,
     ancestorScreens: {type: Array, default: () => []},
+    isMobile: {type: Boolean, default: false},
   },
   data() {
     return {

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -182,6 +182,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :is-mobile="isMobile"
         debug-context="Record List Add"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -210,6 +211,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :is-mobile="isMobile"
         debug-context="Record List Edit"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -293,7 +295,8 @@ export default {
     "source",
     "paginationOption",
     "designerMode",
-    "bgcolormodern"
+    "bgcolormodern",
+    "isMobile"
   ],
   data() {
     return {

--- a/src/components/screen-renderer.vue
+++ b/src/components/screen-renderer.vue
@@ -39,6 +39,7 @@
       :vdata="value"
       :_parent="_parent || value?._parent"
       :_initial-page="currentPage"
+      :is-mobile="isMobile"
       :taskdraft="taskdraft"
       @after-submit="afterSubmit"
       @submit="submit"
@@ -70,6 +71,10 @@ export default {
     loopContext: {
       type: String,
       default: ""
+    },
+    isMobile: {
+      type: Boolean,
+      default: false
     },
     taskdraft: Object
   },

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -12,6 +12,7 @@
       :value="data"
       :_parent="_parent || data?._parent"
       :definition="definition"
+      :is-mobile="responsiveIsMobile"
       :current-page="currentPage"
       data-cy="screen-renderer"
       :show-errors="showErrors"
@@ -72,8 +73,7 @@ export default {
         config: this.config,
         computed: this.computed,
         customCss: this.customCss,
-        watchers: this.watchers,
-        isMobile: false
+        watchers: this.watchers
       },
       formSubmitErrorClass: "",
       // watcher URLs
@@ -114,7 +114,8 @@ export default {
         }
       },
       scrollable: null,
-      containerObserver: null
+      containerObserver: null,
+      containerObserverFrame: null
     };
   },
   computed: {
@@ -187,6 +188,12 @@ export default {
     
     // Initialize the clipboard module
     this.$store.dispatch('clipboardModule/initializeClipboard');
+  },
+  beforeDestroy() {
+    this.containerObserver.disconnect();
+    if (this.containerObserverFrame) {
+      cancelAnimationFrame(this.containerObserverFrame);
+    }
   },
   methods: {
     ...mapActions("globalErrorsModule", [
@@ -367,10 +374,15 @@ export default {
       this.$emit("update-page-task");
       this.$refs.renderer.setCurrentPage(page);
     },
-    onContainerObserver(entries) {
-      // Control coordinates
-      const controlEl = entries[0].target.getBoundingClientRect();
-      this.parseCss();
+    onContainerObserver() {
+      if (this.containerObserverFrame) {
+        cancelAnimationFrame(this.containerObserverFrame);
+      }
+      this.containerObserverFrame = requestAnimationFrame(() => {
+        this.containerObserverFrame = null;
+        this.checkIfIsMobile();
+        this.parseCss();
+      });
     },
     saveClipboarToLocalStorage(items){
       localStorage.setItem("savedClipboard", JSON.stringify(items));

--- a/src/mixins/DeviceDetector.js
+++ b/src/mixins/DeviceDetector.js
@@ -1,6 +1,22 @@
 export const MAX_MOBILE_WIDTH = 480;
 export const originalDevicePixelRatio = window.devicePixelRatio;
 export default {
+  props: {
+    isMobile: {
+      type: Boolean,
+      default: false
+    }
+  },
+  data() {
+    return {
+      detectedIsMobile: false
+    };
+  },
+  computed: {
+    responsiveIsMobile() {
+      return this.isMobile || this.detectedIsMobile;
+    }
+  },
   created() {
     window.addEventListener("resize", this.resizeHandler);
   },
@@ -17,10 +33,10 @@ export default {
       this.checkIfIsMobile();
     },
     checkIfIsMobile() {
-      const renderer = document.getElementById("vue-form-renderer");
+      const renderer = this.$refs.formRendererContainer;
       const isModelerInspector = this.data && this.data.$type && this.data.$type.startsWith("bpmn:");
-      if (this.definition && !isModelerInspector) {
-        this.definition.isMobile =
+      if (!isModelerInspector) {
+        this.detectedIsMobile =
           renderer &&
           renderer.offsetWidth <= MAX_MOBILE_WIDTH &&
           originalDevicePixelRatio === window.devicePixelRatio;

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -448,6 +448,7 @@ export default {
         await ValidationsFactory(definition, {
           screen: definition,
           firstPage,
+          isMobile: this.isMobile,
           data: {
             _parent: this._parent,
             ...this.vdata

--- a/src/mixins/VisibilityRule.js
+++ b/src/mixins/VisibilityRule.js
@@ -2,10 +2,10 @@ import { Parser } from 'expr-eval';
 
 export default {
   methods: {
-    visibilityRuleIsVisible(rule, name, deviceVisibility) {
-      const visibility = deviceVisibility || { showForDesktop: true, showForMobile: true, isMobile: false };
+    visibilityRuleIsVisible(rule, name, deviceVisibility, isMobile = false) {
+      const visibility = deviceVisibility || { showForDesktop: true, showForMobile: true };
       const visibleInDevice =
-        (visibility.isMobile && visibility.showForMobile) || (!visibility.isMobile && visibility.showForDesktop);
+        (isMobile && visibility.showForMobile) || (!isMobile && visibility.showForDesktop);
 
       try {
         if (rule && rule.trim().length > 0) {

--- a/src/mixins/extensions/FormDynamicPanel.js
+++ b/src/mixins/extensions/FormDynamicPanel.js
@@ -20,8 +20,7 @@ export default {
             items: element.items,
           }
         ],
-        watchers: [], 
-        isMobile: false
+        watchers: []
       };
     },
 
@@ -57,6 +56,7 @@ export default {
       return this.createComponent("ScreenRenderer", {
         ":definition": this.byRef(nested),
         ":value": valueExpression,
+        ":is-mobile": "isMobile",
         ":loop-context": loopContextExpression,
         ":_parent": "getValidationData()",
         ":components": this.byRef(this.components),

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -1,4 +1,12 @@
 /* eslint-disable no-param-reassign */
+const RESPONSIVE_COMPONENTS = new Set([
+  "FormLoop",
+  "FormRecordList",
+  "FormNestedScreen",
+  "FormCollectionRecordControl",
+  "FormCollectionViewControl"
+]);
+
 export default {
   data() {
     return {
@@ -6,6 +14,11 @@ export default {
     };
   },
   methods: {
+    addResponsiveProperties(properties, componentName) {
+      if (RESPONSIVE_COMPONENTS.has(componentName)) {
+        properties[":is-mobile"] = "isMobile";
+      }
+    },
     searchForRecordList(items) {
       items.forEach((item) => {
         if (item instanceof Array) {
@@ -86,17 +99,7 @@ export default {
       if (componentName === "FormNestedScreen") {
         properties[":_parent"] = "_parent";
       }
-      if (
-        [
-          "FormLoop",
-          "FormRecordList",
-          "FormNestedScreen",
-          "FormCollectionRecordControl",
-          "FormCollectionViewControl"
-        ].includes(componentName)
-      ) {
-        properties[":is-mobile"] = "isMobile";
-      }
+      this.addResponsiveProperties(properties, componentName);
       // Add cypress testing tags
       if (element.config.name) {
         properties["data-cy"] = `screen-field-${element.config.name}`;

--- a/src/mixins/extensions/LoadFieldComponents.js
+++ b/src/mixins/extensions/LoadFieldComponents.js
@@ -86,6 +86,17 @@ export default {
       if (componentName === "FormNestedScreen") {
         properties[":_parent"] = "_parent";
       }
+      if (
+        [
+          "FormLoop",
+          "FormRecordList",
+          "FormNestedScreen",
+          "FormCollectionRecordControl",
+          "FormCollectionViewControl"
+        ].includes(componentName)
+      ) {
+        properties[":is-mobile"] = "isMobile";
+      }
       // Add cypress testing tags
       if (element.config.name) {
         properties["data-cy"] = `screen-field-${element.config.name}`;

--- a/src/mixins/extensions/LoopContainer.js
+++ b/src/mixins/extensions/LoopContainer.js
@@ -28,8 +28,7 @@ export default {
             items: element.items
           }
         ],
-        watchers: definition.watchers,
-        isMobile: definition.isMobile
+        watchers: definition.watchers
       };
 
       let loopContext = "";
@@ -42,6 +41,7 @@ export default {
       const child = this.createComponent("ScreenRenderer", {
         ":definition": this.byRef(nested),
         ":value": "loopRow",
+        ":is-mobile": "isMobile",
         ":loop-context": `'${loopContext}.' + index`,
         ":_parent": "getValidationData()",
         ":components": this.byRef(this.components),

--- a/src/mixins/extensions/VisibilityRule.js
+++ b/src/mixins/extensions/VisibilityRule.js
@@ -3,25 +3,25 @@ import VisibilityRule from '../VisibilityRule';
 export default {
   mounted() {
     this.extensions.push({
-      onloaditems({ element, wrapper, definition }) {
+      onloaditems({ element, wrapper }) {
         const visibility = element.config.deviceVisibility || { showForDesktop: true, showForMobile: true }
         const restrictDeviceVisibility = !visibility.showForDesktop || !visibility.showForMobile;
 
-
-        element.visibleInDevice =
-          (definition.isMobile && visibility.showForMobile) ||
-          (!definition.isMobile && visibility.showForDesktop);
-
         if (element.config.conditionalHide || restrictDeviceVisibility) {
-          const deviceVisibility = JSON.stringify( { ...visibility, isMobile: definition.isMobile } );
+          const deviceVisibility = JSON.stringify(visibility);
           wrapper.setAttribute(
             'v-show',
             `visibilityRuleIsVisible(${JSON.stringify(element.config.conditionalHide)}, 
-            ${JSON.stringify(element.config.name)}, ${deviceVisibility})`
+            ${JSON.stringify(element.config.name)}, ${deviceVisibility}, isMobile)`
           );
         }
       },
       onbuild({ screen }) {
+        this.addProp(screen, "isMobile", {
+          type: Boolean,
+          default: false,
+        });
+        this.addWatch(screen, "isMobile", "this.loadValidationRules();");
         screen.mixins.push(VisibilityRule);
       },
     });

--- a/tests/e2e/specs/LoopSelectList.spec.js
+++ b/tests/e2e/specs/LoopSelectList.spec.js
@@ -98,15 +98,22 @@ describe("Select List Cache", () => {
 
     cy.loadFromJson("loop_select_list.json", 0);
     cy.get("#screen-builder-container").then(($builder) => {
-      const loop = $builder[0].__vue__.$refs.builder.config[0].items[0];
+      const config = $builder[0].__vue__.$refs.builder.config;
+      const loop = config[0].items[0];
       loop.config.settings.times = "1";
-      loop.items.push({
+      config[0].items.push({
         label: "Line Input",
         config: {
           name: "desktop_only",
           type: "text",
           label: "Desktop Only",
-          validation: [],
+          validation: [
+            {
+              value: "required",
+              helper: "Checks if the field has a value",
+              content: "Required"
+            }
+          ],
           deviceVisibility: {
             showForDesktop: true,
             showForMobile: false
@@ -119,6 +126,7 @@ describe("Select List Cache", () => {
       });
     });
 
+    cy.showValidationOnLoad();
     cy.get("[data-cy=mode-preview]").click();
     cy.wait("@responsiveDataSource");
 
@@ -135,10 +143,17 @@ describe("Select List Cache", () => {
         expect($builder[0].__vue__.previewData.loop_1[0].country).to.equal("1");
       });
     };
+    const assertScreenValidity = (invalid) => {
+      cy.window().should((win) => {
+        const renderer = win.vueInstance.$children[0].$refs.renderer;
+        expect(renderer.getMainScreen().$v.$invalid).to.equal(invalid);
+      });
+    };
 
     cy.get(select).selectOption("Bolivia");
     assertSelectionState();
     cy.get(desktopOnly).should("be.visible");
+    assertScreenValidity(true);
     cy.get(select).then(($select) => {
       originalSelect = $select[0];
     });
@@ -149,6 +164,7 @@ describe("Select List Cache", () => {
     });
     assertSelectionState();
     cy.get(desktopOnly).should("not.be.visible");
+    assertScreenValidity(false);
 
     cy.get("[data-cy=device-screen-desktop-button]").click();
     cy.get(select).should(($select) => {
@@ -156,6 +172,7 @@ describe("Select List Cache", () => {
     });
     assertSelectionState();
     cy.get(desktopOnly).should("be.visible");
+    assertScreenValidity(true);
     cy.get("@responsiveDataSource.all").should("have.length", 1);
   });
 

--- a/tests/e2e/specs/LoopSelectList.spec.js
+++ b/tests/e2e/specs/LoopSelectList.spec.js
@@ -1,4 +1,68 @@
 describe("Select List Cache", () => {
+  const dataSourceResponse = {
+    status: 200,
+    response: {
+      data: [
+        {
+          id: 1,
+          created_by_id: 2,
+          updated_by_id: 2,
+          created_at: "2021-11-08 10:29:56",
+          updated_at: "2021-11-08 10:29:56",
+          data: {
+            id: 1,
+            name: "Bolivia"
+          },
+          collection_id: 3,
+          title: "1",
+          created_by: {
+            id: 2,
+            email: "admin@processmaker.com"
+          },
+          updated_by: {
+            id: 2,
+            email: "admin@processmaker.com"
+          }
+        },
+        {
+          id: 2,
+          created_by_id: 2,
+          updated_by_id: 2,
+          created_at: "2021-11-08 10:29:56",
+          updated_at: "2021-11-08 10:29:56",
+          data: {
+            id: 2,
+            name: "United States"
+          },
+          collection_id: 3,
+          title: "2",
+          created_by: {
+            id: 2,
+            email: "admin@processmaker.com"
+          },
+          updated_by: {
+            id: 2,
+            email: "admin@processmaker.com"
+          }
+        }
+      ],
+      meta: {
+        filter: "",
+        sort_by: "",
+        sort_order: "",
+        count: 2,
+        total_pages: 1,
+        current_page: 1,
+        from: 1,
+        last_page: 1,
+        path: "/api/1.0/collections/3/records",
+        per_page: 9223372036854775807,
+        to: 2,
+        total: 2
+      }
+    }
+  };
+
   function addHeader(win, name, value) {
     const meta = win.document.createElement("meta");
     meta.setAttribute("name", name);
@@ -9,70 +73,90 @@ describe("Select List Cache", () => {
     cy.intercept(
       "GET",
       "/api/1.0/requests/data_sources/3/resources/ListAll/data**",
-      JSON.stringify({
-        status: 200,
-        response: {
-          data: [
-            {
-              id: 1,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                id: 1,
-                name: "Bolivia"
-              },
-              collection_id: 3,
-              title: "1",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            },
-            {
-              id: 2,
-              created_by_id: 2,
-              updated_by_id: 2,
-              created_at: "2021-11-08 10:29:56",
-              updated_at: "2021-11-08 10:29:56",
-              data: {
-                id: 2,
-                name: "United States"
-              },
-              collection_id: 3,
-              title: "2",
-              created_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              },
-              updated_by: {
-                id: 2,
-                email: "admin@processmaker.com"
-              }
-            }
-          ],
-          meta: {
-            filter: "",
-            sort_by: "",
-            sort_order: "",
-            count: 2,
-            total_pages: 1,
-            current_page: 1,
-            from: 1,
-            last_page: 1,
-            path: "/api/1.0/collections/3/records",
-            per_page: 9223372036854775807,
-            to: 2,
-            total: 2
-          }
-        }
-      })
+      JSON.stringify(dataSourceResponse)
     ).as("getDataSource");
+  });
+
+  it("Preserves a Data Connector selection across responsive breakpoints", () => {
+    cy.intercept(
+      "GET",
+      "/api/1.0/requests/data_sources/3/resources/ListAll/data**",
+      (request) => {
+        request.reply({
+          delay: 250,
+          body: JSON.stringify(dataSourceResponse)
+        });
+      }
+    ).as("responsiveDataSource");
+
+    cy.visit("/", {
+      onBeforeLoad(win) {
+        addHeader(win, "screen-cache-enabled", "false");
+        addHeader(win, "screen-cache-timeout", "3000");
+      }
+    });
+
+    cy.loadFromJson("loop_select_list.json", 0);
+    cy.get("#screen-builder-container").then(($builder) => {
+      const loop = $builder[0].__vue__.$refs.builder.config[0].items[0];
+      loop.config.settings.times = "1";
+      loop.items.push({
+        label: "Line Input",
+        config: {
+          name: "desktop_only",
+          type: "text",
+          label: "Desktop Only",
+          validation: [],
+          deviceVisibility: {
+            showForDesktop: true,
+            showForMobile: false
+          }
+        },
+        component: "FormInput",
+        inspector: [],
+        "editor-control": "FormInput",
+        "editor-component": "FormInput"
+      });
+    });
+
+    cy.get("[data-cy=mode-preview]").click();
+    cy.wait("@responsiveDataSource");
+
+    const select = '[data-cy="screen-field-country"]';
+    const selectedLabel = `${select} .multiselect__single`;
+    const desktopOnly = '[data-cy="screen-field-desktop_only"]';
+    let originalSelect;
+    const assertSelectionState = () => {
+      cy.get(selectedLabel).should("contain", "Bolivia");
+      cy.get(select).click();
+      cy.get(select).contains("United States").should("exist");
+      cy.get("body").type("{esc}");
+      cy.get("#screen-builder-container").then(($builder) => {
+        expect($builder[0].__vue__.previewData.loop_1[0].country).to.equal("1");
+      });
+    };
+
+    cy.get(select).selectOption("Bolivia");
+    assertSelectionState();
+    cy.get(desktopOnly).should("be.visible");
+    cy.get(select).then(($select) => {
+      originalSelect = $select[0];
+    });
+
+    cy.get("[data-cy=device-screen-mobile-button]").click();
+    cy.get(select).should(($select) => {
+      expect($select[0]).to.equal(originalSelect);
+    });
+    assertSelectionState();
+    cy.get(desktopOnly).should("not.be.visible");
+
+    cy.get("[data-cy=device-screen-desktop-button]").click();
+    cy.get(select).should(($select) => {
+      expect($select[0]).to.equal(originalSelect);
+    });
+    assertSelectionState();
+    cy.get(desktopOnly).should("be.visible");
+    cy.get("@responsiveDataSource.all").should("have.length", 1);
   });
 
   it("None Cached - Verify number of service calls for loop that contains a multiselect list", () => {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: A Data Connector-backed Select List keeps its selected label, loaded options, and scalar screen-data value when switching between desktop and mobile widths.

Actual behavior: Crossing the 480 px breakpoint updated the structural screen definition, rebuilt the generated screen, remounted the Select List, and repeated its `ListAll` request. The selected scalar value remained in screen data, but its label disappeared while options reloaded.

Reproduction:
1. Configure a Select List to load options from a Data Connector.
2. Select an option in desktop preview.
3. Switch to mobile preview at 480 px, then return to desktop preview.
4. Observe the selection and Data Connector requests.

## Solution

- Keep responsive state reactive and independent from the structural screen definition so breakpoint changes do not rebuild the generated screen.
- Propagate the responsive state through Screen Renderer, loops, dynamic panels, nested screens, Record Lists, and collection controls.
- Update device visibility and validation rules from reactive state while preserving the existing structural rebuild behavior for configuration changes.
- Observe each renderer's own container and coalesce resize updates to prevent ResizeObserver loops.
- Add a deterministic Cypress regression with a delayed mocked Data Connector response that verifies selection state, options, component identity, visibility rules, responsive validation recalculation, and a single `ListAll` request.

## How to Test

1. Configure a Data Connector-backed Select List and select an option.
2. Add an empty required field that is visible only on desktop.
3. Switch desktop -> mobile at 480 px -> desktop.
4. Confirm the selected label, available options, and scalar screen-data value remain unchanged.
5. Confirm the screen changes from invalid -> valid -> invalid as the required field becomes hidden and visible again.
6. Confirm desktop/mobile visibility rules toggle and the Data Connector does not execute again.

Validation completed:
- `LoopSelectList.spec.js`: 3 passing, including responsive invalid -> valid -> invalid coverage.
- `DeviceVisivilityInspector.spec.js`: 22 passing.
- `VisibilityRule.spec.js`: 3 passing.
- `npm run build-bundle`: passed.
- Screen Builder `dist` copied into ProcessMaker Core and `npm run dev`: passed.
- Manual screen 64 verification preserved the same Select List DOM node across desktop -> mobile -> desktop with zero additional `ListAll` requests.

Local toolchain notes:
- Jest completed 60 passing assertions, but 7 suites are blocked before execution by the repository's existing Vue/ES module transform configuration.
- `npm run lint` cannot start because `vue-cli-service` is not installed by the current package manifest; direct ESLint also reports existing repository-wide lint debt.

## Related Tickets & Packages

- https://processmaker.atlassian.net/browse/FOUR-32670
- Screen Builder only; no `vue-form-elements` changes were required.

ci:deploy
