### PR TITLE
Bugfix/FOUR-32292-b: Validation of required fields does not work correctly in Record List controls with checkboxes

### DIFF
--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -137,7 +137,8 @@ class Validations {
    * Device visibility is decided once (screen-level). Conditional Visibility
    * Rules must NOT be applied here: they depend on live data and can change
    * per row / after the user toggles another control. Those expressions are
-   * evaluated inside each validator at submit/validate time instead.
+   * evaluated inside each validator at submit/validate time instead
+   * (field conditionalHide, parentVisibilityRule from containers / PageNavigate).
    */
   isVisible() {
     const visibleInDevice =
@@ -146,6 +147,21 @@ class Validations {
         : this.element.visibleInDevice;
     return !!visibleInDevice;
   }
+}
+
+/**
+ * AND-combine visibility expressions so nested parents and the current control
+ * both gate child validators at validate time.
+ */
+function combineVisibilityRules(...rules) {
+  const parts = rules.filter((rule) => typeof rule === 'string' && rule.trim());
+  if (parts.length === 0) {
+    return undefined;
+  }
+  if (parts.length === 1) {
+    return parts[0];
+  }
+  return parts.map((rule) => `(${rule})`).join(' and ');
 }
 
 /**
@@ -358,7 +374,19 @@ class PageNavigateValidations extends Validations {
     if (pagesValidated.length > 0 && !pagesValidated.includes(screenPageId)) {
       if (this.screen.config[screenNumber] && this.screen.config[screenNumber].items) {
         pagesValidated.push(screenPageId);
-        await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
+        // Propagate the nav button's Visibility Rule (and any parent container
+        // rule) so destination required fields do not block submit while the
+        // page is unreachable. isVisible() no longer evaluates conditionalHide
+        // at build time, so this parentVisibilityRule is the runtime gate.
+        const parentVisibilityRule = combineVisibilityRules(
+          this.parentVisibilityRule,
+          this.element.config && this.element.config.conditionalHide
+        );
+        await ValidationsFactory(this.screen.config[this.element.config.eventData].items, {
+          screen: this.screen,
+          data: this.data,
+          parentVisibilityRule
+        }).addValidations(validations);
       }
     }
   }

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -132,27 +132,19 @@ class Validations {
   }
 
   /**
-   * Check if element/container is visible.
+   * Check if element/container should contribute rules at build time.
+   *
+   * Device visibility is decided once (screen-level). Conditional Visibility
+   * Rules must NOT be applied here: they depend on live data and can change
+   * per row / after the user toggles another control. Those expressions are
+   * evaluated inside each validator at submit/validate time instead.
    */
   isVisible() {
-    // Disable validations if field is hidden
     const visibleInDevice =
       this.element.visibleInDevice === null || this.element.visibleInDevice === undefined
         ? true
         : this.element.visibleInDevice;
-    if (!visibleInDevice) {
-      return false;
-    }
-
-    let visible = true;
-    if (this.element.config.conditionalHide) {
-      try {
-        visible = !!Parser.evaluate(this.element.config.conditionalHide, this.data);
-      } catch (error) {
-        visible = false;
-      }
-    }
-    return visible;
+    return !!visibleInDevice;
   }
 }
 
@@ -407,11 +399,12 @@ class FormRecordListValidations extends Validations {
     }
 
     const rowRules = {};
-    const rows = get(this.data, listName);
-    const firstRow = (Array.isArray(rows) && rows.length > 0) ? rows[0] : {};
+    // Do not seed with the first list row: isVisible() / containers would omit
+    // fields hidden on that row even when later rows show them. Visibility is
+    // applied per row when the wrapped validators run.
     await ValidationsFactory(formPage.items, {
       screen: this.screen,
-      data: { _parent: this.data, ...firstRow },
+      data: { _parent: this.data },
       parentVisibilityRule: this.element.config.conditionalHide,
       insideLoop: true,
       insideRecordListForm: true
@@ -439,10 +432,13 @@ class FormRecordListValidations extends Validations {
           const data = props[1];
           const listRows = get(data, listName);
           // No rows yet: treat as empty field values (required/accepted fail).
+          // Use an empty row context so field/parent visibility rules evaluate
+          // against a row shape, not the root screen alone.
           if (!Array.isArray(listRows) || listRows.length === 0) {
-            return originalFn.apply(this, [undefined, data]);
+            return originalFn.apply(this, [undefined, { _parent: data }]);
           }
-          // Every stored row must satisfy the Record Form rule.
+          // Every stored row must satisfy the Record Form rule. originalFn
+          // already skips the check when the field/parent is hidden for that row.
           return listRows.every((row) =>
             originalFn.apply(this, [get(row, fieldName), { _parent: data, ...row }])
           );

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -1,6 +1,6 @@
 import { validators } from './mixins/ValidationRules';
 import DataProvider from './DataProvider';
-import { get, set, merge } from 'lodash';
+import { get, set, merge, unset } from 'lodash';
 import { Parser } from 'expr-eval';
 
 let globalObject = typeof window === 'undefined'
@@ -8,6 +8,102 @@ let globalObject = typeof window === 'undefined'
   : window;
 
 let pagesValidated = [];
+
+/**
+ * Collect page indexes referenced by FormRecordList "Record Form" configs.
+ */
+export function collectRecordListFormPages(items, pages = new Set()) {
+  if (!Array.isArray(items)) {
+    return pages;
+  }
+  items.forEach((item) => {
+    if (!item) {
+      return;
+    }
+    if (item.component === 'FormRecordList' && item.config && item.config.form !== '' && item.config.form != null) {
+      pages.add(String(item.config.form));
+    }
+    if (item.items) {
+      collectRecordListFormPages(item.items, pages);
+    }
+  });
+  return pages;
+}
+
+/**
+ * Collect variable names from a tree of screen items.
+ */
+export function collectFieldNames(items, names = new Set()) {
+  if (!Array.isArray(items)) {
+    return names;
+  }
+  items.forEach((item) => {
+    if (!item) {
+      return;
+    }
+    if (item.config && typeof item.config.name === 'string' && item.config.name) {
+      names.add(item.config.name);
+    }
+    if (item.items) {
+      collectFieldNames(item.items, names);
+    }
+  });
+  return names;
+}
+
+/**
+ * Remove validation rules that belong only to Record List form pages so they
+ * never block parent-screen submit. Modal renderers (popupConfig with only the
+ * form page) keep their rules.
+ */
+export function stripRecordListFormPageValidations(definition, firstPage, validations) {
+  const config = definition && definition.config;
+  if (!Array.isArray(config) || !validations || typeof validations !== 'object') {
+    return validations;
+  }
+
+  const formPages = new Set();
+  config.forEach((page) => {
+    if (page && page.items) {
+      collectRecordListFormPages(page.items, formPages);
+    }
+  });
+  if (formPages.size === 0) {
+    return validations;
+  }
+
+  // Modal/popup case: config only has the record-form page → keep its rules.
+  const presentPages = config
+    .map((page, index) => (page ? String(index) : null))
+    .filter(Boolean);
+  if (
+    presentPages.length === 1 &&
+    formPages.has(presentPages[0]) &&
+    String(firstPage) === presentPages[0]
+  ) {
+    return validations;
+  }
+
+  const firstPageFields = collectFieldNames((config[firstPage] && config[firstPage].items) || []);
+
+  formPages.forEach((pageIndex) => {
+    if (String(pageIndex) === String(firstPage)) {
+      return;
+    }
+    const page = config[pageIndex];
+    if (!page || !page.items) {
+      return;
+    }
+    collectFieldNames(page.items).forEach((name) => {
+      if (!firstPageFields.has(name)) {
+        unset(validations, name);
+      }
+    });
+  });
+
+  return validations;
+}
+
 class Validations {
   screen = null;
   firstPage = 0;
@@ -221,6 +317,21 @@ class PageNavigateValidations extends Validations {
       return;
     }
     const screenNumber = this.element.config.eventData;
+    // Record List form pages validate only inside the add/edit modal.
+    const recordListFormPages = new Set();
+    if (Array.isArray(this.screen.config)) {
+      this.screen.config.forEach((page) => {
+        if (page && page.items) {
+          collectRecordListFormPages(page.items, recordListFormPages);
+        }
+      });
+    }
+    if (
+      recordListFormPages.has(String(screenNumber)) ||
+      recordListFormPages.has(String(parseInt(screenNumber, 10)))
+    ) {
+      return;
+    }
     let screenName = 'Empty Screen';
     if (this.screen.config[screenNumber] && this.screen.config[screenNumber].name) {
       screenName = this.screen.config[screenNumber].name;
@@ -232,6 +343,80 @@ class PageNavigateValidations extends Validations {
         await ValidationsFactory(this.screen.config[this.element.config.eventData].items, { screen: this.screen, data: this.data }).addValidations(validations);
       }
     }
+  }
+}
+
+/**
+ * Validate Record List rows using the configured Record Form page.
+ *
+ * Rules are always namespaced as `${listName}__${fieldName}` so they never
+ * collide with root controls and are not double-counted against json-schema
+ * entries that use the bare field name. Validators read `listName[]` rows.
+ */
+class FormRecordListValidations extends Validations {
+  async addValidations(validations) {
+    if (!this.isVisible()) {
+      return;
+    }
+    // Collection / read-only lists do not use the add/edit record form.
+    if (this.element.config && this.element.config.editable === false) {
+      return;
+    }
+    const formIndex = this.element.config && this.element.config.form;
+    if (formIndex === '' || formIndex == null) {
+      return;
+    }
+    const listName = this.element.config && this.element.config.name;
+    if (!(listName && typeof listName === 'string')) {
+      return;
+    }
+    const formPage = this.screen && this.screen.config && this.screen.config[formIndex];
+    if (!formPage || !Array.isArray(formPage.items)) {
+      return;
+    }
+
+    const rowRules = {};
+    const rows = get(this.data, listName);
+    const firstRow = (Array.isArray(rows) && rows.length > 0) ? rows[0] : {};
+    await ValidationsFactory(formPage.items, {
+      screen: this.screen,
+      data: { _parent: this.data, ...firstRow },
+      parentVisibilityRule: this.element.config.conditionalHide,
+      insideLoop: true
+    }).addValidations(rowRules);
+
+    Object.keys(rowRules).forEach((fieldName) => {
+      if (fieldName === '$each') {
+        return;
+      }
+      const rules = rowRules[fieldName];
+      if (!rules || typeof rules !== 'object') {
+        return;
+      }
+      // Always namespace: bare field names are also validated by json-schema /
+      // vocabularies; sharing the same key doubles the submit error count.
+      const targetName = `${listName}__${fieldName}`.replace(/\./g, '_');
+      set(validations, targetName, get(validations, targetName, {}));
+      const target = get(validations, targetName);
+      Object.keys(rules).forEach((ruleName) => {
+        const originalFn = rules[ruleName];
+        if (typeof originalFn !== 'function') {
+          return;
+        }
+        target[ruleName] = function(...props) {
+          const data = props[1];
+          const listRows = get(data, listName);
+          // No rows yet: treat as empty field values (required/accepted fail).
+          if (!Array.isArray(listRows) || listRows.length === 0) {
+            return originalFn.apply(this, [undefined, data]);
+          }
+          // Every stored row must satisfy the Record Form rule.
+          return listRows.every((row) =>
+            originalFn.apply(this, [get(row, fieldName), { _parent: data, ...row }])
+          );
+        };
+      });
+    });
   }
 }
 
@@ -400,8 +585,9 @@ function ValidationsFactory(element, options) {
     return new FormLoopValidations(element, options);
   }
   if (element.component === 'FormRecordList') {
-    //not required
-    //return new FormRecordListValidations(element, screen);
+    // Validate Record Form fields against list rows on parent submit.
+    // Modal add/edit keeps its own isolated renderer validation.
+    return new FormRecordListValidations(element, options);
   }
   if (element.component === 'FormButton' && element.config.event === 'pageNavigate') {
     return new PageNavigateValidations(element, options);

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -109,6 +109,10 @@ class Validations {
   firstPage = 0;
   data = {};
   insideLoop = false;
+  // True while collecting field rules for a Record List Record Form page.
+  // PageNavigate must not follow links in that context (would pull the parent
+  // page into rowRules and create ghost/duplicate validation keys).
+  insideRecordListForm = false;
   constructor(element, options) {
     this.element = element;
     Object.assign(this, options);
@@ -158,7 +162,13 @@ class Validations {
 class ArrayOfFieldsValidations extends Validations {
   async addValidations(validations) {
     for (const item of this.element) {
-      await ValidationsFactory(item, { screen: this.screen, data: this.data, parentVisibilityRule: this.parentVisibilityRule, insideLoop: this.insideLoop }).addValidations(validations);
+      await ValidationsFactory(item, {
+        screen: this.screen,
+        data: this.data,
+        parentVisibilityRule: this.parentVisibilityRule,
+        insideLoop: this.insideLoop,
+        insideRecordListForm: this.insideRecordListForm
+      }).addValidations(validations);
     }
   }
 }
@@ -303,7 +313,13 @@ class FormMultiColumnValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
-    await ValidationsFactory(this.element.items, { screen: this.screen, data: this.data, parentVisibilityRule: this.element.config.conditionalHide }).addValidations(validations);
+    await ValidationsFactory(this.element.items, {
+      screen: this.screen,
+      data: this.data,
+      parentVisibilityRule: this.element.config.conditionalHide,
+      insideLoop: this.insideLoop,
+      insideRecordListForm: this.insideRecordListForm
+    }).addValidations(validations);
   }
 }
 
@@ -314,6 +330,12 @@ class PageNavigateValidations extends Validations {
   async addValidations(validations) {
     // Disable validations if field is hidden
     if (!this.isVisible()) {
+      return;
+    }
+    // Record Form pages may include Page Navigation buttons (e.g. back to the
+    // main page). Those must not pull destination-page rules into the Record
+    // List row validators — that duplicates root fields under listName__*.
+    if (this.insideRecordListForm) {
       return;
     }
     const screenNumber = this.element.config.eventData;
@@ -358,6 +380,11 @@ class FormRecordListValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
+    // Nested Record List while already collecting a Record Form's rules:
+    // do not recurse (avoids listName__listName__field ghost keys).
+    if (this.insideRecordListForm) {
+      return;
+    }
     // Collection / read-only lists do not use the add/edit record form.
     if (this.element.config && this.element.config.editable === false) {
       return;
@@ -382,7 +409,8 @@ class FormRecordListValidations extends Validations {
       screen: this.screen,
       data: { _parent: this.data, ...firstRow },
       parentVisibilityRule: this.element.config.conditionalHide,
-      insideLoop: true
+      insideLoop: true,
+      insideRecordListForm: true
     }).addValidations(rowRules);
 
     Object.keys(rowRules).forEach((fieldName) => {

--- a/src/ValidationsFactory.js
+++ b/src/ValidationsFactory.js
@@ -313,11 +313,15 @@ class FormMultiColumnValidations extends Validations {
     if (!this.isVisible()) {
       return;
     }
+    // Do not forward insideLoop to children. Historically multicolumn children
+    // evaluate parentVisibilityRule at the field data level (insideLoop: false).
+    // Forwarding insideLoop:true makes parent visibility walk to `_parent`, which
+    // $each row models often lack — the catch then treats the parent as hidden
+    // and skips required rules (Loop.spec "validation with multicolumn").
     await ValidationsFactory(this.element.items, {
       screen: this.screen,
       data: this.data,
       parentVisibilityRule: this.element.config.conditionalHide,
-      insideLoop: this.insideLoop,
       insideRecordListForm: this.insideRecordListForm
     }).addValidations(validations);
   }

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -174,6 +174,7 @@
       @shown="emitShownEvent"
     >
       <vue-form-renderer
+        v-if="addModalVisible"
         ref="addRenderer"
         :key="Array.isArray(value) ? value.length : 0"
         v-model="addItem"
@@ -182,6 +183,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :isolated="true"
         debug-context="Record List Add"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -198,10 +200,11 @@
       header-close-content="&times;"
       data-cy="modal-edit"
       @ok="edit"
-      @hidden="$refs.addRenderer.hasSubmitted(false)"
+      @hidden="handleHideEditModal"
       @shown="emitShownEvent"
     >
       <vue-form-renderer
+        v-if="editModalVisible"
         ref="editRenderer"
         :key="editFormVersion"
         v-model="editItem"
@@ -210,6 +213,7 @@
         :current-page="form"
         :computed="formComputed"
         :watchers="formWatchers"
+        :isolated="true"
         debug-context="Record List Edit"
         :_parent="validationData"
         @update="updateRowDataNamePrefix"
@@ -254,11 +258,13 @@
 
 <script>
 import _ from "lodash";
+import { mapActions } from "vuex";
 import { dateUtils } from "@processmaker/vue-form-elements";
 import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
+import { findRootScreen } from "@/mixins/DataReference";
 import {
   mapCollectionRecordData,
   normalizeCollectionFieldPath
@@ -333,7 +339,11 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' }
+      popoverPosition: { top: '0px', left: '0px' },
+      // Mount modal renderers only while open so their required fields never
+      // leak into the parent screen validation rules / global error count.
+      addModalVisible: false,
+      editModalVisible: false
     };
   },
   computed: {
@@ -511,6 +521,12 @@ export default {
     this.$root.$emit("record-list-option", this.source?.sourceOptions);
   },
   methods: {
+    ...mapActions("globalErrorsModule", [
+      "validateNow",
+      "close",
+      "restartValidation",
+      "hasSubmitted"
+    ]),
     togglePopover(index, event, rowId) {
       this.deleteIndex = _.find(this.tableData.data, { row_id: rowId });
       this.isPopoverVisible = this.isPopoverVisible === index ? null : index;
@@ -983,13 +999,18 @@ export default {
       this.editIndex = pageIndex;
       // rebuild the edit screen to avoid
       this.editFormVersion++;
+      this.editModalVisible = true;
       this.$nextTick(() => {
         this.setUploadDataNamePrefix(pageIndex);
         this.$refs.editModal.show();
       });
     },
     edit(event) {
-      this.$refs.addRenderer.hasSubmitted(true);
+      if (!this.$refs.editRenderer) {
+        event.preventDefault();
+        return;
+      }
+      this.$refs.editRenderer.hasSubmitted(true);
       if (
         this.$refs.editRenderer.$refs.renderer.$refs.component.$v.vdata.$invalid
       ) {
@@ -1019,8 +1040,11 @@ export default {
         this.$refs.infoModal.show();
         return;
       }
-      // Open form
-      this.$refs.addModal.show();
+      this.addModalVisible = true;
+      // Open form after renderer is mounted
+      this.$nextTick(() => {
+        this.$refs.addModal.show();
+      });
 
       // eslint-disable-next-line no-unused-vars
       const { _parent, ...result } = this.addItem;
@@ -1028,11 +1052,36 @@ export default {
     },
     handleHideAddModal() {
       this.addItem = this.initFormValues;
-      this.$refs.addRenderer.hasSubmitted(false);
+      if (this.$refs.addRenderer) {
+        this.$refs.addRenderer.hasSubmitted(false);
+      }
+      this.addModalVisible = false;
+      this.restoreParentValidationState();
+    },
+    handleHideEditModal() {
+      if (this.$refs.editRenderer) {
+        this.$refs.editRenderer.hasSubmitted(false);
+      }
+      this.editModalVisible = false;
+      this.restoreParentValidationState();
+    },
+    restoreParentValidationState() {
+      // Clear modal-driven global submit flags and refresh parent validity
+      // so required modal fields (e.g. FormCheckbox) never block parent submit.
+      this.restartValidation();
+      this.hasSubmitted(false);
+      this.close();
+      const rootScreen = findRootScreen(this);
+      if (rootScreen && typeof rootScreen.loadValidationRules === "function") {
+        this.validateNow(rootScreen);
+      }
     },
     async handleOk(bvModalEvt) {
-      this.$refs.addRenderer.hasSubmitted(true);
       bvModalEvt.preventDefault();
+      if (!this.$refs.addRenderer) {
+        return;
+      }
+      this.$refs.addRenderer.hasSubmitted(true);
 
       if (
         this.$refs.addRenderer.$refs.renderer.$refs.component.$v.vdata.$invalid

--- a/src/components/renderer/form-record-list.vue
+++ b/src/components/renderer/form-record-list.vue
@@ -174,7 +174,6 @@
       @shown="emitShownEvent"
     >
       <vue-form-renderer
-        v-if="addModalVisible"
         ref="addRenderer"
         :key="Array.isArray(value) ? value.length : 0"
         v-model="addItem"
@@ -204,7 +203,6 @@
       @shown="emitShownEvent"
     >
       <vue-form-renderer
-        v-if="editModalVisible"
         ref="editRenderer"
         :key="editFormVersion"
         v-model="editItem"
@@ -264,7 +262,6 @@ import VueFormRenderer from "@/components/vue-form-renderer.vue";
 import mustacheEvaluation from "../../mixins/mustacheEvaluation";
 import MustacheHelper from "../inspector/mustache-helper.vue";
 import Mustache from "mustache";
-import { findRootScreen } from "@/mixins/DataReference";
 import {
   mapCollectionRecordData,
   normalizeCollectionFieldPath
@@ -339,11 +336,7 @@ export default {
       selectAll: false,
       styleMode: "Classic",
       isPopoverVisible: null,
-      popoverPosition: { top: '0px', left: '0px' },
-      // Mount modal renderers only while open so their required fields never
-      // leak into the parent screen validation rules / global error count.
-      addModalVisible: false,
-      editModalVisible: false
+      popoverPosition: { top: '0px', left: '0px' }
     };
   },
   computed: {
@@ -522,7 +515,6 @@ export default {
   },
   methods: {
     ...mapActions("globalErrorsModule", [
-      "validateNow",
       "close",
       "restartValidation",
       "hasSubmitted"
@@ -992,24 +984,23 @@ export default {
     },
     showEditForm(index, rowId) {
       const pageIndex = (this.currentPage - 1) * this.perPage + index;
-      // Reset edit to be a copy of our data model item
-      this.editItem = JSON.parse(
+      const rowData = JSON.parse(
         JSON.stringify(_.find(this.tableData.data, { row_id: rowId }))
       );
       this.editIndex = pageIndex;
-      // rebuild the edit screen to avoid
+      this.editItem = rowData;
+      // rebuild the edit screen to avoid stale control state between edits
       this.editFormVersion++;
-      this.editModalVisible = true;
       this.$nextTick(() => {
+        // Remount can emit a stale @update with empty defaults; re-seed once
+        // after mount. Do not block later @update — loops need those events
+        // (RecordListWithLoops).
+        this.editItem = JSON.parse(JSON.stringify(rowData));
         this.setUploadDataNamePrefix(pageIndex);
         this.$refs.editModal.show();
       });
     },
     edit(event) {
-      if (!this.$refs.editRenderer) {
-        event.preventDefault();
-        return;
-      }
       this.$refs.editRenderer.hasSubmitted(true);
       if (
         this.$refs.editRenderer.$refs.renderer.$refs.component.$v.vdata.$invalid
@@ -1040,11 +1031,8 @@ export default {
         this.$refs.infoModal.show();
         return;
       }
-      this.addModalVisible = true;
-      // Open form after renderer is mounted
-      this.$nextTick(() => {
-        this.$refs.addModal.show();
-      });
+      // Open form
+      this.$refs.addModal.show();
 
       // eslint-disable-next-line no-unused-vars
       const { _parent, ...result } = this.addItem;
@@ -1052,35 +1040,23 @@ export default {
     },
     handleHideAddModal() {
       this.addItem = this.initFormValues;
-      if (this.$refs.addRenderer) {
-        this.$refs.addRenderer.hasSubmitted(false);
-      }
-      this.addModalVisible = false;
+      this.$refs.addRenderer.hasSubmitted(false);
       this.restoreParentValidationState();
     },
     handleHideEditModal() {
-      if (this.$refs.editRenderer) {
-        this.$refs.editRenderer.hasSubmitted(false);
-      }
-      this.editModalVisible = false;
+      this.$refs.editRenderer.hasSubmitted(false);
       this.restoreParentValidationState();
     },
     restoreParentValidationState() {
-      // Clear modal-driven global submit flags and refresh parent validity
-      // so required modal fields (e.g. FormCheckbox) never block parent submit.
+      // Isolated modals must not leave the parent in a "submitted"/invalid state.
+      // Avoid validateNow/loadValidationRules here — on large screens (ComplexScreen)
+      // that rebuild can race with Record List row data after Add/Edit.
       this.restartValidation();
       this.hasSubmitted(false);
       this.close();
-      const rootScreen = findRootScreen(this);
-      if (rootScreen && typeof rootScreen.loadValidationRules === "function") {
-        this.validateNow(rootScreen);
-      }
     },
     async handleOk(bvModalEvt) {
       bvModalEvt.preventDefault();
-      if (!this.$refs.addRenderer) {
-        return;
-      }
       this.$refs.addRenderer.hasSubmitted(true);
 
       if (
@@ -1089,13 +1065,15 @@ export default {
         return;
       }
 
-      // Add the item to our model and emit change
-      // @todo Also check that value is an array type, if not, reset it to an array
-      const data = this.value ? JSON.parse(JSON.stringify(this.value)) : [];
+      // Snapshot before reset/hide so remount/@update cannot alter the row.
       const item = JSON.parse(
         JSON.stringify({ ...this.addItem, _parent: undefined })
       );
       delete item._parent;
+
+      // Add the item to our model and emit change
+      // @todo Also check that value is an array type, if not, reset it to an array
+      const data = this.value ? JSON.parse(JSON.stringify(this.value)) : [];
       data[data.length] = item;
 
       // Emit the newly updated data model

--- a/src/components/vue-form-renderer.vue
+++ b/src/components/vue-form-renderer.vue
@@ -64,7 +64,10 @@ export default {
     "showErrors",
     "testScreenDefinition",
     "deviceScreen",
-    "taskdraft"
+    "taskdraft",
+    // When true, local $v is still used (e.g. record list modals) but data
+    // changes do not update the parent form's global valid/submit state.
+    "isolated"
   ],
   data() {
     return {
@@ -152,6 +155,9 @@ export default {
       deep: true,
       handler() {
         this.$emit("update", this.data);
+        if (this.isolated) {
+          return;
+        }
         const mainScreen = this.getMainScreen();
         if (mainScreen) {
           this.validate(mainScreen);
@@ -189,12 +195,29 @@ export default {
     this.$store.dispatch('clipboardModule/initializeClipboard');
   },
   methods: {
-    ...mapActions("globalErrorsModule", [
-      "validate",
-      "hasSubmitted",
-      "showValidationOnLoad",
-      "restartValidation"
-    ]),
+    ...mapActions("globalErrorsModule", {
+      validate: "validate",
+      hasSubmittedAction: "hasSubmitted",
+      showValidationOnLoad: "showValidationOnLoad",
+      restartValidation: "restartValidation"
+    }),
+    /**
+     * Isolated renderers (Record List modals) must not flip the parent form's
+     * global submitted flag; keep that state on the modal ScreenContent only.
+     */
+    hasSubmitted(value) {
+      if (this.isolated) {
+        const screen = this.getMainScreen();
+        if (screen) {
+          this.$set(screen, "modalSubmitted__", !!value);
+          if (value && screen.$v) {
+            screen.$v.$touch();
+          }
+        }
+        return;
+      }
+      return this.hasSubmittedAction(value);
+    },
     getMainScreen() {
       return this.$refs.renderer && this.$refs.renderer.$refs.component;
     },

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -2,7 +2,9 @@ import _ from "lodash";
 import extensions from './extensions';
 import ScreenBase from './ScreenBase';
 import CountElements from '../CountElements';
-import ValidationsFactory from '../ValidationsFactory';
+import ValidationsFactory, {
+  collectRecordListFormPages
+} from '../ValidationsFactory';
 
 let screenRenderer;
 
@@ -122,8 +124,27 @@ export default {
       this.variables.splice(0);
       // Extensions.beforeload
       this.extensions.forEach((ext) => ext.beforeload instanceof Function && ext.beforeload.bind(this)({ pages, owner, definition }));
+      const recordListFormPages = new Set();
+      if (Array.isArray(pages)) {
+        pages.forEach((page) => {
+          if (page && page.items) {
+            collectRecordListFormPages(page.items, recordListFormPages);
+          }
+        });
+      }
+      const currentPageIndex = String(parseInt(this.currentPage, 10) || 0);
       pages.forEach((page, index) => {
         if (page) {
+          // Record List "Record Form" pages render only inside the add/edit
+          // modal (popupConfig). Skip them on the parent screen tree so the
+          // modal's empty defaults cannot mount as root-level controls; parent
+          // submit still validates those fields via FormRecordListValidations.
+          if (
+            recordListFormPages.has(String(index)) &&
+            String(index) !== currentPageIndex
+          ) {
+            return;
+          }
           const component = this.createComponent("div", {
             name: page.name,
             class: "page",

--- a/src/mixins/Json2Vue.js
+++ b/src/mixins/Json2Vue.js
@@ -2,9 +2,7 @@ import _ from "lodash";
 import extensions from './extensions';
 import ScreenBase from './ScreenBase';
 import CountElements from '../CountElements';
-import ValidationsFactory, {
-  collectRecordListFormPages
-} from '../ValidationsFactory';
+import ValidationsFactory from '../ValidationsFactory';
 
 let screenRenderer;
 
@@ -124,27 +122,12 @@ export default {
       this.variables.splice(0);
       // Extensions.beforeload
       this.extensions.forEach((ext) => ext.beforeload instanceof Function && ext.beforeload.bind(this)({ pages, owner, definition }));
-      const recordListFormPages = new Set();
-      if (Array.isArray(pages)) {
-        pages.forEach((page) => {
-          if (page && page.items) {
-            collectRecordListFormPages(page.items, recordListFormPages);
-          }
-        });
-      }
-      const currentPageIndex = String(parseInt(this.currentPage, 10) || 0);
+      // Keep every page in the tree (including Record Form pages). E2E fixtures
+      // like RecordListWithLoops expect root defaults from those pages
+      // (e.g. loop_1: [{}]). Parent submit validates list rows via
+      // FormRecordListValidations; modals stay isolated.
       pages.forEach((page, index) => {
         if (page) {
-          // Record List "Record Form" pages render only inside the add/edit
-          // modal (popupConfig). Skip them on the parent screen tree so the
-          // modal's empty defaults cannot mount as root-level controls; parent
-          // submit still validates those fields via FormRecordListValidations.
-          if (
-            recordListFormPages.has(String(index)) &&
-            String(index) !== currentPageIndex
-          ) {
-            return;
-          }
           const component = this.createComponent("div", {
             name: page.name,
             class: "page",

--- a/src/mixins/ScreenBase.js
+++ b/src/mixins/ScreenBase.js
@@ -33,6 +33,9 @@ export default {
     return {
       ValidationRules__: {},
       hiddenFields__: [],
+      // Used by isolated Record List modals so Ok/Add can show field errors
+      // without flipping the parent screen's global "submitted" flag.
+      modalSubmitted__: false,
     };
   },
   props: {
@@ -59,6 +62,10 @@ export default {
       disableSubmit__: "disableSubmit",
     }),
     ...mapGetters("globalErrorsModule", ["showValidationErrors"]),
+    // Parent screens keep the store getter untouched; modals OR in local flag.
+    showValidationErrorsEffective() {
+      return this.showValidationErrors || !!this.modalSubmitted__;
+    },
     references__() {
       return this.$parent && this.$parent.references__;
     },

--- a/src/mixins/extensions/ValidationRules.js
+++ b/src/mixins/extensions/ValidationRules.js
@@ -17,8 +17,8 @@ export default {
               console.error("Invalid variable name");
             }
           } else {
-            properties[':class'] = `{ 'form-group--error': (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && $v.vdata.${element.config.name}.$invalid || (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && $v.schema.${element.config.name}.$invalid }`;
-            properties[':error'] = `(showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && validationMessage($v.vdata.${element.config.name}) || (showValidationErrors || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && validationMessage($v.schema.${element.config.name})`;
+            properties[':class'] = `{ 'form-group--error': (showValidationErrorsEffective || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && $v.vdata.${element.config.name}.$invalid || (showValidationErrorsEffective || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && $v.schema.${element.config.name}.$invalid }`;
+            properties[':error'] = `(showValidationErrorsEffective || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.vdata.' + element.config.name)} && validationMessage($v.vdata.${element.config.name}) || (showValidationErrorsEffective || ${this.fieldValidationShow(element)}) && ${this.checkVariableExists('$v.schema.' + element.config.name)} && validationMessage($v.schema.${element.config.name})`;
           }
         }
       },

--- a/src/store/modules/globalErrorsModule.js
+++ b/src/store/modules/globalErrorsModule.js
@@ -5,42 +5,73 @@ const namespaced = true;
 
 function countErrors(obj) {
   let errors = 0;
-  if (typeof obj !== "object") {
+  if (typeof obj !== "object" || !obj) {
     return errors;
   }
   Object.entries(obj).forEach(([key, value]) => {
-    if (value) {
-      if (typeof value === "object" && "$each" in value) {
-        errors += countErrors(value.$each.$iter);
-        return;
-      }
-      if (
-        key !== "$iter" &&
-        typeof value === "object" &&
-        "$invalid" in value &&
-        value.$invalid &&
-        Number.isNaN(Number(key))
-      ) {
-        errors++;
-      }
-      if (key !== "$iter" && value) {
-        errors += countErrors(value);
-      }
+    if (!value || typeof value !== "object") {
+      return;
     }
+    if (key === "$iter") {
+      return;
+    }
+    if ("$each" in value) {
+      errors += countErrors(value.$each && value.$each.$iter);
+      return;
+    }
+    if ("$invalid" in value && Number.isNaN(Number(key))) {
+      // Nested group (object variable): count invalid children only.
+      const nestedFieldKeys = Object.keys(value).filter(
+        (childKey) =>
+          !childKey.startsWith("$") &&
+          value[childKey] &&
+          typeof value[childKey] === "object" &&
+          "$invalid" in value[childKey]
+      );
+      if (nestedFieldKeys.length > 0) {
+        errors += countErrors(value);
+      } else if (value.$invalid) {
+        // Leaf control — count once, do not recurse into vuelidate meta.
+        errors += 1;
+      }
+      return;
+    }
+    errors += countErrors(value);
   });
   return errors;
 }
 
+/**
+ * Record List add/edit modals use isolated vue-form-renderers. Their ScreenContent
+ * must never drive the parent screen's global submit/valid state.
+ */
+function isInsideIsolatedRenderer(component) {
+  let node = component;
+  while (node) {
+    if (node.isolated === true) {
+      return true;
+    }
+    node = node.$parent;
+  }
+  return false;
+}
+
 const updateValidationRules = async (screens, commit) => {
-  if (screens.length === 0) {
-    // When validation was restarted, the screens array is empty
-    // and we don't need to do anything
+  const usableScreens = (screens || []).filter(
+    (screen) => screen && !isInsideIsolatedRenderer(screen)
+  );
+  if (usableScreens.length === 0) {
+    // When validation was restarted, or only isolated (modal) screens were
+    // queued, do not touch the parent form's global valid/message state.
     return;
   }
-  const rootScreen = findRootScreen(screens[0]);
+  const rootScreen = findRootScreen(usableScreens[0]);
+  if (!rootScreen || isInsideIsolatedRenderer(rootScreen)) {
+    return;
+  }
   const awaitLoad = [];
-  screens.forEach((screen) => {
-    if (rootScreen !== screen) {
+  usableScreens.forEach((screen) => {
+    if (rootScreen !== screen && typeof screen.loadValidationRules === "function") {
       // refresh nested screen validation rules
       awaitLoad.push(screen.loadValidationRules());
     }
@@ -57,8 +88,10 @@ const updateValidationRules = async (screens, commit) => {
     let errors = 0;
     let message = "";
     if (validate.$invalid) {
+      // Count control rules in vdata only. Adding schema on top double-counts the
+      // same required checkboxes when vocabularies/json-schema mirror those fields
+      // (e.g. 4 controls → "8 validation errors"). Schema still affects $invalid.
       errors += countErrors(validate.vdata);
-      errors += countErrors(validate.schema);
       message =
         errors === 1
           ? "There is a validation error in your form."
@@ -85,6 +118,9 @@ const updateValidationRulesDebounced = debounce(updateValidationRules, 500);
 
 const screensToValidate = [];
 const queueUpdateValidationRules = (mainScreen, commit) => {
+  if (isInsideIsolatedRenderer(mainScreen)) {
+    return;
+  }
   if (!screensToValidate.includes(mainScreen)) {
     screensToValidate.push(mainScreen);
   }
@@ -132,12 +168,21 @@ const globalErrorsModule = {
   },
   actions: {
     restartValidation() {
+      if (typeof updateValidationRulesDebounced.cancel === "function") {
+        updateValidationRulesDebounced.cancel();
+      }
       screensToValidate.length = 0;
     },
     validate({ commit }, mainScreen) {
       queueUpdateValidationRules(mainScreen, commit);
     },
     async validateNow({ commit }, mainScreen) {
+      // Cancel any pending debounced modal/parent updates so they cannot
+      // overwrite this authoritative validation result.
+      if (typeof updateValidationRulesDebounced.cancel === "function") {
+        updateValidationRulesDebounced.cancel();
+      }
+      screensToValidate.length = 0;
       await updateValidationRules([mainScreen], commit);
     },
     close({ commit }) {

--- a/tests/unit/RecordListFormValidation.spec.js
+++ b/tests/unit/RecordListFormValidation.spec.js
@@ -723,4 +723,75 @@ describe("Record List form-page validation on parent submit", () => {
       true
     );
   });
+
+  it("does not let a hidden PageNavigate destination block submit", async () => {
+    // isVisible() ignores conditionalHide at build time so Record List/gated
+    // fields still register. PageNavigate must propagate its Visibility Rule as
+    // parentVisibilityRule, or an unreachable page's required fields would fail.
+    const screen = {
+      config: [
+        {
+          name: "page1",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: { name: "show_page2", validation: [] }
+            },
+            {
+              component: "FormButton",
+              config: {
+                event: "pageNavigate",
+                eventData: "1",
+                label: "Go to page 2",
+                conditionalHide: "show_page2 == true"
+              }
+            }
+          ]
+        },
+        {
+          name: "page2",
+          items: [
+            {
+              component: "FormInput",
+              config: {
+                name: "page2_required",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: { show_page2: false, page2_required: "" }
+    }).addValidations(validations);
+
+    expect(validations.page2_required.required).toBeDefined();
+
+    const ctx = ruleContext();
+    // Nav button hidden → destination required must not block submit.
+    expect(
+      validations.page2_required.required.call(ctx, "", {
+        show_page2: false,
+        page2_required: ""
+      })
+    ).toBe(true);
+    // Nav button visible → empty destination field fails as usual.
+    expect(
+      validations.page2_required.required.call(ctx, "", {
+        show_page2: true,
+        page2_required: ""
+      })
+    ).toBe(false);
+    expect(
+      validations.page2_required.required.call(ctx, "ok", {
+        show_page2: true,
+        page2_required: "ok"
+      })
+    ).toBe(true);
+  });
 });

--- a/tests/unit/RecordListFormValidation.spec.js
+++ b/tests/unit/RecordListFormValidation.spec.js
@@ -252,4 +252,63 @@ describe("Record List form-page validation on parent submit", () => {
     expect(validations.loop_1.$each.form_checkbox_3).toBeDefined();
     expect(validations.loop_1.$each.form_checkbox_4).toBeDefined();
   });
+
+  it("keeps required rules for inputs inside Loop > MultiColumn (no false parent-hide)", async () => {
+    // Regression for Loop.spec "Verify validation with multicolumn":
+    // forwarding insideLoop through MultiColumn made parentVisibilityRule walk to
+    // missing `_parent` on $each rows, skip required, and allow invalid submit.
+    const screen = {
+      config: [
+        {
+          name: "page1",
+          items: [
+            {
+              component: "FormLoop",
+              config: {
+                name: "loop_1",
+                settings: { type: "existing", varname: "loop_1" }
+              },
+              items: [
+                {
+                  component: "FormMultiColumn",
+                  config: {
+                    conditionalHide: 'name != "foo"',
+                    items: [[], []]
+                  },
+                  items: [
+                    [
+                      {
+                        component: "FormInput",
+                        config: {
+                          name: "form_input_1",
+                          validation: [{ value: "required", content: "Required" }]
+                        }
+                      }
+                    ],
+                    []
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: { loop_1: [{ name: "bar" }, { name: "foo" }] }
+    }).addValidations(validations);
+
+    expect(validations.loop_1.$each.form_input_1.required).toBeDefined();
+
+    const ctx = ruleContext();
+    const rowBar = { name: "bar", form_input_1: "" };
+    // Required must still run (not skipped via false parent visibility).
+    expect(
+      validations.loop_1.$each.form_input_1.required.call(ctx, "", rowBar)
+    ).toBe(false);
+  });
 });

--- a/tests/unit/RecordListFormValidation.spec.js
+++ b/tests/unit/RecordListFormValidation.spec.js
@@ -311,4 +311,416 @@ describe("Record List form-page validation on parent submit", () => {
       validations.loop_1.$each.form_input_1.required.call(ctx, "", rowBar)
     ).toBe(false);
   });
+
+  it("validates conditionally visible Record Form fields per row (not first-row only)", async () => {
+    // Visibility rule (show when): name == "foo".
+    // First row (name: bar) hides the required field; second row shows it empty.
+    // Building rules from the first row used to omit the field entirely so the
+    // parent could submit with an invalid visible later row.
+    const screen = {
+      config: [
+        {
+          name: "main",
+          items: [
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            }
+          ]
+        },
+        {
+          name: "Record Form",
+          items: [
+            {
+              component: "FormInput",
+              config: {
+                name: "form_input_1",
+                conditionalHide: 'name == "foo"',
+                validation: [{ value: "required", content: "Required" }]
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const data = {
+      form_record_list_1: [
+        { name: "bar" },
+        { name: "foo", form_input_1: "" }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data
+    }).addValidations(validations);
+
+    expect(validations.form_record_list_1__form_input_1.required).toBeDefined();
+
+    const ctx = ruleContext();
+    // Row 0 hidden → skipped; row 1 visible + empty → fails required.
+    expect(
+      validations.form_record_list_1__form_input_1.required.call(ctx, undefined, data)
+    ).toBe(false);
+
+    const validData = {
+      form_record_list_1: [
+        { name: "bar" },
+        { name: "foo", form_input_1: "ok" }
+      ]
+    };
+    expect(
+      validations.form_record_list_1__form_input_1.required.call(
+        ctx,
+        undefined,
+        validData
+      )
+    ).toBe(true);
+  });
+
+  it("requires visible Record Form checkbox after toggle (RLCheck form_checkbox_5/6)", async () => {
+    // Mirrors RLcheck: checkbox_6 is required only when checkbox_5 is true.
+    // Rules must exist even when built with checkbox_5 false (modal open state /
+    // empty seed), and must pass once checkbox_6 is true on the row.
+    const screen = {
+      config: [
+        {
+          name: "screen check",
+          items: [
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            }
+          ]
+        },
+        {
+          name: "RLcheck",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_5",
+                validation: [],
+                initiallyChecked: false
+              }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_6",
+                conditionalHide: "form_checkbox_5 == true",
+                validation: [{ value: "required", content: "Required" }],
+                initiallyChecked: false
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    // Build with no rows / checkbox_5 false — same as modal mount seed.
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: { form_record_list_1: [] }
+    }).addValidations(validations);
+
+    expect(validations.form_record_list_1__form_checkbox_6.required).toBeDefined();
+    // Toggle control itself is not required (empty validation config).
+    expect(
+      validations.form_record_list_1__form_checkbox_5 &&
+        validations.form_record_list_1__form_checkbox_5.required
+    ).toBeUndefined();
+
+    const ctx = ruleContext();
+
+    // Hidden when checkbox_5 is false → do not block submit for that row.
+    const hiddenRow = {
+      form_record_list_1: [{ form_checkbox_5: false, form_checkbox_6: false }]
+    };
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(
+        ctx,
+        undefined,
+        hiddenRow
+      )
+    ).toBe(true);
+
+    // Shown + unchecked → block submit.
+    const visibleEmpty = {
+      form_record_list_1: [{ form_checkbox_5: true, form_checkbox_6: false }]
+    };
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(
+        ctx,
+        undefined,
+        visibleEmpty
+      )
+    ).toBe(false);
+
+    // Shown + checked → allow submit.
+    const visibleChecked = {
+      form_record_list_1: [{ form_checkbox_5: true, form_checkbox_6: true }]
+    };
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(
+        ctx,
+        undefined,
+        visibleChecked
+      )
+    ).toBe(true);
+  });
+
+  it("registers conditionally required checkbox even when seed has toggle false (modal mount)", async () => {
+    // Always-mounted / first paint of the Record Form modal seeds checkbox_5 as
+    // false. Build-time isVisible() used to drop checkbox_6 entirely so Ok/Save
+    // could succeed without selecting it once it became visible.
+    const screen = {
+      config: [
+        {
+          name: "main",
+          items: [
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            }
+          ]
+        },
+        {
+          name: "RLcheck",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: { name: "form_checkbox_5", validation: [] }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_6",
+                conditionalHide: "form_checkbox_5 == true",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: {
+        form_record_list_1: [{ form_checkbox_5: false, form_checkbox_6: false }]
+      }
+    }).addValidations(validations);
+
+    expect(validations.form_record_list_1__form_checkbox_6.required).toBeDefined();
+
+    const ctx = ruleContext();
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(ctx, undefined, {
+        form_record_list_1: [{ form_checkbox_5: true, form_checkbox_6: false }]
+      })
+    ).toBe(false);
+  });
+
+  it("passes parent submit when mixed rows hide or satisfy the conditional checkbox", async () => {
+    const screen = {
+      config: [
+        {
+          name: "main",
+          items: [
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            }
+          ]
+        },
+        {
+          name: "RLcheck",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: { name: "form_checkbox_5", validation: [] }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_6",
+                conditionalHide: "form_checkbox_5 == true",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: {}
+    }).addValidations(validations);
+
+    const ctx = ruleContext();
+
+    // Row 0: toggle off (hidden required). Row 1: toggle on + checked.
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(ctx, undefined, {
+        form_record_list_1: [
+          { form_checkbox_5: false, form_checkbox_6: false },
+          { form_checkbox_5: true, form_checkbox_6: true }
+        ]
+      })
+    ).toBe(true);
+
+    // Same mix but row 1 leaves required unchecked → fail.
+    expect(
+      validations.form_record_list_1__form_checkbox_6.required.call(ctx, undefined, {
+        form_record_list_1: [
+          { form_checkbox_5: false, form_checkbox_6: false },
+          { form_checkbox_5: true, form_checkbox_6: false }
+        ]
+      })
+    ).toBe(false);
+  });
+
+  it("applies Record Form MultiColumn visibility per row for nested required fields", async () => {
+    const screen = {
+      config: [
+        {
+          name: "main",
+          items: [
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            }
+          ]
+        },
+        {
+          name: "Record Form",
+          items: [
+            {
+              component: "FormMultiColumn",
+              config: {
+                conditionalHide: "show_extra == true",
+                items: [[], []]
+              },
+              items: [
+                [
+                  {
+                    component: "FormCheckbox",
+                    config: {
+                      name: "extra_required",
+                      validation: [{ value: "required", content: "Required" }]
+                    }
+                  }
+                ],
+                []
+              ]
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      // Build while the column would be hidden — rule must still be registered.
+      data: { form_record_list_1: [{ show_extra: false }] }
+    }).addValidations(validations);
+
+    expect(validations.form_record_list_1__extra_required.required).toBeDefined();
+
+    const ctx = ruleContext();
+    expect(
+      validations.form_record_list_1__extra_required.required.call(ctx, undefined, {
+        form_record_list_1: [{ show_extra: false, extra_required: false }]
+      })
+    ).toBe(true);
+    expect(
+      validations.form_record_list_1__extra_required.required.call(ctx, undefined, {
+        form_record_list_1: [{ show_extra: true, extra_required: false }]
+      })
+    ).toBe(false);
+    expect(
+      validations.form_record_list_1__extra_required.required.call(ctx, undefined, {
+        form_record_list_1: [{ show_extra: true, extra_required: true }]
+      })
+    ).toBe(true);
+  });
+
+  it("still registers root required fields that start hidden by Visibility Rule", async () => {
+    // Same build-time deferral applies outside Record List (e.g. preview modal
+    // of a normal page): rules must exist so toggling the gate cannot bypass Ok.
+    const screen = {
+      config: [
+        {
+          name: "page1",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: { name: "gate", validation: [] }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "gated_required",
+                conditionalHide: "gate == true",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(screen, {
+      screen,
+      firstPage: 0,
+      data: { gate: false, gated_required: false }
+    }).addValidations(validations);
+
+    expect(validations.gated_required.required).toBeDefined();
+
+    const ctx = ruleContext();
+    expect(validations.gated_required.required.call(ctx, false, { gate: false })).toBe(
+      true
+    );
+    expect(validations.gated_required.required.call(ctx, false, { gate: true })).toBe(
+      false
+    );
+    expect(validations.gated_required.required.call(ctx, true, { gate: true })).toBe(
+      true
+    );
+  });
 });

--- a/tests/unit/RecordListFormValidation.spec.js
+++ b/tests/unit/RecordListFormValidation.spec.js
@@ -142,4 +142,114 @@ describe("Record List form-page validation on parent submit", () => {
       validations.form_record_list_1__rl_checkbox_2.required.call(ctx, undefined, data)
     ).toBe(true);
   });
+
+  it("ignores PageNavigate on the Record Form page (no ghost root rules)", async () => {
+    // Mirrors screens where RLcheck has "back to page 0" navigation: following
+    // that link while building rowRules used to namespace root checkboxes under
+    // form_record_list_1__* and inflate the submit error count (e.g. 10 vs 6).
+    const withPageNavigate = {
+      config: [
+        {
+          name: "screen check",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_1",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_2",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            },
+            {
+              component: "FormLoop",
+              config: {
+                name: "loop_1",
+                settings: { add: true, type: "new", times: "1", varname: "loop_1" }
+              },
+              items: [
+                {
+                  component: "FormCheckbox",
+                  config: {
+                    name: "form_checkbox_3",
+                    validation: [{ value: "required", content: "Required" }]
+                  }
+                },
+                {
+                  component: "FormCheckbox",
+                  config: {
+                    name: "form_checkbox_4",
+                    validation: [{ value: "required", content: "Required" }]
+                  }
+                }
+              ]
+            },
+            {
+              component: "FormRecordList",
+              config: {
+                name: "form_record_list_1",
+                form: "1",
+                editable: true
+              }
+            },
+            {
+              component: "FormButton",
+              config: { event: "pageNavigate", eventData: "1", label: "Page Navigation" }
+            }
+          ]
+        },
+        {
+          name: "RLcheck",
+          items: [
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_5",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            },
+            {
+              component: "FormCheckbox",
+              config: {
+                name: "form_checkbox_6",
+                validation: [{ value: "required", content: "Required" }]
+              }
+            },
+            {
+              component: "FormButton",
+              config: { event: "pageNavigate", eventData: "0", label: "Page Navigation" }
+            }
+          ]
+        }
+      ]
+    };
+
+    const validations = {};
+    await ValidationsFactory(withPageNavigate, {
+      screen: withPageNavigate,
+      firstPage: 0,
+      data: {}
+    }).addValidations(validations);
+
+    const keys = Object.keys(validations).sort();
+    expect(keys).toEqual([
+      "form_checkbox_1",
+      "form_checkbox_2",
+      "form_record_list_1__form_checkbox_5",
+      "form_record_list_1__form_checkbox_6",
+      "loop_1"
+    ]);
+    // Ghost keys from following PageNavigate back to page 0 must not appear.
+    expect(validations.form_record_list_1__form_checkbox_1).toBeUndefined();
+    expect(validations.form_record_list_1__form_checkbox_2).toBeUndefined();
+    expect(validations.form_record_list_1__form_record_list_1__form_checkbox_5).toBeUndefined();
+    expect(validations.form_record_list_1__form_record_list_1__form_checkbox_6).toBeUndefined();
+    expect(validations.loop_1.$each.form_checkbox_3).toBeDefined();
+    expect(validations.loop_1.$each.form_checkbox_4).toBeDefined();
+  });
 });

--- a/tests/unit/RecordListFormValidation.spec.js
+++ b/tests/unit/RecordListFormValidation.spec.js
@@ -1,0 +1,145 @@
+jest.mock("../../src/DataProvider", () => ({
+  __esModule: true,
+  default: {
+    getScreen: jest.fn()
+  }
+}));
+
+import ValidationsFactory, {
+  collectFieldNames,
+  collectRecordListFormPages
+} from "../../src/ValidationsFactory";
+
+function ruleContext() {
+  return {
+    getRootScreen() {
+      return {
+        addReferenceToParents: (data) => data
+      };
+    },
+    getDataAccordingToFieldLevel(data) {
+      return data;
+    },
+    $root: {
+      $children: [{ $refs: { renderer: { definition: { isMobile: false } } } }]
+    }
+  };
+}
+
+describe("Record List form-page validation on parent submit", () => {
+  const definition = {
+    config: [
+      {
+        name: "screen check",
+        items: [
+          {
+            component: "FormCheckbox",
+            config: {
+              name: "root_checkbox_1",
+              validation: [{ value: "required", content: "Required" }]
+            }
+          },
+          {
+            component: "FormCheckbox",
+            config: {
+              name: "root_checkbox_2",
+              validation: [{ value: "required", content: "Required" }]
+            }
+          },
+          {
+            component: "FormRecordList",
+            config: {
+              name: "form_record_list_1",
+              form: "1",
+              editable: true
+            }
+          }
+        ]
+      },
+      {
+        name: "RLCheck",
+        items: [
+          {
+            component: "FormCheckbox",
+            config: {
+              name: "rl_checkbox_1",
+              validation: [{ value: "required", content: "Required" }]
+            }
+          },
+          {
+            component: "FormCheckbox",
+            config: {
+              name: "rl_checkbox_2",
+              validation: [{ value: "required", content: "Required" }]
+            }
+          }
+        ]
+      }
+    ]
+  };
+
+  it("collects record list form pages and field names", () => {
+    expect(collectRecordListFormPages(definition.config[0].items).has("1")).toBe(true);
+    const names = collectFieldNames(definition.config[1].items);
+    expect(names.has("rl_checkbox_1")).toBe(true);
+    expect(names.has("rl_checkbox_2")).toBe(true);
+  });
+
+  it("always namespaces record-form fields away from root checkbox names", async () => {
+    const validations = {};
+    await ValidationsFactory(definition, {
+      screen: definition,
+      firstPage: 0,
+      data: {}
+    }).addValidations(validations);
+
+    expect(Object.keys(validations).sort()).toEqual([
+      "form_record_list_1__rl_checkbox_1",
+      "form_record_list_1__rl_checkbox_2",
+      "root_checkbox_1",
+      "root_checkbox_2"
+    ]);
+    expect(validations.rl_checkbox_1).toBeUndefined();
+    expect(validations.rl_checkbox_2).toBeUndefined();
+  });
+
+  it("fails namespaced rules when the record list is empty", async () => {
+    const validations = {};
+    await ValidationsFactory(definition, {
+      screen: definition,
+      firstPage: 0,
+      data: { form_record_list_1: [] }
+    }).addValidations(validations);
+
+    const ctx = ruleContext();
+    const data = { form_record_list_1: [] };
+    expect(
+      validations.form_record_list_1__rl_checkbox_1.required.call(ctx, undefined, data)
+    ).toBe(false);
+    expect(
+      validations.form_record_list_1__rl_checkbox_2.required.call(ctx, undefined, data)
+    ).toBe(false);
+  });
+
+  it("passes when rows have required checkboxes selected", async () => {
+    const validations = {};
+    await ValidationsFactory(definition, {
+      screen: definition,
+      firstPage: 0,
+      data: {
+        form_record_list_1: [{ rl_checkbox_1: true, rl_checkbox_2: true }]
+      }
+    }).addValidations(validations);
+
+    const ctx = ruleContext();
+    const data = {
+      form_record_list_1: [{ rl_checkbox_1: true, rl_checkbox_2: true }]
+    };
+    expect(
+      validations.form_record_list_1__rl_checkbox_1.required.call(ctx, undefined, data)
+    ).toBe(true);
+    expect(
+      validations.form_record_list_1__rl_checkbox_2.required.call(ctx, undefined, data)
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Solution

Problems addressed

- Required Record Form fields were not validated correctly on parent Submit (values live in list rows, not at root).
- Add/Edit modal renderers polluted global valid/submitted state, so empty modal defaults could block parent Submit.
- Error message double-counted the same controls (vdata + schema / vocabularies → e.g. 4 fields → “8 validation errors”).
- PageNavigate on the Record Form page (e.g. “back to page 0”) pulled the main page into Record List row rules, creating ghost listName__* keys and inflating counts further (e.g. 10 vs 6).

Expected behavior after fix

- N required checkboxes (root + Record Form) → about N errors when invalid (not 2×N).
- Screens with PageNavigate on the Record Form page no longer inflate the count.
- Modal Add/Edit still validates locally; parent Submit validates list rows correctly.

## How to Test

Follow steps detailed in ticket

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-32292

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy