### PR TITLE
FOUR-32834: Preserve Collection Record Control mode

### DIFF
--- a/src/components/renderer/collection-record-mode.js
+++ b/src/components/renderer/collection-record-mode.js
@@ -1,0 +1,6 @@
+export default function resolveCollectionMode(
+  collectionMode,
+  defaultMode = "Edit"
+) {
+  return collectionMode?.modeId ?? defaultMode;
+}

--- a/src/components/renderer/form-collection-record-control.vue
+++ b/src/components/renderer/form-collection-record-control.vue
@@ -17,6 +17,7 @@
 import _ from "lodash";
 import VueFormRenderer from "../vue-form-renderer.vue";
 import CollectionRecordsList from "../inspector/collection-records-list.vue";
+import resolveCollectionMode from "./collection-record-mode";
 
 const globalObject = typeof window === "undefined" ? global : window;
 
@@ -120,7 +121,7 @@ export default {
         this.loadRecordCollection(
           this.collection.collectionId,
           record,
-          this.selDisplayMode
+          this.getCollectionMode()
         );
       } else {
         if (this.isMustache(record)) {
@@ -154,7 +155,7 @@ export default {
         this.hasMustache = true;
       }
 
-      const collectionMode = this.collectionmode?.modeId ?? this.defaultCollectionMode;
+      const collectionMode = this.getCollectionMode();
 
       this.loadRecordCollection(
         this.collection.collectionId,
@@ -164,6 +165,12 @@ export default {
     }
   },
   methods: {
+    getCollectionMode() {
+      return resolveCollectionMode(
+        this.collectionmode,
+        this.defaultCollectionMode
+      );
+    },
     isSubmitButton(item) {
       return (
         item.config &&

--- a/tests/unit/FormCollectionRecordControl.spec.js
+++ b/tests/unit/FormCollectionRecordControl.spec.js
@@ -1,0 +1,30 @@
+import resolveCollectionMode from "../../src/components/renderer/collection-record-mode";
+
+const readScreenId = 101;
+const updateScreenId = 202;
+
+function getScreenId(collectionMode) {
+  return resolveCollectionMode(collectionMode) === "View"
+    ? readScreenId
+    : updateScreenId;
+}
+
+describe("FormCollectionRecordControl mode resolution", () => {
+  test("preserves each configured mode when a shared dynamic record changes", () => {
+    const controls = [
+      { collectionMode: { modeId: "Edit" }, screenId: updateScreenId },
+      { collectionMode: { modeId: "View" }, screenId: readScreenId }
+    ];
+
+    [1, 2].forEach(() => {
+      controls.forEach(({ collectionMode, screenId }) => {
+        expect(getScreenId(collectionMode)).toBe(screenId);
+      });
+    });
+  });
+
+  test("defaults to Edit when collection mode is not configured", () => {
+    expect(resolveCollectionMode()).toBe("Edit");
+    expect(getScreenId()).toBe(updateScreenId);
+  });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps

When two Collection Record Controls use the same dynamic Record ID but different modes, resolving the Record ID causes both controls to display the Edit Screen.

To reproduce, configure two controls against the same collection using `{{option}}` as the Record ID, set one to Edit and the other to View, open Preview, and enter a valid record ID.

Expected behavior: Each control preserves its configured mode and loads the corresponding Update or Read Screen.

Actual behavior: Both controls load the Update Screen in Edit mode.

## Solution

- Resolve the effective mode from `collectionmode.modeId` whenever the dynamic Record ID changes.
- Reuse the same mode resolution during initial mounting and subsequent record changes.
- Preserve Edit as the fallback for legacy configurations without a collection mode.
- Add regression coverage for controls with Edit and View modes sharing a dynamic Record ID.

## How to Test

- Run `npx jest tests/unit/FormCollectionRecordControl.spec.js --runInBand`.
- Run ESLint against the new resolver and regression test.
- Run `npm run build-bundle`.
- Copy the generated `dist/` contents into Core and run `npm run dev`.
- In Screen 17 Preview, enter `1` in `option` and verify that the first control remains editable while the second displays its Read Screen.
- The focused tests pass. The full Jest run reports 94 passing tests, while 7 existing suites fail before execution because of the repository's Vue/Jest transformation configuration.

## Related Tickets & Packages

- https://processmaker.atlassian.net/browse/FOUR-32834
- Package: `@processmaker/screen-builder`

ci:deploy
