### PR TITLE
Task/FOUR-33042: Convert base64 images used in html viewers into media on screens- #9030

### DIFF
--- a/src/components/inspector/html-content-with-media-warning.vue
+++ b/src/components/inspector/html-content-with-media-warning.vue
@@ -1,0 +1,70 @@
+<template>
+  <div class="form-group mb-0">
+    <label v-if="label">{{ $t(label) }}</label>
+    <textarea
+      class="form-control"
+      :rows="rows"
+      :value="value"
+      data-cy="inspector-content"
+      @input="$emit('input', $event.target.value)"
+    />
+    <small v-if="helper" class="form-text text-muted">{{ $t(helper) }}</small>
+    <div
+      v-if="hasInlineBase64Images"
+      class="alert alert-warning mt-2 mb-0 py-2 px-3"
+      role="status"
+      data-cy="inspector-content-base64-warning"
+    >
+      <i class="fas fa-exclamation-triangle mr-1" aria-hidden="true" />
+      {{ warningMessage }}
+    </div>
+  </div>
+</template>
+
+<script>
+const DATA_IMAGE_PATTERN = /data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+/;
+
+export default {
+  name: "HtmlContentWithMediaWarning",
+  props: {
+    value: {
+      type: String,
+      default: "",
+    },
+    label: {
+      type: String,
+      default: "Content",
+    },
+    helper: {
+      type: String,
+      default: "",
+    },
+    rows: {
+      type: [Number, String],
+      default: 5,
+    },
+  },
+  computed: {
+    hasInlineBase64Images() {
+      return DATA_IMAGE_PATTERN.test(this.value || "");
+    },
+    inlineImageCount() {
+      const matches = (this.value || "").match(
+        /data:image\/[a-zA-Z0-9+.-]+;base64,[A-Za-z0-9+/=]+/g,
+      );
+      return matches ? matches.length : 0;
+    },
+    warningMessage() {
+      if (this.inlineImageCount === 1) {
+        return this.$t(
+          "A base64 image was detected. On save it will be stored as a media file and replaced with a URL.",
+        );
+      }
+      return this.$t(
+        "Base64 images were detected ({{count}}). On save they will be stored as media files and replaced with URLs.",
+        { count: this.inlineImageCount },
+      );
+    },
+  },
+};
+</script>

--- a/src/components/inspector/index.js
+++ b/src/components/inspector/index.js
@@ -14,6 +14,7 @@ export { default as DefaultValueEditor } from "./default-value-editor.vue";
 export { default as DeviceVisibility } from "./device-visibility.vue";
 export { default as EditOption } from "./edit-option.vue";
 export { default as FormMultiselect } from "./form-multiselect.vue";
+export { default as HtmlContentWithMediaWarning } from "./html-content-with-media-warning.vue";
 export { default as ImageUpload } from "./image-upload.vue";
 export { default as ImageVariable } from "./image-variable.vue";
 export { default as InputVariable } from "./input-variable.vue";

--- a/src/form-builder-controls.js
+++ b/src/form-builder-controls.js
@@ -78,7 +78,7 @@ export default [
       },
       inspector: [
         {
-          type: 'FormTextArea',
+          type: 'HtmlContentWithMediaWarning',
           field: 'content',
           config: {
             rows: 5,


### PR DESCRIPTION
# Description
Adds a screen inline-image normalizer that converts base64 data URLs in HTML content into Spatie media, deduplicates repeated images by content hash, and stores the normalized config after saves and draft updates. Includes a console command for scanning and dry-run cleanup, plus front-end handling to sync the updated config and surface a success notice after save.

**How to use command**
To replace base64 images inside form_html_viewer control of already existing screens, you can use the following command:

Dry run mode (will detect base 64 images, but not convert them into media)
```
php artisan processmaker:normalize-screen-inline-images --dry-run
```

Dry run mode for a specific screen:
```
php artisan processmaker:normalize-screen-inline-images --dry-run --screen=123
```

Execute conversion from base64 to media:
```
php artisan processmaker:normalize-screen-inline-images
```

# Related Tickets and PRs
https://processmaker.atlassian.net/browse/FOUR-33042
- [Screen builder PR](https://github.com/ProcessMaker/screen-builder/pull/1935)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/9030)