### PR TITLE
fix(FOUR-27647): prevent nested screen watchers from running in desig…

### DIFF
--- a/src/components/renderer/form-nested-screen.vue
+++ b/src/components/renderer/form-nested-screen.vue
@@ -72,6 +72,16 @@ export default {
     },
   },
   methods: {
+    isInScreenBuilder() {
+      let parent = this.$parent;
+      while (parent) {
+        if (parent.$options._componentTag === 'VueFormBuilder') {
+          return true;
+        }
+        parent = parent.$parent;
+      }
+      return false;
+    },
     isSubmitButton(item) {
       return item.config && item.component === 'FormButton' && item.config.event === 'submit';
     },
@@ -130,7 +140,7 @@ export default {
             this.hideSubmitButtons(this.config);
             this.computed = response.data.computed;
             this.customCSS = response.data.custom_css;
-            this.watchers = response.data.watchers;
+            this.watchers = this.isInScreenBuilder() ? [] : (response.data.watchers || []);
             this.screenTitle = response.data.title;
 
             if (this.$attrs['disabled']) {


### PR DESCRIPTION
Skip loading watchers when FormNestedScreen is rendered inside VueFormBuilder. Watchers with run_onload were executing during parent screen design, showing synchronous watcher messages outside runtime.

Detect VueFormBuilder in the component parent chain and assign an empty watchers array on screen load in that context. Preview and request runtime behavior is unchanged.

https://processmaker.atlassian.net/browse/FOUR-27647

ci:deploy